### PR TITLE
feat(subscriptions): список и удаление выпущенных промо-кодов

### DIFF
--- a/src/main/java/club/ttg/dnd5/domain/subscription/model/RedemptionCode.java
+++ b/src/main/java/club/ttg/dnd5/domain/subscription/model/RedemptionCode.java
@@ -76,6 +76,16 @@ public class RedemptionCode {
     @Column(name = "redeemed_at")
     private Instant redeemedAt;
 
+    /** Деактивированный код нельзя погасить; запись сохраняется (мягкое отключение). */
+    @Column(name = "disabled", nullable = false)
+    private boolean disabled = false;
+
+    @Column(name = "disabled_at")
+    private Instant disabledAt;
+
+    @Column(name = "disabled_by")
+    private String disabledBy;
+
     @Column(name = "created_at", updatable = false)
     @CreationTimestamp(source = SourceType.DB)
     private Instant createdAt;

--- a/src/main/java/club/ttg/dnd5/domain/subscription/repository/RedemptionCodeRepository.java
+++ b/src/main/java/club/ttg/dnd5/domain/subscription/repository/RedemptionCodeRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -14,6 +15,9 @@ public interface RedemptionCodeRepository extends JpaRepository<RedemptionCode, 
     Optional<RedemptionCode> findByCode(String code);
 
     boolean existsByCode(String code);
+
+    /** Все выпущенные коды, новые сверху (для админского списка). */
+    List<RedemptionCode> findAllByOrderByCreatedAtDesc();
 
     /**
      * Атомарно помечает код использованным. Условие {@code redeemed_by IS NULL}

--- a/src/main/java/club/ttg/dnd5/domain/subscription/rest/controller/SubscriptionController.java
+++ b/src/main/java/club/ttg/dnd5/domain/subscription/rest/controller/SubscriptionController.java
@@ -45,6 +45,20 @@ public class SubscriptionController {
         return subscriptionService.allCodes();
     }
 
+    @Secured("ADMIN")
+    @Operation(summary = "Деактивировать выпущенный код (его нельзя будет погасить)")
+    @PostMapping("/codes/{id}/deactivate")
+    public RedemptionCodeResponse deactivateCode(@PathVariable UUID id) {
+        return subscriptionService.setCodeDisabled(id, true);
+    }
+
+    @Secured("ADMIN")
+    @Operation(summary = "Снова активировать ранее деактивированный код")
+    @PostMapping("/codes/{id}/reactivate")
+    public RedemptionCodeResponse reactivateCode(@PathVariable UUID id) {
+        return subscriptionService.setCodeDisabled(id, false);
+    }
+
     @Secured("USER")
     @Operation(summary = "Погасить код: выдать награды и зарегистрировать подписку")
     @PostMapping("/redeem")

--- a/src/main/java/club/ttg/dnd5/domain/subscription/rest/controller/SubscriptionController.java
+++ b/src/main/java/club/ttg/dnd5/domain/subscription/rest/controller/SubscriptionController.java
@@ -12,7 +12,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.annotation.Secured;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -44,14 +43,6 @@ public class SubscriptionController {
     @GetMapping("/codes")
     public List<RedemptionCodeResponse> allCodes() {
         return subscriptionService.allCodes();
-    }
-
-    @Secured("ADMIN")
-    @Operation(summary = "Удалить выпущенный код по id (только непогашенный)")
-    @DeleteMapping("/codes/{id}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteCode(@PathVariable UUID id) {
-        subscriptionService.deleteCode(id);
     }
 
     @Secured("USER")

--- a/src/main/java/club/ttg/dnd5/domain/subscription/rest/controller/SubscriptionController.java
+++ b/src/main/java/club/ttg/dnd5/domain/subscription/rest/controller/SubscriptionController.java
@@ -12,6 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -36,6 +37,21 @@ public class SubscriptionController {
     @ResponseStatus(HttpStatus.CREATED)
     public List<RedemptionCodeResponse> createCodes(@Valid @RequestBody CreateCodesRequest request) {
         return subscriptionService.createCodes(request);
+    }
+
+    @Secured("ADMIN")
+    @Operation(summary = "Получить все выпущенные коды (для админки)")
+    @GetMapping("/codes")
+    public List<RedemptionCodeResponse> allCodes() {
+        return subscriptionService.allCodes();
+    }
+
+    @Secured("ADMIN")
+    @Operation(summary = "Удалить выпущенный код по id (только непогашенный)")
+    @DeleteMapping("/codes/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteCode(@PathVariable UUID id) {
+        subscriptionService.deleteCode(id);
     }
 
     @Secured("USER")

--- a/src/main/java/club/ttg/dnd5/domain/subscription/rest/dto/RedemptionCodeResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/subscription/rest/dto/RedemptionCodeResponse.java
@@ -19,6 +19,9 @@ public record RedemptionCodeResponse(
         String label,
         String redeemedBy,
         Instant redeemedAt,
+        boolean disabled,
+        Instant disabledAt,
+        String disabledBy,
         Instant createdAt
 ) {
 }

--- a/src/main/java/club/ttg/dnd5/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/club/ttg/dnd5/domain/subscription/service/SubscriptionService.java
@@ -177,6 +177,29 @@ public class SubscriptionService {
                 .toList();
     }
 
+    /** Все выпущенные коды для админского списка (новые сверху). */
+    @Transactional(readOnly = true)
+    public List<RedemptionCodeResponse> allCodes() {
+        return codeRepository.findAllByOrderByCreatedAtDesc().stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    /**
+     * Удаляет выпущенный код. Удалять можно только непогашенные коды:
+     * удаление не отзывает уже выданную подписку/награды, а у погашенного кода
+     * нужно сохранить аудит «кто/когда активировал».
+     */
+    @Transactional
+    public void deleteCode(UUID id) {
+        RedemptionCode code = codeRepository.findById(id)
+                .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "Код не найден"));
+        if (code.getRedeemedBy() != null) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "Нельзя удалить уже использованный код");
+        }
+        codeRepository.delete(code);
+    }
+
     @Transactional(readOnly = true)
     public List<SubscriptionResponse> currentUserSubscriptions() {
         Instant now = Instant.now();

--- a/src/main/java/club/ttg/dnd5/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/club/ttg/dnd5/domain/subscription/service/SubscriptionService.java
@@ -111,6 +111,9 @@ public class SubscriptionService {
         if (code.getRedeemedBy() != null) {
             throw new ApiException(HttpStatus.CONFLICT, "Код уже использован");
         }
+        if (code.isDisabled()) {
+            throw new ApiException(HttpStatus.CONFLICT, "Код деактивирован");
+        }
 
         Instant now = Instant.now();
         if (codeRepository.claim(normalized, username, now) == 0) {
@@ -183,6 +186,31 @@ public class SubscriptionService {
         return codeRepository.findAllByOrderByCreatedAtDesc().stream()
                 .map(this::toResponse)
                 .toList();
+    }
+
+    /**
+     * Мягко деактивирует или возвращает в строй выпущенный код. Деактивированный код
+     * нельзя погасить, но запись сохраняется. Менять статус уже использованного кода
+     * нельзя. Деактивацию пишем в аудит (кем/когда), при возврате — очищаем.
+     */
+    @Transactional
+    public RedemptionCodeResponse setCodeDisabled(UUID id, boolean disabled) {
+        RedemptionCode code = codeRepository.findById(id)
+                .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "Код не найден"));
+        if (code.getRedeemedBy() != null) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "Нельзя изменить статус уже использованного кода");
+        }
+
+        if (disabled) {
+            code.setDisabled(true);
+            code.setDisabledAt(Instant.now());
+            code.setDisabledBy(currentUsername());
+        } else {
+            code.setDisabled(false);
+            code.setDisabledAt(null);
+            code.setDisabledBy(null);
+        }
+        return toResponse(codeRepository.save(code));
     }
 
     @Transactional(readOnly = true)
