### PR TITLE
feat(subscriptions): ручка «мои погашенные коды» и привязка подписки к коду

### DIFF
--- a/src/main/java/club/ttg/dnd5/domain/achievement/service/AchievementService.java
+++ b/src/main/java/club/ttg/dnd5/domain/achievement/service/AchievementService.java
@@ -96,6 +96,28 @@ public class AchievementService {
                 .toList();
     }
 
+    /**
+     * Описывает достижения по их кодам из каталога — для встраивания в другие ответы
+     * (например список погашенных кодов). Несуществующие в каталоге показываются кодом.
+     *
+     * @param grantedAt момент получения, проставляемый в ответ
+     */
+    @Transactional(readOnly = true)
+    public List<UserAchievementResponse> describe(Collection<String> codes, Instant grantedAt) {
+        if (codes == null || codes.isEmpty()) {
+            return List.of();
+        }
+        Map<String, Achievement> catalog = catalogMap();
+        return codes.stream()
+                .map(code -> {
+                    Achievement achievement = catalog.get(code);
+                    return achievement == null
+                            ? new UserAchievementResponse(code, code, null, null, grantedAt)
+                            : toUserResponse(achievement, grantedAt);
+                })
+                .toList();
+    }
+
     @Transactional
     public AchievementResponse createOrUpdate(String code, AchievementRequest request) {
         if (!StringUtils.hasText(code)) {

--- a/src/main/java/club/ttg/dnd5/domain/subscription/model/UserSubscription.java
+++ b/src/main/java/club/ttg/dnd5/domain/subscription/model/UserSubscription.java
@@ -38,6 +38,10 @@ public class UserSubscription {
     @Column(name = "owner_username")
     private String ownerUsername;
 
+    /** Код, по которому создана подписка (null для ручной выдачи). */
+    @Column(name = "source_code")
+    private UUID sourceCode;
+
     @Column(name = "registered_at")
     private Instant registeredAt;
 

--- a/src/main/java/club/ttg/dnd5/domain/subscription/repository/RedemptionCodeRepository.java
+++ b/src/main/java/club/ttg/dnd5/domain/subscription/repository/RedemptionCodeRepository.java
@@ -1,6 +1,7 @@
 package club.ttg.dnd5.domain.subscription.repository;
 
 import club.ttg.dnd5.domain.subscription.model.RedemptionCode;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -18,6 +19,10 @@ public interface RedemptionCodeRepository extends JpaRepository<RedemptionCode, 
 
     /** Все выпущенные коды, новые сверху (для админского списка). */
     List<RedemptionCode> findAllByOrderByCreatedAtDesc();
+
+    /** Коды, погашенные пользователем, новые сверху (для личного кабинета). */
+    @EntityGraph(attributePaths = {"perks", "achievements"})
+    List<RedemptionCode> findByRedeemedByOrderByRedeemedAtDesc(String redeemedBy);
 
     /**
      * Атомарно помечает код использованным. Условие {@code redeemed_by IS NULL}

--- a/src/main/java/club/ttg/dnd5/domain/subscription/rest/controller/SubscriptionController.java
+++ b/src/main/java/club/ttg/dnd5/domain/subscription/rest/controller/SubscriptionController.java
@@ -1,6 +1,7 @@
 package club.ttg.dnd5.domain.subscription.rest.controller;
 
 import club.ttg.dnd5.domain.subscription.rest.dto.CreateCodesRequest;
+import club.ttg.dnd5.domain.subscription.rest.dto.MyRedemptionResponse;
 import club.ttg.dnd5.domain.subscription.rest.dto.RedeemCodeRequest;
 import club.ttg.dnd5.domain.subscription.rest.dto.RedeemResponse;
 import club.ttg.dnd5.domain.subscription.rest.dto.RedemptionCodeResponse;
@@ -78,6 +79,13 @@ public class SubscriptionController {
     @GetMapping("/my")
     public List<SubscriptionResponse> mySubscriptions() {
         return subscriptionService.currentUserSubscriptions();
+    }
+
+    @Secured("USER")
+    @Operation(summary = "Коды, погашенные текущим пользователем, с наградами и ссылками")
+    @GetMapping("/my-codes")
+    public List<MyRedemptionResponse> myCodes() {
+        return subscriptionService.currentUserRedemptions();
     }
 
     @Secured("ADMIN")

--- a/src/main/java/club/ttg/dnd5/domain/subscription/rest/dto/MyRedemptionResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/subscription/rest/dto/MyRedemptionResponse.java
@@ -1,0 +1,32 @@
+package club.ttg.dnd5.domain.subscription.rest.dto;
+
+import club.ttg.dnd5.domain.achievement.rest.dto.UserAchievementResponse;
+import club.ttg.dnd5.domain.subscription.model.RewardTier;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Погашенный текущим пользователем код вместе с его содержимым для личного кабинета.
+ * В отличие от админского {@link RedemptionCodeResponse}, не раскрывает сам код и
+ * служебные поля, зато сразу резолвит награды в ссылки/статусы готовности.
+ *
+ * @param id           идентификатор кода
+ * @param code         сам погашенный код (виден владельцу)
+ * @param redeemedAt   момент погашения
+ * @param rewardTier   тир-пресет кода (null — без пресета)
+ * @param rewards      перки кода (пресет тира ∪ доп. перки) со ссылками и статусом
+ * @param achievements достижения кода с названиями из каталога
+ * @param subscription подписка, созданная этим кодом; null — код без подписки
+ */
+public record MyRedemptionResponse(
+        UUID id,
+        String code,
+        Instant redeemedAt,
+        RewardTier rewardTier,
+        List<UserRewardResponse> rewards,
+        List<UserAchievementResponse> achievements,
+        SubscriptionResponse subscription
+) {
+}

--- a/src/main/java/club/ttg/dnd5/domain/subscription/service/RewardService.java
+++ b/src/main/java/club/ttg/dnd5/domain/subscription/service/RewardService.java
@@ -86,6 +86,36 @@ public class RewardService {
         return StringUtils.hasText(username) && rewardRepository.existsByUsernameAndPerk(username, perk);
     }
 
+    /**
+     * Описывает набор перков их контентом (ссылка/статус готовности) — без привязки
+     * к конкретной выдаче. Нужен для показа «что даёт код» в личном кабинете: для
+     * каждого перка подставляются title/url/availability из {@link RewardResource}.
+     * Порядок — по объявлению перков (детерминированный). Готовую карту ресурсов
+     * берут через {@link #resourceMap()} один раз и переиспользуют для многих кодов,
+     * чтобы не сканировать reward_resource на каждый код.
+     *
+     * @param grantedAt момент получения (например, дата погашения кода)
+     */
+    public List<UserRewardResponse> describe(Collection<RewardPerk> perks, Instant grantedAt,
+                                             Map<RewardPerk, RewardResource> resources) {
+        if (perks == null || perks.isEmpty()) {
+            return List.of();
+        }
+        return EnumSet.copyOf(perks).stream()
+                .map(perk -> describe(perk, grantedAt, resources.get(perk)))
+                .toList();
+    }
+
+    private UserRewardResponse describe(RewardPerk perk, Instant grantedAt, RewardResource resource) {
+        return new UserRewardResponse(
+                perk,
+                grantedAt,
+                resource == null ? null : resource.getTitle(),
+                resource == null ? null : resource.getUrl(),
+                resource == null ? null : resource.getAvailability(),
+                resource == null ? null : resource.getNote());
+    }
+
     @Transactional(readOnly = true)
     public List<RewardResourceResponse> resources() {
         return resourceRepository.findAll().stream()
@@ -116,7 +146,9 @@ public class RewardService {
                 .toList();
     }
 
-    private Map<RewardPerk, RewardResource> resourceMap() {
+    /** Справочник контента наград (perk → ресурс). Публичный для батч-резолва в других сервисах. */
+    @Transactional(readOnly = true)
+    public Map<RewardPerk, RewardResource> resourceMap() {
         Map<RewardPerk, RewardResource> map = new EnumMap<>(RewardPerk.class);
         resourceRepository.findAll().forEach(resource -> map.put(resource.getPerk(), resource));
         return map;

--- a/src/main/java/club/ttg/dnd5/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/club/ttg/dnd5/domain/subscription/service/SubscriptionService.java
@@ -4,10 +4,12 @@ import club.ttg.dnd5.domain.achievement.rest.dto.UserAchievementResponse;
 import club.ttg.dnd5.domain.achievement.service.AchievementService;
 import club.ttg.dnd5.domain.subscription.model.RedemptionCode;
 import club.ttg.dnd5.domain.subscription.model.RewardPerk;
+import club.ttg.dnd5.domain.subscription.model.RewardResource;
 import club.ttg.dnd5.domain.subscription.model.UserSubscription;
 import club.ttg.dnd5.domain.subscription.repository.RedemptionCodeRepository;
 import club.ttg.dnd5.domain.subscription.repository.UserSubscriptionRepository;
 import club.ttg.dnd5.domain.subscription.rest.dto.CreateCodesRequest;
+import club.ttg.dnd5.domain.subscription.rest.dto.MyRedemptionResponse;
 import club.ttg.dnd5.domain.subscription.rest.dto.RedeemResponse;
 import club.ttg.dnd5.domain.subscription.rest.dto.RedemptionCodeResponse;
 import club.ttg.dnd5.domain.subscription.rest.dto.SubscriptionResponse;
@@ -29,9 +31,11 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -127,6 +131,7 @@ public class SubscriptionService {
             entity.setType(code.getSubscriptionType());
             entity.setDurationMonths(code.getSubscriptionMonths());
             entity.setOwnerUsername(username);
+            entity.setSourceCode(code.getUuid());
             entity.setRegisteredAt(now);
             subscription = toResponse(subscriptionRepository.save(entity), now);
         }
@@ -218,6 +223,49 @@ public class SubscriptionService {
         Instant now = Instant.now();
         return subscriptionRepository.findByOwnerUsernameOrderByCreatedAtDesc(currentUsername()).stream()
                 .map(subscription -> toResponse(subscription, now))
+                .toList();
+    }
+
+    /**
+     * Коды, погашенные текущим пользователем (новые сверху), с резолвом наград в
+     * ссылки и привязанной подпиской — для раздела «Активация кодов» в кабинете.
+     * Награды кода = пресет тира ∪ доп. перки кода (как при погашении), что даёт
+     * стабильный перечень ссылок независимо от дедупликации выданных перков.
+     */
+    @Transactional(readOnly = true)
+    public List<MyRedemptionResponse> currentUserRedemptions() {
+        String username = currentUsername();
+        Instant now = Instant.now();
+
+        // подписки пользователя по коду-источнику — чтобы прицепить к своей строке без N+1
+        Map<UUID, UserSubscription> subscriptionsByCode = new HashMap<>();
+        for (UserSubscription subscription : subscriptionRepository.findByOwnerUsernameOrderByCreatedAtDesc(username)) {
+            if (subscription.getSourceCode() != null) {
+                subscriptionsByCode.putIfAbsent(subscription.getSourceCode(), subscription);
+            }
+        }
+
+        // справочник ссылок на награды — один раз на весь список (а не на каждый код)
+        Map<RewardPerk, RewardResource> resources = rewardService.resourceMap();
+
+        return codeRepository.findByRedeemedByOrderByRedeemedAtDesc(username).stream()
+                .map(code -> {
+                    Set<RewardPerk> perks = EnumSet.noneOf(RewardPerk.class);
+                    if (code.getRewardTier() != null) {
+                        perks.addAll(code.getRewardTier().perks());
+                    }
+                    perks.addAll(code.getPerks());
+
+                    UserSubscription subscription = subscriptionsByCode.get(code.getUuid());
+                    return new MyRedemptionResponse(
+                            code.getUuid(),
+                            code.getCode(),
+                            code.getRedeemedAt(),
+                            code.getRewardTier(),
+                            rewardService.describe(perks, code.getRedeemedAt(), resources),
+                            achievementService.describe(code.getAchievements(), code.getRedeemedAt()),
+                            subscription == null ? null : toResponse(subscription, now));
+                })
                 .toList();
     }
 

--- a/src/main/resources/db/changelog/2026/06/26-02-add-source-code-to-subscription.yaml
+++ b/src/main/resources/db/changelog/2026/06/26-02-add-source-code-to-subscription.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-26-02-add-source-code-to-subscription
+      author: claude
+      changes:
+        - addColumn:
+            tableName: user_subscription
+            columns:
+              - column:
+                  name: source_code
+                  type: UUID

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -213,3 +213,5 @@ databaseChangeLog:
       file: db/changelog/2026/06/25-01-add-magic-item-items.yaml
   - include:
       file: db/changelog/2026/06/26-01-add-disabled-to-redemption-code.yaml
+  - include:
+      file: db/changelog/2026/06/26-02-add-source-code-to-subscription.yaml


### PR DESCRIPTION
Серверная часть личного кабинета активации кодов.

- GET /api/subscriptions/my-codes (USER): коды, погашенные текущим пользователем (новые сверху), с резолвом наград в ссылки и статус готовности и привязанной подпиской. Набор наград кода = пресет тира ∪ дополнительные перки кода (как при погашении), что даёт стабильный перечень ссылок независимо от дедупликации уже выданных перков.
- Подписка связывается с кодом-источником: колонка user_subscription.source_code (миграция 26-02), redeem проставляет sourceCode при создании подписки. Колонка nullable.
- RewardService: describe(perks, grantedAt, resources) с готовой картой ресурсов + публичный resourceMap() — справочник ссылок берётся один раз на весь список, без повторного скана reward_resource на каждый код.
- AchievementService.describe(codes, grantedAt): достижения кода с названиями из каталога вместо сырых кодов.
- RedemptionCodeRepository.findByRedeemedByOrderByRedeemedAtDesc с @EntityGraph(perks, achievements) — без лишних запросов при выборке.

Новый DTO MyRedemptionResponse. Изменения аддитивные и обратносовместимые.