### PR TITLE
feat(vttg): экспорт таблиц/списков/цитат фронтового диалекта разметки

### DIFF
--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgMarkupConverter.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgMarkupConverter.java
@@ -84,23 +84,39 @@ public class VttgMarkupConverter {
         }
         if (node.isObject()) {
             String type = node.path("type").asText();
+
+            // Перенос строки — и ProseMirror (hardBreak), и фронтовый узел (break).
+            if ("hardBreak".equals(type) || "break".equals(type)) {
+                return "\n";
+            }
+            // Списки: ProseMirror (bulletList/orderedList) и фронтовый {type:list}.
             if ("bulletList".equals(type)) {
                 return extractList(node, false);
             }
             if ("orderedList".equals(type)) {
                 return extractList(node, true);
             }
-            if ("table".equals(type)) {
-                return extractTable(node);
+            if ("list".equals(type)) {
+                return extractFrontendList(node);
             }
+            // Таблица: фронтовая форма (colLabels/rows) либо ProseMirror (content).
+            if ("table".equals(type)) {
+                return node.has("colLabels") || node.has("rows")
+                        ? extractFrontendTable(node)
+                        : extractTable(node);
+            }
+            // Инлайн-узлы фронтового диалекта (формат/ссылки) — узловая форма тех
+            // же тегов, что в строках-абзацах идут литералами и разворачиваются в
+            // replaceMarkup. null — не инлайн-узел, идёт обобщённо (текст+контент).
+            String inline = extractInlineNode(node, type);
+            if (inline != null) {
+                return inline;
+            }
+
             String text = node.hasNonNull("text") ? node.get("text").asText() : "";
             String content = node.has("content")
                     ? extractChildren(node.get("content"), hasBlockContent(type))
                     : "";
-
-            if ("hardBreak".equals(type)) {
-                return "\n";
-            }
             return text + content;
         }
         return "";
@@ -138,6 +154,137 @@ public class VttgMarkupConverter {
 
     private String indentContinuation(String content) {
         return content.trim().replace("\n", "\n  ");
+    }
+
+    /**
+     * Список фронтового диалекта {@code {type:list, attrs:{type}, content:[...]}}:
+     * пункт — это МАССИВ-батч инлайна либо узел {@code {type:li}}. В markdown —
+     * маркеры {@code - } / {@code N. } (как {@link #extractList}).
+     */
+    private String extractFrontendList(JsonNode node) {
+        JsonNode items = node.get("content");
+        if (items == null || !items.isArray()) {
+            return "";
+        }
+
+        boolean ordered = "ordered".equals(node.path("attrs").path("type").asText());
+        List<String> lines = new ArrayList<>();
+        int number = 1;
+        for (JsonNode item : items) {
+            String content = extractFrontendListItem(item).trim();
+            if (StringUtils.hasText(content)) {
+                String marker = ordered ? (number++) + ". " : "- ";
+                lines.add(marker + indentContinuation(content));
+            }
+        }
+        return String.join("\n", lines);
+    }
+
+    /** Содержимое пункта фронтового списка: батч-массив, узел {@code {type:li}} или иной узел. */
+    private String extractFrontendListItem(JsonNode item) {
+        if (item.isArray()) {
+            return extractChildren(item, false);
+        }
+        if ("li".equals(item.path("type").asText())) {
+            return extractContent(item);
+        }
+        return extract(item);
+    }
+
+    /**
+     * Таблица фронтового диалекта {@code {type:table, colLabels[], colStyles[],
+     * rows[][]}} → markdown-таблица. Ячейка — строка либо {@code {content, align}}.
+     * Стили колонок и подпись в VTTG опускаются (как и в {@link #extractTable}).
+     */
+    private String extractFrontendTable(JsonNode node) {
+        List<List<String>> table = new ArrayList<>();
+
+        JsonNode colLabels = node.get("colLabels");
+        if (colLabels != null && colLabels.isArray()) {
+            List<String> header = new ArrayList<>();
+            colLabels.forEach(label -> header.add(formatTableCell(extractInlineCell(label))));
+            if (!header.isEmpty()) {
+                table.add(header);
+            }
+        }
+
+        JsonNode rows = node.get("rows");
+        if (rows != null && rows.isArray()) {
+            for (JsonNode row : rows) {
+                if (!row.isArray()) {
+                    continue;
+                }
+                List<String> cells = new ArrayList<>();
+                row.forEach(cell -> cells.add(formatTableCell(extractInlineCell(cell))));
+                if (!cells.isEmpty()) {
+                    table.add(cells);
+                }
+            }
+        }
+
+        if (table.isEmpty()) {
+            return "";
+        }
+
+        int width = table.stream().mapToInt(List::size).max().orElse(0);
+        List<String> markdown = new ArrayList<>();
+        markdown.add(formatTableRow(table.getFirst(), width));
+        markdown.add(formatTableSeparator(width));
+        for (int index = 1; index < table.size(); index++) {
+            markdown.add(formatTableRow(table.get(index), width));
+        }
+        return String.join("\n", markdown);
+    }
+
+    /**
+     * Инлайн-текст ячейки/заголовка фронтовой таблицы: строка, массив инлайн-узлов
+     * (так фронт сериализует {@code colLabels[i]}/ячейку) либо {@code {content, align}}.
+     * Всегда инлайн-склейка (без блочного {@code \n\n}), иначе в ячейке из нескольких
+     * фрагментов (например {@code {@th Урон ({@dice к6})}}) появился бы ложный перенос.
+     */
+    private String extractInlineCell(JsonNode cell) {
+        if (cell.isArray()) {
+            return extractChildren(cell, false);
+        }
+        if (cell.isObject() && cell.has("content") && !cell.has("type")) {
+            return extractChildren(cell.get("content"), false);
+        }
+        return extract(cell);
+    }
+
+    /**
+     * Разворачивает ИНЛАЙН-узел фронтового диалекта в текст/markdown. Возвращает
+     * null, если это не инлайн-узел (обрабатывается обобщённо). Форматирование
+     * повторяет {@link #replaceMarkup} (там — литеральные {@code {@...}} из строк),
+     * но здесь рекурсирует по вложенным узлам без риска регэкспа на «}».
+     */
+    private String extractInlineNode(JsonNode node, String type) {
+        if ("bold".equals(type)) {
+            return "**" + extractContent(node) + "**";
+        }
+        if ("italic".equals(type)) {
+            return "*" + extractContent(node) + "*";
+        }
+        // Ссылки на разделы сайта ({type:glossary|spell}, attrs.url) — как в
+        // replaceSiteLinks; прочие типы разделов/форматов идут обобщённо (текст).
+        String section = SITE_LINK_SECTIONS.get(type);
+        if (section != null) {
+            String label = extractContent(node).trim();
+            String url = node.path("attrs").path("url").asText("");
+            return url.isEmpty()
+                    ? label
+                    : "[" + label + "](" + siteUrl() + "/" + section + "/" + url + ")";
+        }
+        if ("link".equals(type)) {
+            return extractContent(node);
+        }
+        return null;
+    }
+
+    /** Инлайн-содержимое узла (content) без блочных переносов; "" если пусто. */
+    private String extractContent(JsonNode node) {
+        JsonNode content = node.get("content");
+        return content == null ? "" : extractChildren(content, false);
     }
 
     private String extractTable(JsonNode node) {

--- a/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgMarkupConverterTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgMarkupConverterTest.java
@@ -231,4 +231,99 @@ class VttgMarkupConverterTest {
 
         assertEquals(markup, converter.toText(markup));
     }
+
+    @Test
+    void convertsFrontendDialectTableToMarkdown() {
+        String markup = """
+                {
+                  "type": "table",
+                  "caption": "Пример",
+                  "colLabels": ["Компонент", "Тип"],
+                  "colStyles": ["w-1/2", "w-1/2"],
+                  "rows": [
+                    [
+                      {"content": [{"type": "bold", "content": [{"type": "text", "text": "Badge"}]}]},
+                      "Inline"
+                    ],
+                    [
+                      "Kbd",
+                      {"content": [{"type": "badge", "attrs": {"color": "primary"}, "content": [{"type": "text", "text": "7"}]}]}
+                    ]
+                  ]
+                }
+                """;
+
+        assertEquals(
+                "| Компонент | Тип |\n| --- | --- |\n| **Badge** | Inline |\n| Kbd | 7 |",
+                converter.toText(markup)
+        );
+    }
+
+    @Test
+    void convertsFrontendTableWithNodeArrayHeaders() {
+        // Реальный формат редактора (toStoredMarkup): colLabels[i] — МАССИВ инлайн-
+        // узлов, ячейки — {content}. Заголовок из нескольких фрагментов не должен
+        // склеиваться через <br> (инлайн-склейка, а не блочная).
+        String markup = """
+                {
+                  "type": "table",
+                  "colLabels": [
+                    [
+                      {"type": "text", "text": "Урон ("},
+                      {"type": "roll", "content": [{"type": "text", "text": "к6"}]},
+                      {"type": "text", "text": ")"}
+                    ],
+                    [{"type": "text", "text": "Эффект"}]
+                  ],
+                  "rows": [
+                    [
+                      {"content": [{"type": "text", "text": "10"}]},
+                      {"content": [{"type": "text", "text": "Ожог"}]}
+                    ]
+                  ]
+                }
+                """;
+
+        assertEquals(
+                "| Урон (к6) | Эффект |\n| --- | --- |\n| 10 | Ожог |",
+                converter.toText(markup)
+        );
+    }
+
+    @Test
+    void convertsFrontendDialectOrderedListToMarkdown() {
+        String markup = """
+                {
+                  "type": "list",
+                  "attrs": {"type": "ordered"},
+                  "content": [
+                    [{"type": "text", "text": "Первый"}],
+                    [{"type": "bold", "content": [{"type": "text", "text": "Второй"}]}]
+                  ]
+                }
+                """;
+
+        assertEquals("1. Первый\n2. **Второй**", converter.toText(markup));
+    }
+
+    @Test
+    void convertsFrontendDialectQuoteWithInlineNodes() {
+        String markup = """
+                {
+                  "type": "quote",
+                  "attrs": {"color": "primary", "variant": "outline"},
+                  "content": [
+                    {"type": "bold", "content": [{"type": "text", "text": "Внимание"}]},
+                    {"type": "text", "text": ": смотри "},
+                    {"type": "spell", "attrs": {"url": "fireball-phb"}, "content": [{"type": "text", "text": "Огненный шар"}]},
+                    {"type": "text", "text": "."}
+                  ]
+                }
+                """;
+
+        assertEquals(
+                "**Внимание**: смотри [Огненный шар](https://ttg.club/spells/fireball-phb).",
+                converter.toText(markup)
+        );
+    }
 }


### PR DESCRIPTION
VttgMarkupConverter понимал только ProseMirror-AST, из-за чего таблицы, сохранённые редактором в фронтовом диалекте ({type:table, colLabels, colStyles, rows}), экспортировались пустыми, а списки и цитаты теряли структуру. Добавлена поддержка фронтового диалекта:

- таблицы colLabels/rows конвертируются в markdown-таблицу; ячейки и заголовки собираются инлайн-склейкой (extractInlineCell) — строка, массив инлайн-узлов или {content}, поэтому шапка из нескольких фрагментов (например «Урон ({@dice к6})») не даёт ложный перенос <br>;
- списки {type:list} с пунктами-батчами или узлами {type:li};
- инлайн-узлы bold/italic и ссылки на разделы (glossary/spell) разворачиваются в markdown и ссылку; узел break даёт перенос строки.

ProseMirror-пути и прежние тесты не затронуты. Покрытие VttgMarkupConverterTest — 16 тестов (12 прежних и 4 на фронтовый диалект, включая заголовок-массив).