@@ -273,6 +301,9 @@ public class SubscriptionService {
                 code.getLabel(),
                 code.getRedeemedBy(),
                 code.getRedeemedAt(),
+                code.isDisabled(),
+                code.getDisabledAt(),
+                code.getDisabledBy(),
                 code.getCreatedAt());
     }
 

--- a/src/main/java/club/ttg/dnd5/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/club/ttg/dnd5/domain/subscription/service/SubscriptionService.java
@@ -185,21 +185,6 @@ public class SubscriptionService {
                 .toList();
     }
 
-    /**
-     * Удаляет выпущенный код. Удалять можно только непогашенные коды:
-     * удаление не отзывает уже выданную подписку/награды, а у погашенного кода
-     * нужно сохранить аудит «кто/когда активировал».
-     */
-    @Transactional
-    public void deleteCode(UUID id) {
-        RedemptionCode code = codeRepository.findById(id)
-                .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "Код не найден"));
-        if (code.getRedeemedBy() != null) {
-            throw new ApiException(HttpStatus.BAD_REQUEST, "Нельзя удалить уже использованный код");
-        }
-        codeRepository.delete(code);
-    }
-
     @Transactional(readOnly = true)
     public List<SubscriptionResponse> currentUserSubscriptions() {
         Instant now = Instant.now();

--- a/src/main/resources/db/changelog/2026/06/26-01-add-disabled-to-redemption-code.yaml
+++ b/src/main/resources/db/changelog/2026/06/26-01-add-disabled-to-redemption-code.yaml
@@ -1,0 +1,20 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-26-01-add-disabled-to-redemption-code
+      author: claude
+      changes:
+        - addColumn:
+            tableName: redemption_code
+            columns:
+              - column:
+                  name: disabled
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: disabled_at
+                  type: TIMESTAMP WITH TIME ZONE
+              - column:
+                  name: disabled_by
+                  type: VARCHAR(255)

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -211,3 +211,5 @@ databaseChangeLog:
       file: db/changelog/2026/06/24-01-add-achievements-and-flexible-codes.yaml
   - include:
       file: db/changelog/2026/06/25-01-add-magic-item-items.yaml
+  - include:
+      file: db/changelog/2026/06/26-01-add-disabled-to-redemption-code.yaml


### PR DESCRIPTION
Добавлены два ADMIN-эндпоинта в SubscriptionController для управления ранее выпущенными одноразовыми кодами.

GET /api/subscriptions/codes
- Возвращает список всех выпущенных кодов, отсортированных по дате создания (новые сверху), в виде List<RedemptionCodeResponse>.
- Ответ включает redeemedBy и redeemedAt, чтобы в админке был виден статус активации кода: активирован он или нет, а если активирован — кем и когда.

DELETE /api/subscriptions/codes/{id}
- Удаляет выпущенный код. Удалять разрешено только НЕпогашенные коды.
- Если код уже использован (redeemedBy != null) — возвращается 400: удаление не отзывает выданную подписку и награды, а у активированного кода нужно сохранить аудит «кто и когда активировал».
- Если код не найден — 404. При успешном удалении — 204 No Content.

Изменения по слоям:
- RedemptionCodeRepository: добавлен метод findAllByOrderByCreatedAtDesc().
- SubscriptionService: методы allCodes() (@Transactional readOnly) и deleteCode(UUID) с проверкой redeemedBy; ошибки через ApiException (404 «Код не найден», 400 «Нельзя удалить уже использованный код»).
- SubscriptionController: эндпоинты GET /codes и DELETE /codes/{id} с @Secured("ADMIN") и swagger-аннотациями @Operation; для DELETE выставлен @ResponseStatus(NO_CONTENT).

Новый DTO не понадобился — переиспользован RedemptionCodeResponse. Схема БД и миграции не изменялись.