### PR TITLE
feat(article): статьи/новости — типы, публикация по ссылке и автопостинг в Telegram / Discord / VK

### DIFF
--- a/src/main/java/club/ttg/dnd5/config/DiscordConfig.java
+++ b/src/main/java/club/ttg/dnd5/config/DiscordConfig.java
@@ -1,0 +1,38 @@
+package club.ttg.dnd5.config;
+
+import club.ttg.dnd5.config.properties.DiscordProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+import java.net.http.HttpClient;
+
+/**
+ * Клиент к Discord-вебхуку: конечные таймауты. RestClient собирается здесь (а не в сервисе), чтобы
+ * его можно было подменить mock-ом в тестах — как у {@link TelegramConfig}. Базовый адрес не зашивается:
+ * весь URL вебхука (вместе с токеном) — секрет из окружения, поэтому публикатор бьёт по нему абсолютным
+ * адресом, и бин не зависит от секрета (создаётся всегда, даже когда вебхук не задан).
+ * <p>
+ * Фабрика — {@link JdkClientHttpRequestFactory} (java.net.http), а не Simple/HttpURLConnection: правка
+ * поста в Discord идёт методом {@code PATCH}, который {@code HttpURLConnection} не поддерживает.
+ */
+@Configuration
+public class DiscordConfig {
+
+    @Bean
+    public RestClient discordRestClient(DiscordProperties properties) {
+        return RestClient.builder()
+                .requestFactory(requestFactory(properties))
+                .build();
+    }
+
+    private JdkClientHttpRequestFactory requestFactory(DiscordProperties properties) {
+        HttpClient httpClient = HttpClient.newBuilder()
+                .connectTimeout(properties.getConnectTimeout())
+                .build();
+        JdkClientHttpRequestFactory factory = new JdkClientHttpRequestFactory(httpClient);
+        factory.setReadTimeout(properties.getReadTimeout());
+        return factory;
+    }
+}

--- a/src/main/java/club/ttg/dnd5/config/TelegramConfig.java
+++ b/src/main/java/club/ttg/dnd5/config/TelegramConfig.java
@@ -1,0 +1,33 @@
+package club.ttg.dnd5.config;
+
+import club.ttg.dnd5.config.properties.TelegramProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Клиент к Telegram Bot API: базовый адрес и конечные таймауты. RestClient собирается
+ * здесь (а не в сервисе), чтобы его можно было подменить mock-ом в тестах — как у
+ * {@link SubscriberServiceConfig}. Токен в URL не зашивается: он подставляется в путь
+ * на каждом вызове, поэтому бин не зависит от секрета и создаётся всегда.
+ */
+@Configuration
+public class TelegramConfig {
+
+    @Bean
+    public RestClient telegramRestClient(TelegramProperties properties) {
+        return RestClient.builder()
+                .baseUrl(properties.getApiUrl())
+                .requestFactory(requestFactory(properties))
+                .build();
+    }
+
+    private ClientHttpRequestFactory requestFactory(TelegramProperties properties) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(properties.getConnectTimeout());
+        factory.setReadTimeout(properties.getReadTimeout());
+        return factory;
+    }
+}

--- a/src/main/java/club/ttg/dnd5/config/VkConfig.java
+++ b/src/main/java/club/ttg/dnd5/config/VkConfig.java
@@ -1,0 +1,39 @@
+package club.ttg.dnd5.config;
+
+import club.ttg.dnd5.config.properties.VkProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+import java.net.http.HttpClient;
+
+/**
+ * Клиент к VK API: конечные таймауты. RestClient собирается здесь (а не в сервисе), чтобы его можно было
+ * подменить mock-ом в тестах — как у {@link DiscordConfig} и {@link TelegramConfig}. Базовый адрес не
+ * зашивается: методы VK ({@code wall.post}/{@code wall.edit}/…) и адрес загрузки фото (выдаётся VK на лету)
+ * лежат на разных хостах, поэтому публикатор бьёт по абсолютным адресам. Токен — не в URL, а в теле запроса,
+ * поэтому бин не зависит от секрета и создаётся всегда.
+ * <p>
+ * Фабрика — {@link JdkClientHttpRequestFactory} (java.net.http): вызовы идут методом {@code POST}
+ * (form-urlencoded для методов и multipart для загрузки обложки), длинный текст поста не влезает в URL.
+ */
+@Configuration
+public class VkConfig {
+
+    @Bean
+    public RestClient vkRestClient(VkProperties properties) {
+        return RestClient.builder()
+                .requestFactory(requestFactory(properties))
+                .build();
+    }
+
+    private JdkClientHttpRequestFactory requestFactory(VkProperties properties) {
+        HttpClient httpClient = HttpClient.newBuilder()
+                .connectTimeout(properties.getConnectTimeout())
+                .build();
+        JdkClientHttpRequestFactory factory = new JdkClientHttpRequestFactory(httpClient);
+        factory.setReadTimeout(properties.getReadTimeout());
+        return factory;
+    }
+}

--- a/src/main/java/club/ttg/dnd5/config/properties/DiscordProperties.java
+++ b/src/main/java/club/ttg/dnd5/config/properties/DiscordProperties.java
@@ -1,0 +1,36 @@
+package club.ttg.dnd5.config.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+/**
+ * Настройки автопубликации статей / новостей в Discord-канал через входящий вебхук.
+ * <p>
+ * Секрет ({@code webhookUrl}) приходит из окружения: в Dokploy — через переменную окружения сервиса,
+ * локально — через {@code local.env} (в .gitignore). Интеграция включена ровно тогда, когда задан
+ * {@code webhookUrl}; если его нет (например, локально) — планировщик просто ничего не отправляет.
+ * <p>
+ * В отличие от Telegram (bot-token + chat-id) вебхук самодостаточен: весь адрес канала зашит в URL,
+ * поэтому отдельного идентификатора канала не нужно — «просто подключить вебхук к каналу».
+ */
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "discord")
+public class DiscordProperties {
+    /**
+     * Полный URL входящего вебхука Discord ({@code https://discord.com/api/webhooks/<id>/<token>}).
+     * Пусто — интеграция выключена. Секрет: содержит токен вебхука.
+     */
+    private String webhookUrl;
+
+    private Duration connectTimeout = Duration.ofSeconds(3);
+    private Duration readTimeout = Duration.ofSeconds(10);
+
+    /** Сколько записей отправлять за один тик планировщика (страховка от заливки канала пачкой). */
+    private int batchSize = 10;
+}

--- a/src/main/java/club/ttg/dnd5/config/properties/TelegramProperties.java
+++ b/src/main/java/club/ttg/dnd5/config/properties/TelegramProperties.java
@@ -1,0 +1,40 @@
+package club.ttg.dnd5.config.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+/**
+ * Настройки автопубликации статей / новостей в Telegram-канал.
+ * <p>
+ * Секреты ({@code botToken}, {@code chatId}) приходят из окружения: в Dokploy — через
+ * переменные окружения сервиса, локально — через {@code local.env} (в .gitignore).
+ * Интеграция включена ровно тогда, когда заданы {@code botToken} и {@code chatId}; если их нет
+ * (например, локально) — планировщик просто ничего не отправляет.
+ */
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "telegram")
+public class TelegramProperties {
+    /** Токен бота (формат {@code 123456:AA...}). Пусто — интеграция выключена. */
+    private String botToken;
+
+    /** Канал: {@code @username} или числовой id вида {@code -100...}. */
+    private String chatId;
+
+    /** База Bot API. Меняется только для тестов/прокси. */
+    private String apiUrl = "https://api.telegram.org";
+
+    /** Режим разметки текста поста. HTML проще экранировать, чем MarkdownV2. */
+    private String parseMode = "HTML";
+
+    private Duration connectTimeout = Duration.ofSeconds(3);
+    private Duration readTimeout = Duration.ofSeconds(10);
+
+    /** Сколько записей отправлять за один тик планировщика (страховка от заливки канала пачкой). */
+    private int batchSize = 10;
+}

--- a/src/main/java/club/ttg/dnd5/config/properties/VkProperties.java
+++ b/src/main/java/club/ttg/dnd5/config/properties/VkProperties.java
@@ -1,0 +1,52 @@
+package club.ttg.dnd5.config.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+/**
+ * Настройки автопубликации статей / новостей на стену сообщества ВКонтакте.
+ * <p>
+ * Секреты ({@code accessToken}, {@code groupId}) приходят из окружения: в Dokploy — через переменные
+ * окружения сервиса, локально — через {@code local.env} (в .gitignore). Интеграция включена ровно тогда,
+ * когда заданы {@code accessToken} и {@code groupId}; если их нет (например, локально) — планировщик просто
+ * ничего не отправляет.
+ * <p>
+ * {@code accessToken} — это ключ доступа сообщества («API-ключ группы»): бот не нужен, пост уходит от имени
+ * сообщества ({@code wall.post} с {@code from_group=1}). Токен должен иметь право «Стена» (для постинга) и
+ * «Фотографии» (для обложки). Загрузка обложки на стену через ключ сообщества доступна не всегда (VK может
+ * ответить ошибкой 27) — тогда пост уходит текстом; для гарантированной обложки можно подставить пользовательский
+ * токен администратора группы с правами {@code wall,photos,groups}.
+ */
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "vk")
+public class VkProperties {
+    /**
+     * Ключ доступа сообщества («API-ключ группы») или пользовательский токен админа группы.
+     * Пусто — интеграция выключена. Секрет.
+     */
+    private String accessToken;
+
+    /**
+     * Числовой id сообщества (без знака). Нужен для {@code owner_id=-<groupId>} в постах и как {@code group_id}
+     * при загрузке обложки. Пусто — интеграция выключена.
+     */
+    private String groupId;
+
+    /** База VK API. Меняется только для тестов/прокси. */
+    private String apiUrl = "https://api.vk.com/method";
+
+    /** Версия VK API (обязательный параметр {@code v} каждого вызова). */
+    private String apiVersion = "5.199";
+
+    private Duration connectTimeout = Duration.ofSeconds(3);
+    private Duration readTimeout = Duration.ofSeconds(10);
+
+    /** Сколько записей отправлять за один тик планировщика (страховка от заливки стены пачкой). */
+    private int batchSize = 10;
+}

--- a/src/main/java/club/ttg/dnd5/domain/article/model/Article.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/model/Article.java
@@ -3,11 +3,14 @@ package club.ttg.dnd5.domain.article.model;
 import club.ttg.dnd5.domain.common.model.Timestamped;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -44,5 +47,47 @@ public class Article extends Timestamped {
     @Column(columnDefinition = "TEXT")
     private String preview;
 
-    private Boolean deleted;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ArticleType type;
+
+    @Column(nullable = false)
+    private boolean deleted;
+
+    /**
+     * Черновик: никогда не публиковалась. Не видна на сайте, по ссылке недоступна.
+     */
+    @Column(nullable = false)
+    private boolean draft;
+
+    /**
+     * Флаг публикации (активности): для опубликованной записи — включена ли она
+     * в общий доступ. false = снята с публикации (неактивна).
+     */
+    @Column(nullable = false)
+    private boolean active;
+
+    /**
+     * Доступность по прямой ссылке: если true, запись можно открыть по url,
+     * даже когда она не в общем доступе (актуально для неактивной записи).
+     */
+    @Column(nullable = false)
+    private boolean accessibleByLink;
+
+    /**
+     * Вычисляемый статус: черновик / запланирована / активна / неактивна.
+     */
+    @Transient
+    public ArticleStatus getStatus() {
+        if (draft) {
+            return ArticleStatus.DRAFT;
+        }
+        if (!active) {
+            return ArticleStatus.INACTIVE;
+        }
+        if (publishDateTime != null && publishDateTime.isAfter(Instant.now())) {
+            return ArticleStatus.SCHEDULED;
+        }
+        return ArticleStatus.ACTIVE;
+    }
 }

--- a/src/main/java/club/ttg/dnd5/domain/article/model/Article.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/model/Article.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Transient;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.DynamicUpdate;
 
 import java.time.Instant;
 import java.util.UUID;
@@ -23,6 +24,9 @@ import java.util.UUID;
 @Setter
 @NoArgsConstructor
 @Entity
+// UPDATE только по реально изменённым колонкам: правка новости не должна затирать
+// telegram_* поля, которыми асинхронно владеет планировщик (claim / message_id / dirty).
+@DynamicUpdate
 @Table(name = "article",
         indexes = {
                 @Index(name = "article_url_index", columnList = "url", unique = true)
@@ -73,6 +77,40 @@ public class Article extends Timestamped {
      */
     @Column(nullable = false)
     private boolean accessibleByLink;
+
+    /**
+     * Пожелание автора отправить запись в Telegram-канал. Управляется галочкой в админке.
+     * Постится только при publishToTelegram=true И включённой глобально интеграции, один раз
+     * при попадании записи в общий доступ (см. {@code telegramPostedAt}).
+     */
+    @Column(nullable = false)
+    private boolean publishToTelegram;
+
+    /**
+     * Момент отправки записи в Telegram-канал. NULL — ещё не отправлена.
+     * Служит флагом идемпотентности: планировщик постит запись один раз и проставляет время,
+     * поэтому повторное сохранение/редактирование или снятие-и-возврат публикации не дублируют пост.
+     */
+    private Instant telegramPostedAt;
+
+    /**
+     * id сообщения в Telegram-канале. Заполняется после успешной отправки, нужен для правки поста
+     * при редактировании новости. NULL — пост в канал ещё не ушёл.
+     */
+    private Long telegramMessageId;
+
+    /**
+     * Пост в канале отправлен как фото (с обложкой). Тогда при синхронизации правим caption,
+     * иначе — text (Telegram различает editMessageCaption и editMessageText).
+     */
+    @Column(nullable = false)
+    private boolean telegramPhoto;
+
+    /**
+     * Новость изменена после отправки в канал — планировщик синхронизирует пост (editMessage) и снимет флаг.
+     */
+    @Column(nullable = false)
+    private boolean telegramDirty;
 
     /**
      * Вычисляемый статус: черновик / запланирована / активна / неактивна.

--- a/src/main/java/club/ttg/dnd5/domain/article/model/Article.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/model/Article.java
@@ -24,7 +24,7 @@ import java.util.UUID;
 @Setter
 @NoArgsConstructor
 @Entity
-// UPDATE только по реально изменённым колонкам: правка новости не должна затирать telegram_*/discord_*
+// UPDATE только по реально изменённым колонкам: правка новости не должна затирать telegram_*/discord_*/vk_*
 // поля, которыми асинхронно владеют планировщики публикации (claim / message_id / dirty).
 @DynamicUpdate
 @Table(name = "article",
@@ -140,6 +140,40 @@ public class Article extends Timestamped {
      */
     @Column(nullable = false)
     private boolean discordDirty;
+
+    /**
+     * Пожелание автора отправить запись на стену сообщества ВКонтакте. Управляется галочкой в админке.
+     * Постится только при publishToVk=true И включённой глобально интеграции (заданы токен и id сообщества),
+     * один раз при попадании записи в общий доступ (см. {@code vkPostedAt}). Независима от Telegram и Discord.
+     */
+    @Column(nullable = false)
+    private boolean publishToVk;
+
+    /**
+     * Момент отправки записи на стену VK. NULL — ещё не отправлена.
+     * Служит флагом идемпотентности: планировщик постит запись один раз и проставляет время,
+     * поэтому повторное сохранение/редактирование или снятие-и-возврат публикации не дублируют пост.
+     */
+    private Instant vkPostedAt;
+
+    /**
+     * id поста на стене сообщества (числовой post_id). Заполняется после успешной отправки, нужен для правки
+     * ({@code wall.edit}) и удаления ({@code wall.delete}) поста. NULL — пост на стену ещё не ушёл.
+     */
+    private Long vkPostId;
+
+    /**
+     * Строка вложения-обложки поста ({@code photo<owner_id>_<id>}). Заполняется, если пост ушёл с обложкой:
+     * пере-передаётся в {@code wall.edit}, чтобы правка текста не убрала фото. NULL — пост без обложки.
+     */
+    @Column(length = 64)
+    private String vkAttachment;
+
+    /**
+     * Новость изменена после отправки на стену — планировщик синхронизирует пост (wall.edit) и снимет флаг.
+     */
+    @Column(nullable = false)
+    private boolean vkDirty;
 
     /**
      * Вычисляемый статус: черновик / запланирована / активна / неактивна.

--- a/src/main/java/club/ttg/dnd5/domain/article/model/Article.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/model/Article.java
@@ -24,8 +24,8 @@ import java.util.UUID;
 @Setter
 @NoArgsConstructor
 @Entity
-// UPDATE только по реально изменённым колонкам: правка новости не должна затирать
-// telegram_* поля, которыми асинхронно владеет планировщик (claim / message_id / dirty).
+// UPDATE только по реально изменённым колонкам: правка новости не должна затирать telegram_*/discord_*
+// поля, которыми асинхронно владеют планировщики публикации (claim / message_id / dirty).
 @DynamicUpdate
 @Table(name = "article",
         indexes = {
@@ -111,6 +111,35 @@ public class Article extends Timestamped {
      */
     @Column(nullable = false)
     private boolean telegramDirty;
+
+    /**
+     * Пожелание автора отправить запись в Discord-канал. Управляется галочкой в админке.
+     * Постится только при publishToDiscord=true И включённой глобально интеграции (задан webhook),
+     * один раз при попадании записи в общий доступ (см. {@code discordPostedAt}). Независима от Telegram.
+     */
+    @Column(nullable = false)
+    private boolean publishToDiscord;
+
+    /**
+     * Момент отправки записи в Discord-канал. NULL — ещё не отправлена.
+     * Служит флагом идемпотентности: планировщик постит запись один раз и проставляет время,
+     * поэтому повторное сохранение/редактирование или снятие-и-возврат публикации не дублируют пост.
+     */
+    private Instant discordPostedAt;
+
+    /**
+     * id сообщения в Discord-канале (снежинка). Заполняется после успешной отправки, нужен для правки
+     * и удаления поста. Строка, а не число: снежинка приходит строкой в JSON и используется как сегмент
+     * пути вебхука ({@code /messages/{id}}). NULL — пост в канал ещё не ушёл.
+     */
+    @Column(length = 32)
+    private String discordMessageId;
+
+    /**
+     * Новость изменена после отправки в канал — планировщик синхронизирует пост (editMessage) и снимет флаг.
+     */
+    @Column(nullable = false)
+    private boolean discordDirty;
 
     /**
      * Вычисляемый статус: черновик / запланирована / активна / неактивна.

--- a/src/main/java/club/ttg/dnd5/domain/article/model/ArticleStatus.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/model/ArticleStatus.java
@@ -1,0 +1,15 @@
+package club.ttg.dnd5.domain.article.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ArticleStatus {
+    DRAFT("Черновик"),
+    SCHEDULED("Запланирована"),
+    ACTIVE("Активна"),
+    INACTIVE("Неактивна");
+
+    private final String name;
+}

--- a/src/main/java/club/ttg/dnd5/domain/article/model/ArticleType.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/model/ArticleType.java
@@ -1,0 +1,13 @@
+package club.ttg.dnd5.domain.article.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ArticleType {
+    NEWS("Новость"),
+    ARTICLE("Статья");
+
+    private final String name;
+}

--- a/src/main/java/club/ttg/dnd5/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/repository/ArticleRepository.java
@@ -267,4 +267,99 @@ public interface ArticleRepository extends JpaRepository<Article, UUID> {
     @Query("UPDATE Article a SET a.discordMessageId = null, a.discordPostedAt = null, a.discordDirty = false "
             + "WHERE a.id = :id")
     void clearDiscordPost(@Param("id") UUID id);
+
+    /**
+     * Записи, которые пора отправить в VK: с включённой галочкой (publishToVk=true), живые и опубликованные
+     * (не удалены, не черновик, активны, дата публикации наступила) и ещё не отправленные (vkPostedAt IS NULL).
+     * Один и тот же запрос закрывает и «опубликовано сейчас», и «наступила запланированная дата». Независим
+     * от Telegram и Discord.
+     */
+    @Query("""
+            SELECT a FROM Article a
+            WHERE a.deleted = false
+              AND a.draft = false
+              AND a.active = true
+              AND a.publishToVk = true
+              AND a.publishDateTime < :now
+              AND a.vkPostedAt IS NULL
+            ORDER BY a.publishDateTime ASC
+            """)
+    List<Article> findDueForVk(@Param("now") Instant now, Limit limit);
+
+    /**
+     * Атомарно «занимает» запись под отправку в VK: проставляет время ТОЛЬКО если она ещё не занята
+     * ({@code vkPostedAt IS NULL}). Занимаем ДО сетевого вызова, поэтому:
+     * — параллельный тик / второй инстанс не отправят дубль (займёт кто-то один);
+     * — сбой после успешной отправки (упавшая транзакция/рестарт) не приведёт к повторному посту.
+     *
+     * @return 1 — заняли (можно отправлять), 0 — уже занята кем-то (пропускаем).
+     */
+    @Modifying
+    @Query("UPDATE Article a SET a.vkPostedAt = :postedAt WHERE a.id = :id AND a.vkPostedAt IS NULL")
+    int claimForVk(@Param("id") UUID id, @Param("postedAt") Instant postedAt);
+
+    /**
+     * Снимает отметку об отправке — если отправка не удалась по временной причине, чтобы
+     * повторить попытку на следующем тике.
+     */
+    @Modifying
+    @Query("UPDATE Article a SET a.vkPostedAt = null WHERE a.id = :id")
+    void releaseVkClaim(@Param("id") UUID id);
+
+    /**
+     * Записи, у которых пост на стене уже есть (vkPostId), новость изменена после отправки (vkDirty=true) и
+     * она всё ещё публична (те же условия, что в findDueForVk) — их нужно синхронизировать (отредактировать пост).
+     */
+    @Query("""
+            SELECT a FROM Article a
+            WHERE a.deleted = false
+              AND a.draft = false
+              AND a.active = true
+              AND a.publishToVk = true
+              AND a.publishDateTime < :now
+              AND a.vkPostId IS NOT NULL
+              AND a.vkDirty = true
+            ORDER BY a.updatedAt ASC
+            """)
+    List<Article> findDirtyForVk(@Param("now") Instant now, Limit limit);
+
+    /**
+     * Фиксирует успешную отправку: id поста на стене и строку вложения-обложки (для сохранения фото при правке).
+     * Момент отправки (vkPostedAt) уже проставлен на этапе claim. Флаг vkDirty НЕ трогаем: если правка прилетела
+     * в окне отправки, она останется помеченной и синхронизируется следующим тиком.
+     */
+    @Modifying
+    @Query("UPDATE Article a SET a.vkPostId = :postId, a.vkAttachment = :attachment WHERE a.id = :id")
+    void markVkSent(@Param("id") UUID id, @Param("postId") Long postId, @Param("attachment") String attachment);
+
+    /**
+     * Снимает флаг правки — только если запись не изменилась с момента загрузки (updatedAt совпадает).
+     * Compare-and-clear: правка, прилетевшая во время отправки на стену, сдвинет updatedAt, clear не сработает,
+     * и синхронизация повторится на следующем тике с самым свежим текстом.
+     *
+     * @return 1 — флаг снят, 0 — запись за это время изменилась (флаг оставлен).
+     */
+    @Modifying
+    @Query("UPDATE Article a SET a.vkDirty = false WHERE a.id = :id AND a.updatedAt = :updatedAt")
+    int clearVkDirtyIfUnchanged(@Param("id") UUID id, @Param("updatedAt") Instant updatedAt);
+
+    /**
+     * Удалённые с сайта записи, у которых ещё есть пост на стене (vkPostId) — их надо удалить из VK.
+     */
+    @Query("""
+            SELECT a FROM Article a
+            WHERE a.deleted = true
+              AND a.vkPostId IS NOT NULL
+            ORDER BY a.updatedAt ASC
+            """)
+    List<Article> findDeletedForVk(Limit limit);
+
+    /**
+     * Сбрасывает состояние отправки в VK (после удаления поста со стены). Обнуляет и время отправки,
+     * чтобы восстановленная (снятая с удаления) запись снова опубликовалась.
+     */
+    @Modifying
+    @Query("UPDATE Article a SET a.vkPostId = null, a.vkAttachment = null, a.vkPostedAt = null, a.vkDirty = false "
+            + "WHERE a.id = :id")
+    void clearVkPost(@Param("id") UUID id);
 }

--- a/src/main/java/club/ttg/dnd5/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/repository/ArticleRepository.java
@@ -4,6 +4,7 @@ import club.ttg.dnd5.domain.article.model.Article;
 import club.ttg.dnd5.domain.article.model.ArticleType;
 import org.springframework.data.domain.Limit;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -74,4 +75,100 @@ public interface ArticleRepository extends JpaRepository<Article, UUID> {
             """)
     List<Article> findUnpublished(@Param("now") Instant now, @Param("type") ArticleType type,
                                   @Param("pattern") String pattern, Limit limit);
+
+    /**
+     * Записи, которые пора отправить в Telegram: с включённой галочкой (publishToTelegram=true),
+     * живые и опубликованные (не удалены, не черновик, активны, дата публикации наступила) и ещё
+     * не отправленные (telegramPostedAt IS NULL).
+     * Один и тот же запрос закрывает и «опубликовано сейчас», и «наступила запланированная дата».
+     */
+    @Query("""
+            SELECT a FROM Article a
+            WHERE a.deleted = false
+              AND a.draft = false
+              AND a.active = true
+              AND a.publishToTelegram = true
+              AND a.publishDateTime < :now
+              AND a.telegramPostedAt IS NULL
+            ORDER BY a.publishDateTime ASC
+            """)
+    List<Article> findDueForTelegram(@Param("now") Instant now, Limit limit);
+
+    /**
+     * Атомарно «занимает» запись под отправку в Telegram: проставляет время ТОЛЬКО если она ещё
+     * не занята ({@code telegramPostedAt IS NULL}). Занимаем ДО сетевого вызова, поэтому:
+     * — параллельный тик / второй инстанс не отправят дубль (займёт кто-то один);
+     * — сбой после успешной отправки (упавшая транзакция/рестарт) не приведёт к повторному посту.
+     *
+     * @return 1 — заняли (можно отправлять), 0 — уже занята кем-то (пропускаем).
+     */
+    @Modifying
+    @Query("UPDATE Article a SET a.telegramPostedAt = :postedAt WHERE a.id = :id AND a.telegramPostedAt IS NULL")
+    int claimForTelegram(@Param("id") UUID id, @Param("postedAt") Instant postedAt);
+
+    /**
+     * Снимает отметку об отправке — если отправка не удалась по временной причине, чтобы
+     * повторить попытку на следующем тике.
+     */
+    @Modifying
+    @Query("UPDATE Article a SET a.telegramPostedAt = null WHERE a.id = :id")
+    void releaseTelegramClaim(@Param("id") UUID id);
+
+    /**
+     * Записи, у которых пост в канале уже есть (telegramMessageId), новость изменена после отправки
+     * (telegramDirty=true) и она всё ещё публична (те же условия, что в findDueForTelegram: не удалена,
+     * не черновик, активна, дата наступила) — их нужно синхронизировать (отредактировать пост).
+     */
+    @Query("""
+            SELECT a FROM Article a
+            WHERE a.deleted = false
+              AND a.draft = false
+              AND a.active = true
+              AND a.publishToTelegram = true
+              AND a.publishDateTime < :now
+              AND a.telegramMessageId IS NOT NULL
+              AND a.telegramDirty = true
+            ORDER BY a.updatedAt ASC
+            """)
+    List<Article> findDirtyForTelegram(@Param("now") Instant now, Limit limit);
+
+    /**
+     * Фиксирует успешную отправку: id поста в канале и тип (фото/текст).
+     * Момент отправки (telegramPostedAt) уже проставлен на этапе claim. Флаг telegramDirty НЕ трогаем:
+     * если правка прилетела в окне отправки, она останется помеченной и синхронизируется следующим тиком.
+     */
+    @Modifying
+    @Query("UPDATE Article a SET a.telegramMessageId = :messageId, a.telegramPhoto = :photo WHERE a.id = :id")
+    void markTelegramSent(@Param("id") UUID id, @Param("messageId") Long messageId, @Param("photo") boolean photo);
+
+    /**
+     * Снимает флаг правки — только если запись не изменилась с момента загрузки (updatedAt совпадает).
+     * Compare-and-clear: правка, прилетевшая во время отправки в канал, сдвинет updatedAt, clear не сработает,
+     * и синхронизация повторится на следующем тике с самым свежим текстом.
+     *
+     * @return 1 — флаг снят, 0 — запись за это время изменилась (флаг оставлен).
+     */
+    @Modifying
+    @Query("UPDATE Article a SET a.telegramDirty = false WHERE a.id = :id AND a.updatedAt = :updatedAt")
+    int clearTelegramDirtyIfUnchanged(@Param("id") UUID id, @Param("updatedAt") Instant updatedAt);
+
+    /**
+     * Удалённые с сайта записи, у которых ещё есть пост в канале (telegramMessageId) — их надо удалить из Telegram.
+     */
+    @Query("""
+            SELECT a FROM Article a
+            WHERE a.deleted = true
+              AND a.telegramMessageId IS NOT NULL
+            ORDER BY a.updatedAt ASC
+            """)
+    List<Article> findDeletedForTelegram(Limit limit);
+
+    /**
+     * Сбрасывает состояние отправки в Telegram (после удаления поста из канала). Обнуляет и время отправки,
+     * чтобы восстановленная (снятая с удаления) запись снова опубликовалась.
+     */
+    @Modifying
+    @Query("UPDATE Article a SET a.telegramMessageId = null, a.telegramPostedAt = null, a.telegramDirty = false "
+            + "WHERE a.id = :id")
+    void clearTelegramPost(@Param("id") UUID id);
 }

--- a/src/main/java/club/ttg/dnd5/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/repository/ArticleRepository.java
@@ -1,8 +1,11 @@
 package club.ttg.dnd5.domain.article.repository;
 
 import club.ttg.dnd5.domain.article.model.Article;
+import club.ttg.dnd5.domain.article.model.ArticleType;
 import org.springframework.data.domain.Limit;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.Instant;
@@ -17,7 +20,58 @@ public interface ArticleRepository extends JpaRepository<Article, UUID> {
 
     Optional<Article> findByUrl(String url);
 
-    List<Article> findAllByDeletedFalseOrderByCreatedAtDesc(Limit limit);
+    /**
+     * Публичная выдача одной записи по url: доступна, если запись не удалена,
+     * не черновик И (уже в общем доступе — активна и дата наступила — ЛИБО открыта
+     * по прямой ссылке).
+     */
+    @Query("""
+            SELECT a FROM Article a
+            WHERE a.url = :url
+              AND a.deleted = false
+              AND a.draft = false
+              AND (
+                (a.active = true AND a.publishDateTime < :now)
+                OR a.accessibleByLink = true
+              )
+            """)
+    Optional<Article> findAccessibleByUrl(@Param("url") String url, @Param("now") Instant now);
 
-    List<Article> findAllByDeletedFalseAndPublishDateTimeBeforeOrderByPublishDateTimeDesc(Instant publishDateTimeBefore, Limit limit);
+    /**
+     * Опубликованные и активные записи (публичная лента). Опциональный фильтр по типу —
+     * инлайном `(:type is null or ...)`, как в остальных репозиториях проекта.
+     * Параметр pattern — готовый LIKE-шаблон в нижнем регистре ("%текст%" или "%" без фильтра);
+     * он собирается в сервисе, чтобы не давать Hibernate вывести тип строкового параметра как bytea.
+     */
+    @Query("""
+            SELECT a FROM Article a
+            WHERE a.deleted = false
+              AND a.draft = false
+              AND a.active = true
+              AND a.publishDateTime < :now
+              AND (:type IS NULL OR a.type = :type)
+              AND LOWER(a.title) LIKE :pattern
+            ORDER BY a.publishDateTime DESC
+            """)
+    List<Article> findPublished(@Param("now") Instant now, @Param("type") ArticleType type,
+                                @Param("pattern") String pattern, Limit limit);
+
+    /**
+     * Не-живые записи (черновики + запланированные + неактивные) для модерации.
+     */
+    @Query("""
+            SELECT a FROM Article a
+            WHERE a.deleted = false
+              AND (
+                a.draft = true
+                OR a.active = false
+                OR a.publishDateTime IS NULL
+                OR a.publishDateTime >= :now
+              )
+              AND (:type IS NULL OR a.type = :type)
+              AND LOWER(a.title) LIKE :pattern
+            ORDER BY a.createdAt DESC
+            """)
+    List<Article> findUnpublished(@Param("now") Instant now, @Param("type") ArticleType type,
+                                  @Param("pattern") String pattern, Limit limit);
 }

--- a/src/main/java/club/ttg/dnd5/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/repository/ArticleRepository.java
@@ -171,4 +171,100 @@ public interface ArticleRepository extends JpaRepository<Article, UUID> {
     @Query("UPDATE Article a SET a.telegramMessageId = null, a.telegramPostedAt = null, a.telegramDirty = false "
             + "WHERE a.id = :id")
     void clearTelegramPost(@Param("id") UUID id);
+
+    /**
+     * Записи, которые пора отправить в Discord: с включённой галочкой (publishToDiscord=true),
+     * живые и опубликованные (не удалены, не черновик, активны, дата публикации наступила) и ещё
+     * не отправленные (discordPostedAt IS NULL). Один и тот же запрос закрывает и «опубликовано
+     * сейчас», и «наступила запланированная дата». Независим от Telegram.
+     */
+    @Query("""
+            SELECT a FROM Article a
+            WHERE a.deleted = false
+              AND a.draft = false
+              AND a.active = true
+              AND a.publishToDiscord = true
+              AND a.publishDateTime < :now
+              AND a.discordPostedAt IS NULL
+            ORDER BY a.publishDateTime ASC
+            """)
+    List<Article> findDueForDiscord(@Param("now") Instant now, Limit limit);
+
+    /**
+     * Атомарно «занимает» запись под отправку в Discord: проставляет время ТОЛЬКО если она ещё
+     * не занята ({@code discordPostedAt IS NULL}). Занимаем ДО сетевого вызова, поэтому:
+     * — параллельный тик / второй инстанс не отправят дубль (займёт кто-то один);
+     * — сбой после успешной отправки (упавшая транзакция/рестарт) не приведёт к повторному посту.
+     *
+     * @return 1 — заняли (можно отправлять), 0 — уже занята кем-то (пропускаем).
+     */
+    @Modifying
+    @Query("UPDATE Article a SET a.discordPostedAt = :postedAt WHERE a.id = :id AND a.discordPostedAt IS NULL")
+    int claimForDiscord(@Param("id") UUID id, @Param("postedAt") Instant postedAt);
+
+    /**
+     * Снимает отметку об отправке — если отправка не удалась по временной причине, чтобы
+     * повторить попытку на следующем тике.
+     */
+    @Modifying
+    @Query("UPDATE Article a SET a.discordPostedAt = null WHERE a.id = :id")
+    void releaseDiscordClaim(@Param("id") UUID id);
+
+    /**
+     * Записи, у которых пост в канале уже есть (discordMessageId), новость изменена после отправки
+     * (discordDirty=true) и она всё ещё публична (те же условия, что в findDueForDiscord) — их нужно
+     * синхронизировать (отредактировать пост).
+     */
+    @Query("""
+            SELECT a FROM Article a
+            WHERE a.deleted = false
+              AND a.draft = false
+              AND a.active = true
+              AND a.publishToDiscord = true
+              AND a.publishDateTime < :now
+              AND a.discordMessageId IS NOT NULL
+              AND a.discordDirty = true
+            ORDER BY a.updatedAt ASC
+            """)
+    List<Article> findDirtyForDiscord(@Param("now") Instant now, Limit limit);
+
+    /**
+     * Фиксирует успешную отправку: id поста в канале. Момент отправки (discordPostedAt) уже проставлен
+     * на этапе claim. Флаг discordDirty НЕ трогаем: если правка прилетела в окне отправки, она останется
+     * помеченной и синхронизируется следующим тиком.
+     */
+    @Modifying
+    @Query("UPDATE Article a SET a.discordMessageId = :messageId WHERE a.id = :id")
+    void markDiscordSent(@Param("id") UUID id, @Param("messageId") String messageId);
+
+    /**
+     * Снимает флаг правки — только если запись не изменилась с момента загрузки (updatedAt совпадает).
+     * Compare-and-clear: правка, прилетевшая во время отправки в канал, сдвинет updatedAt, clear не сработает,
+     * и синхронизация повторится на следующем тике с самым свежим текстом.
+     *
+     * @return 1 — флаг снят, 0 — запись за это время изменилась (флаг оставлен).
+     */
+    @Modifying
+    @Query("UPDATE Article a SET a.discordDirty = false WHERE a.id = :id AND a.updatedAt = :updatedAt")
+    int clearDiscordDirtyIfUnchanged(@Param("id") UUID id, @Param("updatedAt") Instant updatedAt);
+
+    /**
+     * Удалённые с сайта записи, у которых ещё есть пост в канале (discordMessageId) — их надо удалить из Discord.
+     */
+    @Query("""
+            SELECT a FROM Article a
+            WHERE a.deleted = true
+              AND a.discordMessageId IS NOT NULL
+            ORDER BY a.updatedAt ASC
+            """)
+    List<Article> findDeletedForDiscord(Limit limit);
+
+    /**
+     * Сбрасывает состояние отправки в Discord (после удаления поста из канала). Обнуляет и время отправки,
+     * чтобы восстановленная (снятая с удаления) запись снова опубликовалась.
+     */
+    @Modifying
+    @Query("UPDATE Article a SET a.discordMessageId = null, a.discordPostedAt = null, a.discordDirty = false "
+            + "WHERE a.id = :id")
+    void clearDiscordPost(@Param("id") UUID id);
 }

--- a/src/main/java/club/ttg/dnd5/domain/article/rest/controller/ArticleController.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/rest/controller/ArticleController.java
@@ -1,6 +1,6 @@
 package club.ttg.dnd5.domain.article.rest.controller;
 
-import org.springdoc.core.annotations.ParameterObject;
+import club.ttg.dnd5.domain.article.model.ArticleType;
 import club.ttg.dnd5.domain.article.rest.dto.ArticleDetailedResponse;
 import club.ttg.dnd5.domain.article.rest.dto.ArticleRequest;
 import club.ttg.dnd5.domain.article.rest.dto.ArticleShortResponse;
@@ -25,29 +25,31 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-import java.util.UUID;
 
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v2/articles")
-@Tag(name = "Новости", description = "REST API новостей")
+@Tag(name = "Статьи / Новости", description = "REST API статей / новостей")
 public class ArticleController {
 
     private final ArticleService articleService;
 
+    @Operation(summary = "Проверка занятости url (для админки при выборе slug): "
+            + "200 — url уже занят (в т.ч. черновиком/удалённой/отложенной), 404 — свободен")
+    @Secured({"ADMIN", "MODERATOR"})
     @RequestMapping(path = "/{url}", method = RequestMethod.HEAD)
     public boolean existByUrl(@PathVariable final String url) {
         articleService.validateUrlExistence(url);
         return true;
     }
 
-    @Operation(summary = "Полный объект новости по url")
+    @Operation(summary = "Полная статья / новость по url")
     @GetMapping("/{url}")
     public ArticleDetailedResponse findByUrl(@PathVariable final String url) {
         return articleService.findByUrl(url);
     }
 
-    @Operation(summary = "Создание новости")
+    @Operation(summary = "Создание статьи / новости")
     @Secured({"ADMIN", "MODERATOR"})
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
@@ -55,45 +57,56 @@ public class ArticleController {
         return articleService.save(request);
     }
 
-    @Operation(summary = "Обновление новости")
+    @Operation(summary = "Обновление статьи / новости")
     @Secured({"ADMIN", "MODERATOR"})
-    @PutMapping("/{id}")
-    public String updateArticle(@PathVariable final UUID id, @RequestBody final ArticleRequest request) {
-        return articleService.update(id, request);
+    @PutMapping("/{url}")
+    public String updateArticle(@PathVariable final String url, @RequestBody @Valid final ArticleRequest request) {
+        return articleService.update(url, request);
     }
 
-    @Operation(summary = "Полный форма для редактирования новости по id")
-    @GetMapping("/{id}/raw")
-    public ArticleRequest getById(@PathVariable final UUID id) {
-        return articleService.findFormById(id);
+    @Operation(summary = "Полная форма для редактирования статьи / новости по url")
+    @Secured({"ADMIN", "MODERATOR"})
+    @GetMapping("/{url}/raw")
+    public ArticleRequest getRawByUrl(@PathVariable final String url) {
+        return articleService.findFormByUrl(url);
     }
 
-    @Operation(summary = "Предпросмотр новости")
+    @Operation(summary = "Предпросмотр статьи / новости")
     @Secured({"ADMIN", "MODERATOR"})
     @PostMapping("/preview")
     public ArticleDetailedResponse preview(@RequestBody @Valid final ArticleRequest request) {
         return articleService.preview(request);
     }
 
-    @Operation(summary = "Помечает новость как скрытую для списков")
+    @Operation(summary = "Помечает статью / новость как скрытую для списков")
     @Secured({"ADMIN", "MODERATOR"})
-    @DeleteMapping("{id}")
-    public String deleteArticle(@PathVariable final UUID id) {
-        return articleService.delete(id);
+    @DeleteMapping("/{url}")
+    public String deleteArticle(@PathVariable final String url) {
+        return articleService.delete(url);
     }
 
-    @Operation(summary = "Получить cnt последних новостей")
+    @Operation(summary = "Получить cnt последних опубликованных статей / новостей (с фильтром по типу и поиском)")
     @GetMapping("/search")
-    public List<ArticleShortResponse> search(@RequestParam(required = false)
-            @Schema(description = "Сколько новостей грузить (дефолт - 10)") final Integer cnt) {
-        return articleService.searchPublished(cnt);
+    public List<ArticleShortResponse> search(
+            @RequestParam(required = false)
+            @Schema(description = "Сколько статей / новостей грузить (дефолт - 10)") final Integer cnt,
+            @RequestParam(required = false)
+            @Schema(description = "Фильтр по типу: NEWS или ARTICLE (по умолчанию — все)") final ArticleType type,
+            @RequestParam(required = false)
+            @Schema(description = "Поиск по подстроке в заголовке (регистронезависимо)") final String search) {
+        return articleService.searchPublished(cnt, type, search);
     }
 
-    @Operation(summary = "Получить cnt последних новостей")
+    @Operation(summary = "Получить cnt последних неопубликованных статей / новостей (для модерации, с фильтром и поиском)")
     @GetMapping("/search/unpublished")
     @Secured({"ADMIN", "MODERATOR"})
-    public List<ArticleShortResponse> searchUnpublished(@RequestParam(required = false)
-            @Schema(description = "Сколько новостей грузить (дефолт - 10)") final Integer cnt) {
-        return articleService.searchUnpublished(cnt);
+    public List<ArticleShortResponse> searchUnpublished(
+            @RequestParam(required = false)
+            @Schema(description = "Сколько статей / новостей грузить (дефолт - 10)") final Integer cnt,
+            @RequestParam(required = false)
+            @Schema(description = "Фильтр по типу: NEWS или ARTICLE (по умолчанию — все)") final ArticleType type,
+            @RequestParam(required = false)
+            @Schema(description = "Поиск по подстроке в заголовке (регистронезависимо)") final String search) {
+        return articleService.searchUnpublished(cnt, type, search);
     }
 }

--- a/src/main/java/club/ttg/dnd5/domain/article/rest/dto/ArticleDetailedResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/rest/dto/ArticleDetailedResponse.java
@@ -1,5 +1,7 @@
 package club.ttg.dnd5.domain.article.rest.dto;
 
+import club.ttg.dnd5.domain.article.model.ArticleStatus;
+import club.ttg.dnd5.domain.article.model.ArticleType;
 import club.ttg.dnd5.dto.base.deserializer.MarkupDescriptionDeserializer;
 import club.ttg.dnd5.dto.base.serializer.MarkupDescriptionSerializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -21,14 +23,41 @@ import java.util.UUID;
 @Setter
 public class ArticleDetailedResponse {
     @NotNull
+    @Schema(description = "Идентификатор статьи / новости")
     private UUID id;
 
     @NotNull
+    @Schema(description = "Уникальный url статьи / новости (slug)")
     private String url;
+
+    @NotNull
+    @Schema(description = "Тип (ключ): NEWS или ARTICLE")
+    private ArticleType type;
+
+    @NotNull
+    @Schema(description = "Человеко-читаемое название типа: «Новость» или «Статья»")
+    private String typeName;
+
+    @NotNull
+    @Schema(description = "Статус (ключ): DRAFT, SCHEDULED, ACTIVE или INACTIVE")
+    private ArticleStatus status;
+
+    @NotNull
+    @Schema(description = "Человеко-читаемый статус: «Черновик» / «Запланирована» / «Активна» / «Неактивна»")
+    private String statusName;
+
+    @Schema(description = "Черновик (не опубликована)")
+    private boolean draft;
+
+    @Schema(description = "Активна (в общем доступе); false — неактивна (снята с сайта, но опубликована)")
+    private boolean active;
 
     @Nullable
     @Schema(description = "Дата и время публикации")
     private Instant publishDateTime;
+
+    @Schema(description = "Доступна по прямой ссылке даже если не опубликована")
+    private boolean accessibleByLink;
 
     @NotNull
     @Schema(description = "Заголовок")
@@ -44,7 +73,7 @@ public class ArticleDetailedResponse {
     private String preview;
 
     @JsonSerialize(using = MarkupDescriptionSerializer.class)
-    @Schema(description = "Текст новости")
+    @Schema(description = "Текст статьи / новости")
     @NotNull
     private String content;
 

--- a/src/main/java/club/ttg/dnd5/domain/article/rest/dto/ArticleRequest.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/rest/dto/ArticleRequest.java
@@ -64,6 +64,11 @@ public class ArticleRequest {
             + "Независима от Telegram.")
     private boolean publishToDiscord;
 
+    @Schema(description = "Опубликовать на стену сообщества ВКонтакте. true — при публикации (сейчас или по "
+            + "наступлении даты) запись один раз уйдёт на стену, если интеграция включена глобально. false — "
+            + "на стену не отправлять. Независима от Telegram и Discord.")
+    private boolean publishToVk;
+
     @Schema(description = "Текст превью")
     @NotNull
     @JsonDeserialize(using = MarkupDescriptionDeserializer.class)

--- a/src/main/java/club/ttg/dnd5/domain/article/rest/dto/ArticleRequest.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/rest/dto/ArticleRequest.java
@@ -55,6 +55,10 @@ public class ArticleRequest {
             + "Актуально для неактивной опубликованной записи (draft=false, active=false); к черновику не относится.")
     private boolean accessibleByLink;
 
+    @Schema(description = "Опубликовать в Telegram-канал. true — при публикации (сейчас или по наступлении даты) "
+            + "запись один раз уйдёт в канал, если интеграция включена глобально. false — в канал не отправлять.")
+    private boolean publishToTelegram;
+
     @Schema(description = "Текст превью")
     @NotNull
     @JsonDeserialize(using = MarkupDescriptionDeserializer.class)

--- a/src/main/java/club/ttg/dnd5/domain/article/rest/dto/ArticleRequest.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/rest/dto/ArticleRequest.java
@@ -1,5 +1,6 @@
 package club.ttg.dnd5.domain.article.rest.dto;
 
+import club.ttg.dnd5.domain.article.model.ArticleType;
 import club.ttg.dnd5.dto.base.deserializer.MarkupDescriptionDeserializer;
 import club.ttg.dnd5.dto.base.serializer.FormattedMarkupDescriptionSerializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -21,7 +22,21 @@ import java.time.Instant;
 public class ArticleRequest {
 
     @NotNull
+    @Schema(description = "Уникальный url статьи / новости (slug)")
     private String url;
+
+    @NotNull
+    @Schema(description = "Тип: NEWS (новость) или ARTICLE (статья)")
+    private ArticleType type;
+
+    @Schema(description = "Черновик. true — сохранить черновиком (не публиковать): виден только в списке "
+            + "черновиков, недоступен ни на сайте, ни по ссылке. false — опубликована (не черновик).")
+    private boolean draft;
+
+    @Schema(description = "Активность опубликованной записи (учитывается при draft=false). true — активна "
+            + "(в общем доступе на сайте, с учётом даты публикации); false — неактивна (снята с сайта, "
+            + "но остаётся опубликованной, не черновик).")
+    private boolean active;
 
     @NotNull
     @Schema(description = "Заголовок")
@@ -32,8 +47,13 @@ public class ArticleRequest {
     private String previewImageUrl;
 
     @Nullable
-    @Schema(description = "Дата и время публикации")
+    @Schema(description = "Дата публикации. Будущая дата при draft=false, active=true — запись запланирована "
+            + "и появится на сайте автоматически по её наступлении. Если не задана при публикации — ставится «сейчас».")
     private Instant publishDateTime;
+
+    @Schema(description = "Доступна по прямой ссылке, даже когда не в общем доступе (для предпросмотра/шеринга). "
+            + "Актуально для неактивной опубликованной записи (draft=false, active=false); к черновику не относится.")
+    private boolean accessibleByLink;
 
     @Schema(description = "Текст превью")
     @NotNull
@@ -43,7 +63,7 @@ public class ArticleRequest {
 
     @JsonDeserialize(using = MarkupDescriptionDeserializer.class)
     @JsonSerialize(using = FormattedMarkupDescriptionSerializer.class)
-    @Schema(description = "Текст новости")
+    @Schema(description = "Текст статьи / новости")
     @NotNull
     private String content;
 }

--- a/src/main/java/club/ttg/dnd5/domain/article/rest/dto/ArticleRequest.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/rest/dto/ArticleRequest.java
@@ -59,6 +59,11 @@ public class ArticleRequest {
             + "запись один раз уйдёт в канал, если интеграция включена глобально. false — в канал не отправлять.")
     private boolean publishToTelegram;
 
+    @Schema(description = "Опубликовать в Discord-канал. true — при публикации (сейчас или по наступлении даты) "
+            + "запись один раз уйдёт в канал, если интеграция включена глобально. false — в канал не отправлять. "
+            + "Независима от Telegram.")
+    private boolean publishToDiscord;
+
     @Schema(description = "Текст превью")
     @NotNull
     @JsonDeserialize(using = MarkupDescriptionDeserializer.class)

--- a/src/main/java/club/ttg/dnd5/domain/article/rest/dto/ArticleShortResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/rest/dto/ArticleShortResponse.java
@@ -1,5 +1,7 @@
 package club.ttg.dnd5.domain.article.rest.dto;
 
+import club.ttg.dnd5.domain.article.model.ArticleStatus;
+import club.ttg.dnd5.domain.article.model.ArticleType;
 import club.ttg.dnd5.dto.base.deserializer.MarkupDescriptionDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -20,10 +22,34 @@ import java.util.UUID;
 @Setter
 public class ArticleShortResponse {
     @NotNull
+    @Schema(description = "Идентификатор статьи / новости")
     private UUID id;
 
     @NotNull
+    @Schema(description = "Уникальный url статьи / новости (slug)")
     private String url;
+
+    @NotNull
+    @Schema(description = "Тип (ключ): NEWS или ARTICLE")
+    private ArticleType type;
+
+    @NotNull
+    @Schema(description = "Человеко-читаемое название типа: «Новость» или «Статья»")
+    private String typeName;
+
+    @NotNull
+    @Schema(description = "Статус (ключ): DRAFT, SCHEDULED, ACTIVE или INACTIVE")
+    private ArticleStatus status;
+
+    @NotNull
+    @Schema(description = "Человеко-читаемый статус: «Черновик» / «Запланирована» / «Активна» / «Неактивна»")
+    private String statusName;
+
+    @Schema(description = "Черновик (не опубликована)")
+    private boolean draft;
+
+    @Schema(description = "Активна (в общем доступе); false — неактивна (снята с сайта, но опубликована)")
+    private boolean active;
 
     @NotNull
     @Schema(description = "Заголовок")
@@ -32,6 +58,9 @@ public class ArticleShortResponse {
     @Nullable
     @Schema(description = "Дата и время публикации")
     private Instant publishDateTime;
+
+    @Schema(description = "Доступна по прямой ссылке даже если не опубликована")
+    private boolean accessibleByLink;
 
     @Schema(description = "Cсылка на превью-изображение")
     @Nullable

--- a/src/main/java/club/ttg/dnd5/domain/article/rest/mapper/ArticleMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/rest/mapper/ArticleMapper.java
@@ -18,18 +18,28 @@ public interface ArticleMapper {
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "deleted", constant = "false")
+    @Mapping(target = "draft", ignore = true)
+    @Mapping(target = "active", ignore = true)
+    @Mapping(target = "publishDateTime", ignore = true)
     @BaseMapping.TimestampedMappingIgnore
     Article toEntity(ArticleRequest article);
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "deleted", ignore = true)
+    @Mapping(target = "draft", ignore = true)
+    @Mapping(target = "active", ignore = true)
+    @Mapping(target = "publishDateTime", ignore = true)
     @BaseMapping.TimestampedMappingIgnore
     void updateEntity(@MappingTarget Article article, ArticleRequest articleRequest);
 
+    @Mapping(source = "type.name", target = "typeName")
+    @Mapping(source = "status.name", target = "statusName")
     ArticleDetailedResponse toDetailedResponse(Article byUrl);
 
     ArticleRequest toRequest(Article article);
 
+    @Mapping(source = "type.name", target = "typeName")
+    @Mapping(source = "status.name", target = "statusName")
     ArticleShortResponse toShortResponse(Article article);
 
     List<ArticleShortResponse> toShortResponseList(Collection<Article> articles);

--- a/src/main/java/club/ttg/dnd5/domain/article/rest/mapper/ArticleMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/rest/mapper/ArticleMapper.java
@@ -21,6 +21,10 @@ public interface ArticleMapper {
     @Mapping(target = "draft", ignore = true)
     @Mapping(target = "active", ignore = true)
     @Mapping(target = "publishDateTime", ignore = true)
+    @Mapping(target = "telegramPostedAt", ignore = true)
+    @Mapping(target = "telegramMessageId", ignore = true)
+    @Mapping(target = "telegramPhoto", ignore = true)
+    @Mapping(target = "telegramDirty", ignore = true)
     @BaseMapping.TimestampedMappingIgnore
     Article toEntity(ArticleRequest article);
 
@@ -29,6 +33,10 @@ public interface ArticleMapper {
     @Mapping(target = "draft", ignore = true)
     @Mapping(target = "active", ignore = true)
     @Mapping(target = "publishDateTime", ignore = true)
+    @Mapping(target = "telegramPostedAt", ignore = true)
+    @Mapping(target = "telegramMessageId", ignore = true)
+    @Mapping(target = "telegramPhoto", ignore = true)
+    @Mapping(target = "telegramDirty", ignore = true)
     @BaseMapping.TimestampedMappingIgnore
     void updateEntity(@MappingTarget Article article, ArticleRequest articleRequest);
 

--- a/src/main/java/club/ttg/dnd5/domain/article/rest/mapper/ArticleMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/rest/mapper/ArticleMapper.java
@@ -28,6 +28,10 @@ public interface ArticleMapper {
     @Mapping(target = "discordPostedAt", ignore = true)
     @Mapping(target = "discordMessageId", ignore = true)
     @Mapping(target = "discordDirty", ignore = true)
+    @Mapping(target = "vkPostedAt", ignore = true)
+    @Mapping(target = "vkPostId", ignore = true)
+    @Mapping(target = "vkAttachment", ignore = true)
+    @Mapping(target = "vkDirty", ignore = true)
     @BaseMapping.TimestampedMappingIgnore
     Article toEntity(ArticleRequest article);
 
@@ -43,6 +47,10 @@ public interface ArticleMapper {
     @Mapping(target = "discordPostedAt", ignore = true)
     @Mapping(target = "discordMessageId", ignore = true)
     @Mapping(target = "discordDirty", ignore = true)
+    @Mapping(target = "vkPostedAt", ignore = true)
+    @Mapping(target = "vkPostId", ignore = true)
+    @Mapping(target = "vkAttachment", ignore = true)
+    @Mapping(target = "vkDirty", ignore = true)
     @BaseMapping.TimestampedMappingIgnore
     void updateEntity(@MappingTarget Article article, ArticleRequest articleRequest);
 

--- a/src/main/java/club/ttg/dnd5/domain/article/rest/mapper/ArticleMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/rest/mapper/ArticleMapper.java
@@ -25,6 +25,9 @@ public interface ArticleMapper {
     @Mapping(target = "telegramMessageId", ignore = true)
     @Mapping(target = "telegramPhoto", ignore = true)
     @Mapping(target = "telegramDirty", ignore = true)
+    @Mapping(target = "discordPostedAt", ignore = true)
+    @Mapping(target = "discordMessageId", ignore = true)
+    @Mapping(target = "discordDirty", ignore = true)
     @BaseMapping.TimestampedMappingIgnore
     Article toEntity(ArticleRequest article);
 
@@ -37,6 +40,9 @@ public interface ArticleMapper {
     @Mapping(target = "telegramMessageId", ignore = true)
     @Mapping(target = "telegramPhoto", ignore = true)
     @Mapping(target = "telegramDirty", ignore = true)
+    @Mapping(target = "discordPostedAt", ignore = true)
+    @Mapping(target = "discordMessageId", ignore = true)
+    @Mapping(target = "discordDirty", ignore = true)
     @BaseMapping.TimestampedMappingIgnore
     void updateEntity(@MappingTarget Article article, ArticleRequest articleRequest);
 

--- a/src/main/java/club/ttg/dnd5/domain/article/service/ArticleDiscordPublicationScheduler.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/service/ArticleDiscordPublicationScheduler.java
@@ -1,0 +1,147 @@
+package club.ttg.dnd5.domain.article.service;
+
+import club.ttg.dnd5.config.properties.DiscordProperties;
+import club.ttg.dnd5.domain.article.model.Article;
+import club.ttg.dnd5.domain.article.repository.ArticleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Limit;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Периодически отправляет в Discord-канал новые опубликованные записи нужного типа — через входящий вебхук.
+ * <p>
+ * Полный аналог {@link ArticleTelegramPublicationScheduler}, но независимый: своя галочка
+ * ({@code publishToDiscord}), свои отметки ({@code discord*}) и свой канал (вебхук). Один поллер закрывает
+ * оба сценария публикации: «опубликовать сейчас» и «наступила запланированная дата» — потому что видимость
+ * записи на сайте пассивна (сравнение {@code publishDateTime < now} в запросе), отдельного события нет.
+ * <p>
+ * Устойчивость и идемпотентность (claim-before-send): запись атомарно «занимаем» ДО отправки
+ * ({@link ArticleService#claimDiscordPost}), а сам HTTP-вызов держим ВНЕ транзакции. Занявший запись один —
+ * параллельный тик/второй инстанс её уже не отправит; сбой после успешной отправки не даёт дубля. При
+ * временной ошибке отправки отметку снимаем ({@link ArticleService#releaseDiscordPost}) и повторяем на
+ * следующем тике.
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ArticleDiscordPublicationScheduler {
+
+    private final ArticleRepository articleRepository;
+    private final ArticleService articleService;
+    private final DiscordPublisher discordPublisher;
+    private final DiscordProperties properties;
+
+    @Scheduled(fixedDelayString = "${discord.poll-interval:PT1M}")
+    public void publishDueToDiscord() {
+        if (!StringUtils.hasText(properties.getWebhookUrl())) {
+            // Вебхук не задан для этого окружения — интеграция выключена (напр. локально). Тихо выходим.
+            return;
+        }
+
+        Limit batch = Limit.of(Math.max(1, properties.getBatchSize()));
+        postNew(batch);
+        syncEdited(batch);
+        deleteRemoved(batch);
+    }
+
+    /** Отправляет в канал новые записи, у которых наступила публикация и стоит галочка. */
+    private void postNew(Limit batch) {
+        List<Article> due = articleRepository.findDueForDiscord(Instant.now(), batch);
+        int posted = 0;
+        for (Article snapshot : due) {
+            UUID id = snapshot.getId();
+            // Занимаем запись ДО отправки: если её уже занял другой тик/инстанс — пропускаем (без дубля).
+            if (!articleService.claimDiscordPost(id, Instant.now())) {
+                continue;
+            }
+            // Перечитываем СВЕЖУЮ версию после claim: правка, прилетевшая между выборкой батча и claim,
+            // попадёт в пост; правка ПОСЛЕ claim пометит запись dirty и синхронизируется отдельным проходом.
+            Article article = articleRepository.findById(id).orElse(null);
+            if (article == null || article.isDeleted()) {
+                articleService.releaseDiscordPost(id);
+                continue;
+            }
+            DiscordPublisher.PublishResult result;
+            try {
+                result = discordPublisher.publish(article);
+            } catch (RuntimeException ex) {
+                // Любой сбой отправки (в т.ч. временный сбой чтения обложки из S3) не должен оставить
+                // запись «занятой» навсегда — освобождаем и повторим на следующем тике.
+                log.warn("Ошибка отправки {} в Discord — освобождаю для повтора", article.getUrl(), ex);
+                articleService.releaseDiscordPost(id);
+                continue;
+            }
+            switch (result.status()) {
+                case POSTED -> {
+                    articleService.markDiscordSent(id, result.messageId());
+                    posted++;
+                }
+                // Временный сбой — снимаем отметку, повторим на следующем тике.
+                case RETRY -> articleService.releaseDiscordPost(id);
+                // Перманентный отказ Discord (битый запрос/вебхук) — оставляем занятой, чтобы не долбить канал.
+                case GIVE_UP -> log.warn("Discord навсегда отклонил публикацию {} — больше не пытаюсь", article.getUrl());
+            }
+        }
+        if (posted > 0) {
+            log.info("Отправлено в Discord записей: {} из {} готовых", posted, due.size());
+        }
+    }
+
+    /** Синхронизирует пост в канале для записей, изменённых после отправки. */
+    private void syncEdited(Limit batch) {
+        List<Article> dirty = articleRepository.findDirtyForDiscord(Instant.now(), batch);
+        int synced = 0;
+        for (Article article : dirty) {
+            DiscordPublisher.EditResult result;
+            try {
+                result = discordPublisher.editPost(article);
+            } catch (RuntimeException ex) {
+                log.warn("Ошибка синхронизации поста {} в Discord — повторю на следующем тике", article.getUrl(), ex);
+                continue;
+            }
+            if (result != DiscordPublisher.EditResult.RETRY) {
+                // SYNCED или GIVE_UP — снимаем флаг, но только если запись не изменилась в окне отправки
+                // (иначе свежая правка сдвинула updatedAt, флаг останется и синхронизируется следующим тиком).
+                articleService.clearDiscordDirty(article.getId(), article.getUpdatedAt());
+            }
+            if (result == DiscordPublisher.EditResult.SYNCED) {
+                synced++;
+            }
+        }
+        if (synced > 0) {
+            log.info("Синхронизировано правок постов в Discord: {} из {}", synced, dirty.size());
+        }
+    }
+
+    /** Удаляет из канала посты новостей, удалённых с сайта. */
+    private void deleteRemoved(Limit batch) {
+        List<Article> removed = articleRepository.findDeletedForDiscord(batch);
+        int deleted = 0;
+        for (Article article : removed) {
+            DiscordPublisher.EditResult result;
+            try {
+                result = discordPublisher.deletePost(article);
+            } catch (RuntimeException ex) {
+                log.warn("Ошибка удаления поста {} из Discord — повторю на следующем тике", article.getUrl(), ex);
+                continue;
+            }
+            if (result != DiscordPublisher.EditResult.RETRY) {
+                // SYNCED (удалили) или GIVE_UP (поста уже нет / нельзя удалить) — сбрасываем маркер, не долбим.
+                articleService.clearDiscordPost(article.getId());
+            }
+            if (result == DiscordPublisher.EditResult.SYNCED) {
+                deleted++;
+            }
+        }
+        if (deleted > 0) {
+            log.info("Удалено постов из Discord: {}", deleted);
+        }
+    }
+}

--- a/src/main/java/club/ttg/dnd5/domain/article/service/ArticleImageSource.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/service/ArticleImageSource.java
@@ -10,7 +10,7 @@ import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 
 /**
  * Достаёт байты обложки новости из S3, чтобы залить их в канал файлом (а не ссылкой) — общий источник
- * для Telegram- и Discord-публикаторов. previewImageUrl хранится как относительный путь {@code /s3/<key>};
+ * для Telegram-, Discord- и VK-публикаторов. previewImageUrl хранится как относительный путь {@code /s3/<key>};
  * публичного URL у объекта нет (bucket закрыт), поэтому картинку читаем напрямую из S3 — доступ у сервиса есть.
  */
 @Slf4j

--- a/src/main/java/club/ttg/dnd5/domain/article/service/ArticleImageSource.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/service/ArticleImageSource.java
@@ -9,14 +9,14 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 
 /**
- * Достаёт байты обложки новости из S3, чтобы залить их в Telegram файлом (а не ссылкой).
- * previewImageUrl хранится как относительный путь {@code /s3/<key>}; публичного URL у объекта нет
- * (bucket закрыт), поэтому картинку читаем напрямую из S3 — доступ у сервиса уже есть.
+ * Достаёт байты обложки новости из S3, чтобы залить их в канал файлом (а не ссылкой) — общий источник
+ * для Telegram- и Discord-публикаторов. previewImageUrl хранится как относительный путь {@code /s3/<key>};
+ * публичного URL у объекта нет (bucket закрыт), поэтому картинку читаем напрямую из S3 — доступ у сервиса есть.
  */
 @Slf4j
 @RequiredArgsConstructor
 @Component
-public class TelegramImageSource {
+public class ArticleImageSource {
 
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucket;
@@ -46,7 +46,7 @@ public class TelegramImageSource {
         }
     }
 
-    /** Имя файла для Telegram (по расширению определяет тип). */
+    /** Имя файла для загрузки в канал (по расширению определяет тип). */
     public String filename(String previewImageUrl) {
         String key = key(previewImageUrl);
         if (key == null) {

--- a/src/main/java/club/ttg/dnd5/domain/article/service/ArticleRevisionRevertHandler.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/service/ArticleRevisionRevertHandler.java
@@ -9,8 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
-import java.util.UUID;
-
 @Component
 @RequiredArgsConstructor
 public class ArticleRevisionRevertHandler implements RevisionRevertHandler {
@@ -30,8 +28,8 @@ public class ArticleRevisionRevertHandler implements RevisionRevertHandler {
             request = objectMapper.readValue(snapshotJson, ArticleRequest.class);
         } catch (JsonProcessingException e) {
             throw new ApiException(HttpStatus.INTERNAL_SERVER_ERROR,
-                    "Не удалось прочитать снимок новости для отката");
+                    "Не удалось прочитать снимок статьи / новости для отката");
         }
-        articleService.update(UUID.fromString(entityId), request);
+        articleService.update(entityId, request);
     }
 }

--- a/src/main/java/club/ttg/dnd5/domain/article/service/ArticleService.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/service/ArticleService.java
@@ -65,6 +65,13 @@ public class ArticleService {
             toUpdate.setTelegramDirty(true);
         }
 
+        // То же для Discord: занята под отправку или уже отправлена (и всё ещё помечена к публикации) —
+        // пометить на синхронизацию. Независимо от Telegram.
+        boolean discordClaimedOrPosted = toUpdate.getDiscordPostedAt() != null || toUpdate.getDiscordMessageId() != null;
+        if (discordClaimedOrPosted && toUpdate.isPublishToDiscord()) {
+            toUpdate.setDiscordDirty(true);
+        }
+
         String savedUrl = articleRepository.save(toUpdate).getUrl();
         revisionService.record(REVISION_ENTITY_TYPE, savedUrl, RevisionOperation.UPDATE, findFormByUrl(savedUrl));
         return savedUrl;
@@ -137,6 +144,50 @@ public class ArticleService {
     @Transactional
     public void clearTelegramPost(UUID id) {
         articleRepository.clearTelegramPost(id);
+    }
+
+    /**
+     * Пытается занять запись под отправку в Discord (см. {@link ArticleRepository#claimForDiscord}).
+     * Короткая отдельная транзакция ДО сетевого вызова.
+     *
+     * @return {@code true}, если заняли (можно отправлять); {@code false}, если уже занята.
+     */
+    @Transactional
+    public boolean claimDiscordPost(UUID id, Instant when) {
+        return articleRepository.claimForDiscord(id, when) == 1;
+    }
+
+    /**
+     * Освобождает ранее занятую запись после неуспешной отправки — чтобы повторить на следующем тике.
+     */
+    @Transactional
+    public void releaseDiscordPost(UUID id) {
+        articleRepository.releaseDiscordClaim(id);
+    }
+
+    /**
+     * Фиксирует успешную отправку в Discord: id поста в канале.
+     */
+    @Transactional
+    public void markDiscordSent(UUID id, String messageId) {
+        articleRepository.markDiscordSent(id, messageId);
+    }
+
+    /**
+     * Снимает флаг правки после синхронизации — только если запись не изменилась с момента загрузки
+     * (updatedAt совпадает). Иначе правку, прилетевшую во время отправки, не теряем: флаг остаётся.
+     */
+    @Transactional
+    public void clearDiscordDirty(UUID id, Instant updatedAt) {
+        articleRepository.clearDiscordDirtyIfUnchanged(id, updatedAt);
+    }
+
+    /**
+     * Сбрасывает состояние отправки в Discord после удаления поста из канала.
+     */
+    @Transactional
+    public void clearDiscordPost(UUID id) {
+        articleRepository.clearDiscordPost(id);
     }
 
     public boolean existsByUrl(String url) {

--- a/src/main/java/club/ttg/dnd5/domain/article/service/ArticleService.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/service/ArticleService.java
@@ -1,6 +1,7 @@
 package club.ttg.dnd5.domain.article.service;
 
 import club.ttg.dnd5.domain.article.model.Article;
+import club.ttg.dnd5.domain.article.model.ArticleType;
 import club.ttg.dnd5.domain.article.repository.ArticleRepository;
 import club.ttg.dnd5.domain.article.rest.dto.ArticleDetailedResponse;
 import club.ttg.dnd5.domain.article.rest.dto.ArticleRequest;
@@ -10,12 +11,14 @@ import club.ttg.dnd5.domain.revision.model.RevisionOperation;
 import club.ttg.dnd5.domain.revision.service.EntityRevisionService;
 import club.ttg.dnd5.exception.EntityExistException;
 import club.ttg.dnd5.exception.EntityNotFoundException;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Limit;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -30,25 +33,58 @@ public class ArticleService {
     private final ArticleMapper articleMapper;
     private final EntityRevisionService revisionService;
 
+    @Transactional
     public String save(ArticleRequest request) {
         validateUrlNonExistence(request.getUrl());
 
         Article toSave = articleMapper.toEntity(request);
+        applyPublication(toSave, request);
 
         Article saved = articleRepository.save(toSave);
-        revisionService.record(REVISION_ENTITY_TYPE, saved.getId().toString(), RevisionOperation.CREATE,
-                findFormById(saved.getId()));
+        revisionService.record(REVISION_ENTITY_TYPE, saved.getUrl(), RevisionOperation.CREATE,
+                findFormByUrl(saved.getUrl()));
         return saved.getUrl();
     }
 
-    public String update(UUID id, ArticleRequest request) {
-        Article toUpdate = getById(id);
+    @Transactional
+    public String update(String url, ArticleRequest request) {
+        Article toUpdate = getByUrl(url);
+
+        if (!url.equals(request.getUrl())) {
+            validateUrlNonExistence(request.getUrl());
+        }
 
         articleMapper.updateEntity(toUpdate, request);
+        applyPublication(toUpdate, request);
 
-        String url = articleRepository.save(toUpdate).getUrl();
-        revisionService.record(REVISION_ENTITY_TYPE, id.toString(), RevisionOperation.UPDATE, findFormById(id));
-        return url;
+        String savedUrl = articleRepository.save(toUpdate).getUrl();
+        revisionService.record(REVISION_ENTITY_TYPE, savedUrl, RevisionOperation.UPDATE, findFormByUrl(savedUrl));
+        return savedUrl;
+    }
+
+    /**
+     * Переносит флаги публикации в поля сущности.
+     * draft=true — черновик: не публична, не активна; дату можно сохранить на будущее.
+     * draft=false — опубликована: active=true — активна (будущая дата = запланирована; если дата не задана
+     * и её ещё нет — ставим «сейчас»); active=false — неактивна (снята с сайта, дату публикации не трогаем).
+     * Черновик и активность/неактивность — независимые оси: неактивная запись остаётся опубликованной.
+     */
+    private void applyPublication(Article article, ArticleRequest request) {
+        if (request.isDraft()) {
+            article.setDraft(true);
+            article.setActive(false);
+            article.setPublishDateTime(request.getPublishDateTime());
+            return;
+        }
+        article.setDraft(false);
+        article.setActive(request.isActive());
+        if (request.isActive()) {
+            if (request.getPublishDateTime() != null) {
+                article.setPublishDateTime(request.getPublishDateTime());
+            } else if (article.getPublishDateTime() == null) {
+                article.setPublishDateTime(Instant.now());
+            }
+        }
     }
 
     public boolean existsByUrl(String url) {
@@ -57,58 +93,78 @@ public class ArticleService {
 
     public void validateUrlNonExistence(String url) {
         if (existsByUrl(url)) {
-            throw new EntityExistException(String.format("Статья с url %s уже существует", url));
+            throw new EntityExistException(String.format("Статья / новость с url %s уже существует", url));
         }
     }
 
     public void validateUrlExistence(String url) {
         if (!existsByUrl(url)) {
-            throw new EntityNotFoundException(String.format("Статья с url %s не существует", url));
+            throw new EntityNotFoundException(String.format("Статья / новость с url %s не существует", url));
         }
     }
 
     public Article getByUrl(String url) {
         return articleRepository.findByUrl(url)
-                .orElseThrow(() -> new EntityNotFoundException(String.format("Статья с url %s не существует", url)));
+                .orElseThrow(() -> new EntityNotFoundException(String.format("Статья / новость с url %s не существует", url)));
     }
 
-    public Article getById(UUID id) {
-        return articleRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException(String.format("Статья с id %s не существует", id)));
-    }
-
+    /**
+     * Публичная выдача: возвращает запись только если она не удалена и уже опубликована.
+     */
     public ArticleDetailedResponse findByUrl(String url) {
-        return articleMapper.toDetailedResponse(getByUrl(url));
+        Article article = articleRepository.findAccessibleByUrl(url, Instant.now())
+                .orElseThrow(() -> new EntityNotFoundException(String.format("Статья / новость с url %s не существует", url)));
+        return articleMapper.toDetailedResponse(article);
     }
 
-    public ArticleRequest findFormById(UUID id) {
-        return articleMapper.toRequest(getById(id));
+    public ArticleRequest findFormByUrl(String url) {
+        return articleMapper.toRequest(getByUrl(url));
     }
 
     public ArticleDetailedResponse preview(ArticleRequest request) {
-        return articleMapper.toDetailedResponse(articleMapper.toEntity(request));
+        Article entity = articleMapper.toEntity(request);
+        applyPublication(entity, request);
+        Instant now = Instant.now();
+        entity.setId(new UUID(0L, 0L));
+        entity.setCreatedAt(now);
+        entity.setUpdatedAt(now);
+        return articleMapper.toDetailedResponse(entity);
     }
 
-    public String delete(UUID id) {
-        Article toDelete = getById(id);
+    @Transactional
+    public String delete(String url) {
+        Article toDelete = getByUrl(url);
         toDelete.setDeleted(true);
-        String url = articleRepository.save(toDelete).getUrl();
-        revisionService.record(REVISION_ENTITY_TYPE, id.toString(), RevisionOperation.DELETE, findFormById(id));
-        return url;
+        String savedUrl = articleRepository.save(toDelete).getUrl();
+        revisionService.record(REVISION_ENTITY_TYPE, savedUrl, RevisionOperation.DELETE, findFormByUrl(savedUrl));
+        return savedUrl;
     }
 
 
-    public List<ArticleShortResponse> searchPublished(Integer cnt) {
-        return articleMapper.toShortResponseList(articleRepository.findAllByDeletedFalseAndPublishDateTimeBeforeOrderByPublishDateTimeDesc(
-                Instant.now(),
-                Optional.ofNullable(cnt)
-                        .map(Limit::of)
-                        .orElseGet(() -> Limit.of(DEFAULT_SEARCH_SIZE))));
+    public List<ArticleShortResponse> searchPublished(Integer cnt, ArticleType type, String search) {
+        return articleMapper.toShortResponseList(
+                articleRepository.findPublished(Instant.now(), type, toLikePattern(search), toLimit(cnt)));
     }
 
-    public List<ArticleShortResponse> searchUnpublished(Integer cnt) {
-        return articleMapper.toShortResponseList(articleRepository.findAllByDeletedFalseOrderByCreatedAtDesc(Optional.ofNullable(cnt)
+    public List<ArticleShortResponse> searchUnpublished(Integer cnt, ArticleType type, String search) {
+        return articleMapper.toShortResponseList(
+                articleRepository.findUnpublished(Instant.now(), type, toLikePattern(search), toLimit(cnt)));
+    }
+
+    private Limit toLimit(Integer cnt) {
+        return Optional.ofNullable(cnt)
                 .map(Limit::of)
-                .orElseGet(() -> Limit.of(DEFAULT_SEARCH_SIZE))));
+                .orElseGet(() -> Limit.of(DEFAULT_SEARCH_SIZE));
+    }
+
+    /**
+     * Готовый LIKE-шаблон в нижнем регистре: "%" — без фильтра (совпадает со всеми заголовками),
+     * иначе "%<текст>%". Всегда непустая строка, поэтому параметр биндится как varchar (не bytea).
+     */
+    private String toLikePattern(String search) {
+        if (search == null || search.isBlank()) {
+            return "%";
+        }
+        return "%" + search.trim().toLowerCase(Locale.ROOT) + "%";
     }
 }

--- a/src/main/java/club/ttg/dnd5/domain/article/service/ArticleService.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/service/ArticleService.java
@@ -72,6 +72,13 @@ public class ArticleService {
             toUpdate.setDiscordDirty(true);
         }
 
+        // То же для VK: занята под отправку или уже отправлена (и всё ещё помечена к публикации) —
+        // пометить на синхронизацию. Независимо от Telegram и Discord.
+        boolean vkClaimedOrPosted = toUpdate.getVkPostedAt() != null || toUpdate.getVkPostId() != null;
+        if (vkClaimedOrPosted && toUpdate.isPublishToVk()) {
+            toUpdate.setVkDirty(true);
+        }
+
         String savedUrl = articleRepository.save(toUpdate).getUrl();
         revisionService.record(REVISION_ENTITY_TYPE, savedUrl, RevisionOperation.UPDATE, findFormByUrl(savedUrl));
         return savedUrl;
@@ -188,6 +195,50 @@ public class ArticleService {
     @Transactional
     public void clearDiscordPost(UUID id) {
         articleRepository.clearDiscordPost(id);
+    }
+
+    /**
+     * Пытается занять запись под отправку в VK (см. {@link ArticleRepository#claimForVk}).
+     * Короткая отдельная транзакция ДО сетевого вызова.
+     *
+     * @return {@code true}, если заняли (можно отправлять); {@code false}, если уже занята.
+     */
+    @Transactional
+    public boolean claimVkPost(UUID id, Instant when) {
+        return articleRepository.claimForVk(id, when) == 1;
+    }
+
+    /**
+     * Освобождает ранее занятую запись после неуспешной отправки — чтобы повторить на следующем тике.
+     */
+    @Transactional
+    public void releaseVkPost(UUID id) {
+        articleRepository.releaseVkClaim(id);
+    }
+
+    /**
+     * Фиксирует успешную отправку в VK: id поста на стене и строку вложения-обложки.
+     */
+    @Transactional
+    public void markVkSent(UUID id, Long postId, String attachment) {
+        articleRepository.markVkSent(id, postId, attachment);
+    }
+
+    /**
+     * Снимает флаг правки после синхронизации — только если запись не изменилась с момента загрузки
+     * (updatedAt совпадает). Иначе правку, прилетевшую во время отправки, не теряем: флаг остаётся.
+     */
+    @Transactional
+    public void clearVkDirty(UUID id, Instant updatedAt) {
+        articleRepository.clearVkDirtyIfUnchanged(id, updatedAt);
+    }
+
+    /**
+     * Сбрасывает состояние отправки в VK после удаления поста со стены.
+     */
+    @Transactional
+    public void clearVkPost(UUID id) {
+        articleRepository.clearVkPost(id);
     }
 
     public boolean existsByUrl(String url) {

--- a/src/main/java/club/ttg/dnd5/domain/article/service/ArticleService.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/service/ArticleService.java
@@ -57,6 +57,14 @@ public class ArticleService {
         articleMapper.updateEntity(toUpdate, request);
         applyPublication(toUpdate, request);
 
+        // Занята под отправку или уже отправлена в канал (и всё ещё помечена к публикации) — пометить на
+        // синхронизацию. Учитываем telegramPostedAt (claim), чтобы правка в окне ПЕРВОЙ отправки не потерялась:
+        // тогда message_id ещё null, но claim уже стоит, и после отправки поллер синхронизирует свежий текст.
+        boolean claimedOrPosted = toUpdate.getTelegramPostedAt() != null || toUpdate.getTelegramMessageId() != null;
+        if (claimedOrPosted && toUpdate.isPublishToTelegram()) {
+            toUpdate.setTelegramDirty(true);
+        }
+
         String savedUrl = articleRepository.save(toUpdate).getUrl();
         revisionService.record(REVISION_ENTITY_TYPE, savedUrl, RevisionOperation.UPDATE, findFormByUrl(savedUrl));
         return savedUrl;
@@ -85,6 +93,50 @@ public class ArticleService {
                 article.setPublishDateTime(Instant.now());
             }
         }
+    }
+
+    /**
+     * Пытается занять запись под отправку в Telegram (см. {@link ArticleRepository#claimForTelegram}).
+     * Короткая отдельная транзакция ДО сетевого вызова.
+     *
+     * @return {@code true}, если заняли (можно отправлять); {@code false}, если уже занята.
+     */
+    @Transactional
+    public boolean claimTelegramPost(UUID id, Instant when) {
+        return articleRepository.claimForTelegram(id, when) == 1;
+    }
+
+    /**
+     * Освобождает ранее занятую запись после неуспешной отправки — чтобы повторить на следующем тике.
+     */
+    @Transactional
+    public void releaseTelegramPost(UUID id) {
+        articleRepository.releaseTelegramClaim(id);
+    }
+
+    /**
+     * Фиксирует успешную отправку в Telegram: id поста в канале и тип (фото/текст).
+     */
+    @Transactional
+    public void markTelegramSent(UUID id, Long messageId, boolean photo) {
+        articleRepository.markTelegramSent(id, messageId, photo);
+    }
+
+    /**
+     * Снимает флаг правки после синхронизации — только если запись не изменилась с момента загрузки
+     * (updatedAt совпадает). Иначе правку, прилетевшую во время отправки, не теряем: флаг остаётся.
+     */
+    @Transactional
+    public void clearTelegramDirty(UUID id, Instant updatedAt) {
+        articleRepository.clearTelegramDirtyIfUnchanged(id, updatedAt);
+    }
+
+    /**
+     * Сбрасывает состояние отправки в Telegram после удаления поста из канала.
+     */
+    @Transactional
+    public void clearTelegramPost(UUID id) {
+        articleRepository.clearTelegramPost(id);
     }
 
     public boolean existsByUrl(String url) {

--- a/src/main/java/club/ttg/dnd5/domain/article/service/ArticleTelegramPublicationScheduler.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/service/ArticleTelegramPublicationScheduler.java
@@ -1,0 +1,147 @@
+package club.ttg.dnd5.domain.article.service;
+
+import club.ttg.dnd5.config.properties.TelegramProperties;
+import club.ttg.dnd5.domain.article.model.Article;
+import club.ttg.dnd5.domain.article.repository.ArticleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Limit;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Периодически отправляет в Telegram-канал новые опубликованные записи нужного типа.
+ * <p>
+ * Один поллер закрывает оба сценария публикации: «опубликовать сейчас» и «наступила
+ * запланированная дата» — потому что видимость записи на сайте пассивна (сравнение
+ * {@code publishDateTime < now} в запросе), отдельного события перехода нет.
+ * <p>
+ * Устойчивость и идемпотентность (claim-before-send): запись атомарно «занимаем» ДО
+ * отправки ({@link ArticleService#claimTelegramPost}), а сам HTTP-вызов держим ВНЕ транзакции.
+ * Занявший запись один — параллельный тик/второй инстанс её уже не отправит; сбой после
+ * успешной отправки не даёт дубля (отметка уже стоит). При временной ошибке отправки отметку
+ * снимаем ({@link ArticleService#releaseTelegramPost}) и повторяем на следующем тике. Признак
+ * «пора и ещё не отправлено» — поле {@code telegramPostedAt} (см. {@link ArticleRepository#findDueForTelegram}).
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ArticleTelegramPublicationScheduler {
+
+    private final ArticleRepository articleRepository;
+    private final ArticleService articleService;
+    private final TelegramPublisher telegramPublisher;
+    private final TelegramProperties properties;
+
+    @Scheduled(fixedDelayString = "${telegram.poll-interval:PT1M}")
+    public void publishDueToTelegram() {
+        if (!StringUtils.hasText(properties.getBotToken()) || !StringUtils.hasText(properties.getChatId())) {
+            // Токен/канал не заданы для этого окружения — интеграция выключена (напр. локально). Тихо выходим.
+            return;
+        }
+
+        Limit batch = Limit.of(Math.max(1, properties.getBatchSize()));
+        postNew(batch);
+        syncEdited(batch);
+        deleteRemoved(batch);
+    }
+
+    /** Отправляет в канал новые записи, у которых наступила публикация и стоит галочка. */
+    private void postNew(Limit batch) {
+        List<Article> due = articleRepository.findDueForTelegram(Instant.now(), batch);
+        int posted = 0;
+        for (Article snapshot : due) {
+            UUID id = snapshot.getId();
+            // Занимаем запись ДО отправки: если её уже занял другой тик/инстанс — пропускаем (без дубля).
+            if (!articleService.claimTelegramPost(id, Instant.now())) {
+                continue;
+            }
+            // Перечитываем СВЕЖУЮ версию после claim: правка, прилетевшая между выборкой батча и claim,
+            // попадёт в пост; правка ПОСЛЕ claim пометит запись dirty и синхронизируется отдельным проходом.
+            Article article = articleRepository.findById(id).orElse(null);
+            if (article == null || article.isDeleted()) {
+                articleService.releaseTelegramPost(id);
+                continue;
+            }
+            TelegramPublisher.PublishResult result;
+            try {
+                result = telegramPublisher.publish(article);
+            } catch (RuntimeException ex) {
+                // Любой сбой отправки (в т.ч. временный сбой чтения обложки из S3) не должен оставить
+                // запись «занятой» навсегда — освобождаем и повторим на следующем тике.
+                log.warn("Ошибка отправки {} в Telegram — освобождаю для повтора", article.getUrl(), ex);
+                articleService.releaseTelegramPost(id);
+                continue;
+            }
+            switch (result.status()) {
+                case POSTED -> {
+                    articleService.markTelegramSent(id, result.messageId(), result.photo());
+                    posted++;
+                }
+                // Временный сбой — снимаем отметку, повторим на следующем тике.
+                case RETRY -> articleService.releaseTelegramPost(id);
+                // Перманентный отказ Telegram (битый запрос/чат) — оставляем занятой, чтобы не долбить канал бесконечно.
+                case GIVE_UP -> log.warn("Telegram навсегда отклонил публикацию {} — больше не пытаюсь", article.getUrl());
+            }
+        }
+        if (posted > 0) {
+            log.info("Отправлено в Telegram записей: {} из {} готовых", posted, due.size());
+        }
+    }
+
+    /** Синхронизирует пост в канале для записей, изменённых после отправки. */
+    private void syncEdited(Limit batch) {
+        List<Article> dirty = articleRepository.findDirtyForTelegram(Instant.now(), batch);
+        int synced = 0;
+        for (Article article : dirty) {
+            TelegramPublisher.EditResult result;
+            try {
+                result = telegramPublisher.editPost(article);
+            } catch (RuntimeException ex) {
+                log.warn("Ошибка синхронизации поста {} — повторю на следующем тике", article.getUrl(), ex);
+                continue;
+            }
+            if (result != TelegramPublisher.EditResult.RETRY) {
+                // SYNCED или GIVE_UP — снимаем флаг, но только если запись не изменилась в окне отправки
+                // (иначе свежая правка сдвинула updatedAt, флаг останется и синхронизируется следующим тиком).
+                articleService.clearTelegramDirty(article.getId(), article.getUpdatedAt());
+            }
+            if (result == TelegramPublisher.EditResult.SYNCED) {
+                synced++;
+            }
+        }
+        if (synced > 0) {
+            log.info("Синхронизировано правок постов в Telegram: {} из {}", synced, dirty.size());
+        }
+    }
+
+    /** Удаляет из канала посты новостей, удалённых с сайта. */
+    private void deleteRemoved(Limit batch) {
+        List<Article> removed = articleRepository.findDeletedForTelegram(batch);
+        int deleted = 0;
+        for (Article article : removed) {
+            TelegramPublisher.EditResult result;
+            try {
+                result = telegramPublisher.deletePost(article);
+            } catch (RuntimeException ex) {
+                log.warn("Ошибка удаления поста {} из Telegram — повторю на следующем тике", article.getUrl(), ex);
+                continue;
+            }
+            if (result != TelegramPublisher.EditResult.RETRY) {
+                // SYNCED (удалили) или GIVE_UP (поста уже нет / нельзя удалить) — сбрасываем маркер, не долбим.
+                articleService.clearTelegramPost(article.getId());
+            }
+            if (result == TelegramPublisher.EditResult.SYNCED) {
+                deleted++;
+            }
+        }
+        if (deleted > 0) {
+            log.info("Удалено постов из Telegram: {}", deleted);
+        }
+    }
+}

--- a/src/main/java/club/ttg/dnd5/domain/article/service/ArticleVkPublicationScheduler.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/service/ArticleVkPublicationScheduler.java
@@ -1,0 +1,147 @@
+package club.ttg.dnd5.domain.article.service;
+
+import club.ttg.dnd5.config.properties.VkProperties;
+import club.ttg.dnd5.domain.article.model.Article;
+import club.ttg.dnd5.domain.article.repository.ArticleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Limit;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Периодически публикует на стену сообщества ВКонтакте новые опубликованные записи нужного типа — через
+ * ключ доступа сообщества, без бота.
+ * <p>
+ * Полный аналог {@link ArticleDiscordPublicationScheduler}, но независимый: своя галочка ({@code publishToVk}),
+ * свои отметки ({@code vk*}) и своё сообщество. Один поллер закрывает оба сценария публикации: «опубликовать
+ * сейчас» и «наступила запланированная дата» — потому что видимость записи на сайте пассивна (сравнение
+ * {@code publishDateTime < now} в запросе), отдельного события нет.
+ * <p>
+ * Устойчивость и идемпотентность (claim-before-send): запись атомарно «занимаем» ДО отправки
+ * ({@link ArticleService#claimVkPost}), а сам HTTP-вызов держим ВНЕ транзакции. Занявший запись один —
+ * параллельный тик/второй инстанс её уже не отправит; сбой после успешной отправки не даёт дубля. При
+ * временной ошибке отправки отметку снимаем ({@link ArticleService#releaseVkPost}) и повторяем на следующем тике.
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ArticleVkPublicationScheduler {
+
+    private final ArticleRepository articleRepository;
+    private final ArticleService articleService;
+    private final VkPublisher vkPublisher;
+    private final VkProperties properties;
+
+    @Scheduled(fixedDelayString = "${vk.poll-interval:PT1M}")
+    public void publishDueToVk() {
+        if (!StringUtils.hasText(properties.getAccessToken()) || !StringUtils.hasText(properties.getGroupId())) {
+            // Токен/сообщество не заданы для этого окружения — интеграция выключена (напр. локально). Тихо выходим.
+            return;
+        }
+
+        Limit batch = Limit.of(Math.max(1, properties.getBatchSize()));
+        postNew(batch);
+        syncEdited(batch);
+        deleteRemoved(batch);
+    }
+
+    /** Публикует новые записи, у которых наступила публикация и стоит галочка. */
+    private void postNew(Limit batch) {
+        List<Article> due = articleRepository.findDueForVk(Instant.now(), batch);
+        int posted = 0;
+        for (Article snapshot : due) {
+            UUID id = snapshot.getId();
+            // Занимаем запись ДО отправки: если её уже занял другой тик/инстанс — пропускаем (без дубля).
+            if (!articleService.claimVkPost(id, Instant.now())) {
+                continue;
+            }
+            // Перечитываем СВЕЖУЮ версию после claim: правка, прилетевшая между выборкой батча и claim,
+            // попадёт в пост; правка ПОСЛЕ claim пометит запись dirty и синхронизируется отдельным проходом.
+            Article article = articleRepository.findById(id).orElse(null);
+            if (article == null || article.isDeleted()) {
+                articleService.releaseVkPost(id);
+                continue;
+            }
+            VkPublisher.PublishResult result;
+            try {
+                result = vkPublisher.publish(article);
+            } catch (RuntimeException ex) {
+                // Любой сбой отправки (в т.ч. временный сбой чтения обложки из S3) не должен оставить
+                // запись «занятой» навсегда — освобождаем и повторим на следующем тике.
+                log.warn("Ошибка отправки {} в VK — освобождаю для повтора", article.getUrl(), ex);
+                articleService.releaseVkPost(id);
+                continue;
+            }
+            switch (result.status()) {
+                case POSTED -> {
+                    articleService.markVkSent(id, result.postId(), result.attachment());
+                    posted++;
+                }
+                // Временный сбой — снимаем отметку, повторим на следующем тике.
+                case RETRY -> articleService.releaseVkPost(id);
+                // Перманентный отказ VK (битый запрос/токен) — оставляем занятой, чтобы не долбить стену.
+                case GIVE_UP -> log.warn("VK навсегда отклонил публикацию {} — больше не пытаюсь", article.getUrl());
+            }
+        }
+        if (posted > 0) {
+            log.info("Отправлено в VK записей: {} из {} готовых", posted, due.size());
+        }
+    }
+
+    /** Синхронизирует пост на стене для записей, изменённых после отправки. */
+    private void syncEdited(Limit batch) {
+        List<Article> dirty = articleRepository.findDirtyForVk(Instant.now(), batch);
+        int synced = 0;
+        for (Article article : dirty) {
+            VkPublisher.EditResult result;
+            try {
+                result = vkPublisher.editPost(article);
+            } catch (RuntimeException ex) {
+                log.warn("Ошибка синхронизации поста {} в VK — повторю на следующем тике", article.getUrl(), ex);
+                continue;
+            }
+            if (result != VkPublisher.EditResult.RETRY) {
+                // SYNCED или GIVE_UP — снимаем флаг, но только если запись не изменилась в окне отправки
+                // (иначе свежая правка сдвинула updatedAt, флаг останется и синхронизируется следующим тиком).
+                articleService.clearVkDirty(article.getId(), article.getUpdatedAt());
+            }
+            if (result == VkPublisher.EditResult.SYNCED) {
+                synced++;
+            }
+        }
+        if (synced > 0) {
+            log.info("Синхронизировано правок постов в VK: {} из {}", synced, dirty.size());
+        }
+    }
+
+    /** Удаляет со стены посты новостей, удалённых с сайта. */
+    private void deleteRemoved(Limit batch) {
+        List<Article> removed = articleRepository.findDeletedForVk(batch);
+        int deleted = 0;
+        for (Article article : removed) {
+            VkPublisher.EditResult result;
+            try {
+                result = vkPublisher.deletePost(article);
+            } catch (RuntimeException ex) {
+                log.warn("Ошибка удаления поста {} из VK — повторю на следующем тике", article.getUrl(), ex);
+                continue;
+            }
+            if (result != VkPublisher.EditResult.RETRY) {
+                // SYNCED (удалили) или GIVE_UP (поста уже нет / нельзя удалить) — сбрасываем маркер, не долбим.
+                articleService.clearVkPost(article.getId());
+            }
+            if (result == VkPublisher.EditResult.SYNCED) {
+                deleted++;
+            }
+        }
+        if (deleted > 0) {
+            log.info("Удалено постов из VK: {}", deleted);
+        }
+    }
+}

--- a/src/main/java/club/ttg/dnd5/domain/article/service/DiscordMarkdownFormatter.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/service/DiscordMarkdownFormatter.java
@@ -1,0 +1,404 @@
+package club.ttg.dnd5.domain.article.service;
+
+import club.ttg.dnd5.domain.vttg.service.VttgMarkupConverter;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Приводит разметку статьи/новости к тексту для Discord (обычное сообщение, не embed).
+ * <p>
+ * Контент хранится массивом блоков: строки-абзацы и узлы-объекты (цитата/список/таблица/заголовок).
+ * {@link VttgMarkupConverter#toText} разворачивает блок в промежуточный markdown-подобный текст
+ * ({@code **жирный**}, {@code *курсив*}, {@code [метка](url)}). Discord-разметка почти совпадает с ним,
+ * поэтому {@code **}/{@code *} оставляем как есть; переводим лишь литеральные маркеры {@code {@u}}/
+ * {@code {@s}}/{@code {@spoiler}}/{@code {@code}} в Discord-markdown и цитату — в префикс {@code > }.
+ * <p>
+ * Ссылки: постим вебхуком, а у вебхуков/ботов Discord рендерит «маскированные» ссылки {@code [метка](url)}
+ * в обычном сообщении — поэтому кликабельной делаем саму метку-слово. URL оборачиваем в {@code <>}
+ * ({@code [метка](<url>)}): гасит громоздкую карточку-превью и не даёт скобкам в URL ломать разметку.
+ * Внутренние ссылки на разделы сайта достраиваются до абсолютного URL.
+ * <p>
+ * Лимит Discord считается по «сырой» длине строки (символы {@code **}/{@code <>} тоже учитываются),
+ * поэтому режем по этой длине, а не по видимой — в отличие от Telegram-HTML.
+ */
+@RequiredArgsConstructor
+@Component
+public class DiscordMarkdownFormatter {
+
+    /** Вид блока контента. */
+    private enum Kind { NORMAL, QUOTE, HEADING, SEPARATOR }
+
+    /** Типы блочных узлов (алиасы фронтового диалекта). */
+    private static final Set<String> QUOTE_TYPES = Set.of("quote", "blockquote", "q");
+    private static final Set<String> HEADING_TYPES = Set.of("heading", "h");
+    private static final Set<String> SEPARATOR_TYPES = Set.of("separator", "hr");
+    /** Разделитель (в Discord нет горизонтальной черты). */
+    private static final String DIVIDER = "———";
+
+    private static final Pattern MD_BOLD = Pattern.compile("\\*\\*(.+?)\\*\\*", Pattern.DOTALL);
+    private static final Pattern MD_ITALIC = Pattern.compile("\\*(.+?)\\*", Pattern.DOTALL);
+    private static final Pattern MD_LINK = Pattern.compile("\\[([^\\]]+)]\\(([^)]+)\\)");
+    /** Самый внутренний тег {@code {@name content}} (content без вложенных фигурных скобок; может быть пустым). */
+    private static final Pattern TAG = Pattern.compile("\\{@(\\w+)\\s*([^{}]*)}");
+    private static final int MAX_NESTING = 8;
+
+    /** Инлайн-маркер {@code {@type тело}} (тело без вложенных фигурных скобок). */
+    private static final Pattern MARKER = Pattern.compile("\\{@([\\w-]+)\\s+([^{}]*)}");
+    /** Тип ссылки-раздела → путь раздела на сайте (по фронтовой MARKER_URL_MAP). */
+    private static final Map<String, String> SECTION_PATHS = Map.ofEntries(
+            Map.entry("class", "classes"), Map.entry("spell", "spells"), Map.entry("feat", "feats"),
+            Map.entry("background", "backgrounds"), Map.entry("magicItem", "magic-items"),
+            Map.entry("magic-item", "magic-items"), Map.entry("item", "items"),
+            Map.entry("creature", "bestiary"), Map.entry("bestiary", "bestiary"),
+            Map.entry("glossary", "glossary"));
+    /** Обычная (внешняя/произвольная) ссылка. */
+    private static final Set<String> LINK_TYPES = Set.of("link", "a");
+
+    private final VttgMarkupConverter markupConverter;
+    private final ObjectMapper objectMapper;
+
+    @Value("${app.url:https://ttg.club}")
+    private String appUrl;
+
+    /** Разметка → обычный текст без форматирования (для оценки видимой длины и проверки на пустоту). */
+    public String toPlain(String markup) {
+        StringBuilder sb = new StringBuilder();
+        for (Rendered block : render(markup)) {
+            if (sb.length() > 0) {
+                sb.append("\n\n");
+            }
+            sb.append(block.plain());
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Разметка → список сообщений Discord-markdown: первое ≤ {@code firstLimit} символов (в нём публикатор
+     * добавит заголовок), последующие ≤ {@code restLimit}. Режем по границам блоков (абзацев); блок крупнее
+     * {@code restLimit} дробим по словам плоским текстом. Так длинная новость не обрезается, а досылается
+     * частями. Первый кусок может быть пустым — тогда первое сообщение = только заголовок.
+     */
+    public List<String> toMarkdownChunks(String markup, int firstLimit, int restLimit) {
+        List<String> chunks = new ArrayList<>();
+        StringBuilder cur = new StringBuilder();
+        int curLen = 0;
+        for (Rendered block : render(markup)) {
+            List<Rendered> pieces = block.md().length() <= restLimit
+                    ? List.of(block)
+                    : splitPlain(block.plain(), restLimit);
+            for (Rendered piece : pieces) {
+                int limit = chunks.isEmpty() ? firstLimit : restLimit;
+                int pieceLen = piece.md().length();
+                if (curLen == 0) {
+                    if (pieceLen > limit) {
+                        // Не влезает в первый кусок — оставляем его пустым, кладём со следующего.
+                        chunks.add("");
+                    }
+                    cur.append(piece.md());
+                    curLen = pieceLen;
+                } else if (curLen + 2 + pieceLen <= limit) {
+                    cur.append("\n\n").append(piece.md());
+                    curLen += 2 + pieceLen;
+                } else {
+                    chunks.add(cur.toString());
+                    cur.setLength(0);
+                    cur.append(piece.md());
+                    curLen = pieceLen;
+                }
+            }
+        }
+        if (cur.length() > 0 || chunks.isEmpty()) {
+            chunks.add(cur.toString());
+        }
+        return chunks;
+    }
+
+    /** Один отрендеренный блок: Discord-markdown, его плоский текст и длина (по сырому markdown). */
+    private record Rendered(String md, String plain) {
+    }
+
+    private List<Rendered> render(String markup) {
+        List<Rendered> out = new ArrayList<>();
+        for (Block block : blocks(markup)) {
+            if (block.kind() == Kind.SEPARATOR) {
+                out.add(new Rendered(DIVIDER, DIVIDER));
+                continue;
+            }
+            String text = clean(markupConverter.toText(preprocessLinks(block.markup())));
+            if (text.isEmpty()) {
+                continue;
+            }
+            String plain = plainFrom(text);
+            String tagized = tagize(text);
+            String md = switch (block.kind()) {
+                case QUOTE -> quote(tagized);
+                // Заголовок → жирная строка; внутренние ** убираем, чтобы не ломать вложенным жирным.
+                case HEADING -> "**" + tagized.replace("**", "") + "**";
+                default -> tagized;
+            };
+            out.add(new Rendered(md, plain));
+        }
+        return out;
+    }
+
+    /** Дробит плоский текст на куски ≤ limit по границам слов (формат теряется — только для огромных блоков). */
+    private static List<Rendered> splitPlain(String plain, int limit) {
+        List<Rendered> pieces = new ArrayList<>();
+        String rest = plain.strip();
+        while (!rest.isEmpty()) {
+            if (rest.length() <= limit) {
+                pieces.add(new Rendered(rest, rest));
+                break;
+            }
+            int cut = rest.lastIndexOf(' ', limit);
+            if (cut <= 0) {
+                cut = limit;
+            }
+            if (Character.isHighSurrogate(rest.charAt(cut - 1))) {
+                cut--;
+            }
+            String piece = rest.substring(0, cut).strip();
+            pieces.add(new Rendered(piece, piece));
+            rest = rest.substring(cut).strip();
+        }
+        return pieces;
+    }
+
+    /** Оборачивает блок в цитату Discord: префикс {@code > } к каждой строке (в т.ч. пустой). */
+    private static String quote(String md) {
+        String[] lines = md.split("\n", -1);
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < lines.length; i++) {
+            if (i > 0) {
+                sb.append('\n');
+            }
+            sb.append("> ").append(lines[i]);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Пред-обработка ДО {@link VttgMarkupConverter#toText}: маркеры-ссылки {@code {@type label | url:...}}
+     * → markdown {@code [label](абсолютный url)}. Нужна потому, что toText теряет ссылки: у обычного
+     * {@code {@link}} выкидывает url, а секции со спейсовым {@code | url:} не распознаёт. Остальные маркеры
+     * ({@code {@b}}/{@code {@u}}/…) не трогаем — их разберут toText и {@link #applyTags}.
+     */
+    private String preprocessLinks(String markup) {
+        if (markup == null || markup.indexOf("{@") < 0) {
+            return markup;
+        }
+        Matcher matcher = MARKER.matcher(markup);
+        StringBuilder result = new StringBuilder();
+        while (matcher.find()) {
+            String href = href(matcher.group(1), matcher.group(2));
+            String replacement = href != null
+                    ? "[" + label(matcher.group(2)) + "](" + href + ")"
+                    : matcher.group();
+            matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(result);
+        return result.toString();
+    }
+
+    /** Абсолютный href для маркера-ссылки; {@code null}, если это не ссылка (нет url или не тот тип). */
+    private String href(String type, String body) {
+        int pipe = body.indexOf('|');
+        if (pipe < 0) {
+            return null;
+        }
+        String attrs = body.substring(pipe + 1);
+        String url = attr(attrs, "url");
+        if (url == null) {
+            url = attr(attrs, "href");
+        }
+        if (url == null) {
+            return null;
+        }
+        if (LINK_TYPES.contains(type)) {
+            // Обычная ссылка: абсолютную оставляем, относительный роут сайта достраиваем.
+            return url.startsWith("http://") || url.startsWith("https://")
+                    ? url
+                    : site() + (url.startsWith("/") ? url : "/" + url);
+        }
+        String section = SECTION_PATHS.get(type);
+        return section != null ? site() + "/" + section + "/" + url : null;
+    }
+
+    private static String label(String body) {
+        int pipe = body.indexOf('|');
+        return (pipe < 0 ? body : body.substring(0, pipe)).trim();
+    }
+
+    private static String attr(String attrs, String key) {
+        for (String part : attrs.split("\\|")) {
+            String trimmed = part.trim();
+            if (trimmed.startsWith(key + ":")) {
+                return trimmed.substring(key.length() + 1).trim();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * База для абсолютных ссылок на разделы сайта. Ссылки идут в публичный канал, поэтому нужен
+     * полноценный публичный URL: если {@code app.url} без схемы или localhost (локальная разработка) —
+     * ведём на боевой сайт (иначе относительный href будет неполноценным).
+     */
+    private String site() {
+        String url = appUrl == null ? "" : appUrl.trim();
+        boolean usable = (url.startsWith("http://") || url.startsWith("https://")) && !url.contains("localhost");
+        if (!usable) {
+            url = "https://ttg.club";
+        }
+        return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+    }
+
+    /** Блок контента: исходная разметка блока и его вид. */
+    private record Block(String markup, Kind kind) {
+    }
+
+    /**
+     * Разбивает контент на блоки. Хранимая форма — JSON-массив: строки-абзацы и узлы-объекты
+     * (цитата/заголовок/разделитель — по {@code type}). Не-массив (обычная строка) — один блок.
+     */
+    private List<Block> blocks(String markup) {
+        if (!StringUtils.hasText(markup)) {
+            return List.of();
+        }
+        try {
+            JsonNode root = objectMapper.readTree(markup);
+            if (root.isArray()) {
+                List<Block> list = new ArrayList<>();
+                for (JsonNode element : root) {
+                    list.add(new Block(element.toString(), kindOf(element)));
+                }
+                return list;
+            }
+        } catch (Exception ignored) {
+            // Не JSON — обычная строка-разметка, обрабатываем одним блоком.
+        }
+        return List.of(new Block(markup, Kind.NORMAL));
+    }
+
+    private static Kind kindOf(JsonNode element) {
+        if (!element.isObject()) {
+            return Kind.NORMAL;
+        }
+        String type = element.path("type").asText();
+        if (QUOTE_TYPES.contains(type)) {
+            return Kind.QUOTE;
+        }
+        if (HEADING_TYPES.contains(type)) {
+            return Kind.HEADING;
+        }
+        if (SEPARATOR_TYPES.contains(type)) {
+            return Kind.SEPARATOR;
+        }
+        return Kind.NORMAL;
+    }
+
+    /** Нормализует результат toText: {@code <br>} → перевод строки; сырую JSON-разметку считаем пустой. */
+    private String clean(String text) {
+        if (!StringUtils.hasText(text)) {
+            return "";
+        }
+        text = text.replace("<br>", "\n").strip();
+        return looksLikeJson(text) ? "" : text;
+    }
+
+    /** markdown-подобный текст блока → Discord-markdown: раскрываем ссылки и литеральные теги {@code {@..}}. */
+    private String tagize(String text) {
+        return applyTags(convertLinks(text), true);
+    }
+
+    /** Плоский текст блока: снимаем {@code **}/{@code *}, ссылки сводим к метке, теги {@code {@..}} — к содержимому. */
+    private String plainFrom(String text) {
+        text = MD_BOLD.matcher(text).replaceAll("$1");
+        text = MD_ITALIC.matcher(text).replaceAll("$1");
+        text = MD_LINK.matcher(text).replaceAll("$1");
+        return applyTags(text, false);
+    }
+
+    /** {@code [метка](url)} → маскированная ссылка {@code [метка](<url>)} (или {@code <url>}, если метки нет). */
+    private String convertLinks(String text) {
+        Matcher link = MD_LINK.matcher(text);
+        StringBuilder result = new StringBuilder();
+        while (link.find()) {
+            link.appendReplacement(result,
+                    Matcher.quoteReplacement(linkText(link.group(1).trim(), link.group(2).trim())));
+        }
+        link.appendTail(result);
+        return result.toString();
+    }
+
+    /**
+     * {@code [метка](url)} → маскированная ссылка Discord, где кликабельна сама метка-слово (у вебхуков/ботов
+     * это работает и в обычном сообщении). http(s)-URL оборачиваем в {@code <>}: гасит громоздкую карточку-превью
+     * и не даёт скобкам/спецсимволам в URL ломать разметку. Если метки нет (пустая/совпадает с url) — показываем
+     * сам URL (кликабелен, без превью).
+     */
+    private static String linkText(String label, String url) {
+        boolean http = url.startsWith("http://") || url.startsWith("https://");
+        String target = http ? "<" + url + ">" : url;
+        if (label.isEmpty() || label.equals(url)) {
+            return target;
+        }
+        return "[" + label + "](" + target + ")";
+    }
+
+    /**
+     * Переводит литеральные теги {@code {@name ...}} в Discord-markdown (или снимает их), раскрывая
+     * вложенность изнутри наружу. {@code md=false} — просто снимает теги, оставляя содержимое.
+     */
+    private String applyTags(String text, boolean md) {
+        for (int pass = 0; pass < MAX_NESTING && text.indexOf("{@") >= 0; pass++) {
+            Matcher matcher = TAG.matcher(text);
+            if (!matcher.find()) {
+                break;
+            }
+            matcher.reset();
+            StringBuilder result = new StringBuilder();
+            while (matcher.find()) {
+                String tag = matcher.group(1).toLowerCase();
+                String content = matcher.group(2);
+                matcher.appendReplacement(result, Matcher.quoteReplacement(wrap(tag, content, md)));
+            }
+            matcher.appendTail(result);
+            text = result.toString();
+        }
+        return text;
+    }
+
+    private String wrap(String tag, String content, boolean md) {
+        if (!md || !StringUtils.hasText(content)) {
+            return content;
+        }
+        return switch (tag) {
+            case "b", "bold" -> "**" + content + "**";
+            case "i", "italic" -> "*" + content + "*";
+            case "u", "underline" -> "__" + content + "__";
+            case "s", "strike", "strikethrough" -> "~~" + content + "~~";
+            case "kbd", "code" -> "`" + content + "`";
+            case "spoiler" -> "||" + content + "||";
+            case "h", "heading" -> "**" + content + "**";
+            // sup/sub/highlight/mark/badge/roll/dice/separator и прочее не выражаем в Discord-markdown —
+            // оставляем только содержимое (без тега), чтобы ничего не текло сырым.
+            default -> content;
+        };
+    }
+
+    private static boolean looksLikeJson(String s) {
+        return (s.startsWith("{") && s.endsWith("}")) || (s.startsWith("[") && s.endsWith("]"));
+    }
+}

--- a/src/main/java/club/ttg/dnd5/domain/article/service/DiscordPublisher.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/service/DiscordPublisher.java
@@ -1,0 +1,307 @@
+package club.ttg.dnd5.domain.article.service;
+
+import club.ttg.dnd5.config.properties.DiscordProperties;
+import club.ttg.dnd5.domain.article.model.Article;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Отправляет и синхронизирует пост статьи / новости в Discord-канале через входящий вебхук.
+ * <p>
+ * Ничего не знает про БД и транзакции — только строит текст/пейлоад и делает HTTP-вызов. Пост — обычное
+ * сообщение (не embed): жирный заголовок + текст в Discord-markdown (см. {@link DiscordMarkdownFormatter}),
+ * обложку прикрепляем файлом из S3 (см. {@link ArticleImageSource}). Длинный пост не обрезается: первый кусок
+ * (≤2000) идёт первым сообщением с обложкой, остаток досылается отдельными сообщениями (≤2000).
+ * <p>
+ * Отправляем с {@code ?wait=true}, чтобы получить id сообщения (снежинку) — он нужен для правки
+ * ({@code PATCH /messages/{id}}) и удаления ({@code DELETE /messages/{id}}). Итог отправки — явный статус,
+ * чтобы планировщик отличал «повторить» (временный сбой) от «сдаться» (перманентный отказ Discord).
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class DiscordPublisher {
+
+    /** Лимит длины сообщения Discord (символы; считается по сырому тексту, включая markdown). */
+    private static final int MESSAGE_LIMIT = 2000;
+
+    /** Итог одного вызова вебхука. */
+    private enum SendResult {
+        /** 2xx — отправлено. */
+        SENT,
+        /** 4xx (кроме 429) — запрос неверен навсегда (битая картинка/чат/сообщение удалено): повтор бесполезен. */
+        REJECTED,
+        /** 429/5xx/сеть/таймаут — временно: имеет смысл повторить. */
+        TRANSIENT
+    }
+
+    /** Итог отправки нового поста (messageId — id ПЕРВОГО сообщения). */
+    public record PublishResult(Status status, String messageId) {
+        public enum Status { POSTED, RETRY, GIVE_UP }
+
+        static PublishResult posted(String messageId) {
+            return new PublishResult(Status.POSTED, messageId);
+        }
+
+        static PublishResult retry() {
+            return new PublishResult(Status.RETRY, null);
+        }
+
+        static PublishResult giveUp() {
+            return new PublishResult(Status.GIVE_UP, null);
+        }
+    }
+
+    /** Итог синхронизации правки / удаления поста. */
+    public enum EditResult { SYNCED, RETRY, GIVE_UP }
+
+    private final RestClient discordRestClient;
+    private final DiscordProperties properties;
+    private final DiscordMarkdownFormatter formatter;
+    private final ArticleImageSource imageSource;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Отправляет новый пост в канал (при необходимости — несколькими сообщениями).
+     */
+    public PublishResult publish(Article article) {
+        if (!StringUtils.hasText(article.getTitle()) && !StringUtils.hasText(formatter.toPlain(description(article)))) {
+            log.warn("Пустой заголовок и текст — пропускаю отправку {} в Discord", article.getUrl());
+            return PublishResult.giveUp();
+        }
+
+        List<String> messages = buildMessages(article);
+        if (messages.isEmpty()) {
+            // Ни заголовка, ни текста после рендера — постить нечего (страховка; обычно отсекается проверкой выше).
+            return PublishResult.giveUp();
+        }
+
+        // Первое сообщение: с обложкой (файлом), если она есть; иначе текстом.
+        SendOutcome first = null;
+        if (StringUtils.hasText(article.getPreviewImageUrl())) {
+            SendOutcome sent = trySendPhoto(article, messages.get(0));
+            if (sent != null) {
+                if (sent.result() == SendResult.TRANSIENT) {
+                    // Временный сбой (загрузка файла/сеть) — не теряем обложку, повторим весь пост.
+                    return PublishResult.retry();
+                }
+                if (sent.result() == SendResult.SENT) {
+                    first = sent;
+                } else {
+                    log.info("Отправка обложки отклонена Discord для {} — отправляю текстом", article.getUrl());
+                }
+            }
+        }
+        if (first == null) {
+            first = sendMessage(messages.get(0));
+        }
+
+        if (first.result() != SendResult.SENT) {
+            return first.result() == SendResult.TRANSIENT ? PublishResult.retry() : PublishResult.giveUp();
+        }
+        String firstId = first.messageId();
+
+        // Хвост — отдельными сообщениями (best-effort: если не ушло, пост неполный, но первое не дублируем).
+        for (int i = 1; i < messages.size(); i++) {
+            if (sendMessage(messages.get(i)).result() != SendResult.SENT) {
+                log.warn("Не отправлено хвостовое сообщение {}/{} для {} — пост неполный",
+                        i, messages.size() - 1, article.getUrl());
+            }
+        }
+        return PublishResult.posted(firstId);
+    }
+
+    /**
+     * Синхронизирует пост с обновлённой новостью: правит content ПЕРВОГО сообщения на месте. Вложение
+     * (обложку) не трогаем — поле {@code attachments} не передаём, и Discord сохраняет уже загруженный файл.
+     * Хвостовые сообщения многочастного поста правка тоже не трогает (правится только первое).
+     */
+    public EditResult editPost(Article article) {
+        List<String> messages = buildMessages(article);
+        if (messages.isEmpty()) {
+            // Правка сделала запись пустой — пустой content Discord отвергнет, корректной альтернативы нет:
+            // прекращаем попытки (планировщик снимет флаг dirty).
+            return EditResult.GIVE_UP;
+        }
+        Map<String, Object> payload = messagePayload(messages.get(0));
+        return switch (send(HttpMethod.PATCH, messageUri(article.getDiscordMessageId()), payload,
+                MediaType.APPLICATION_JSON).result()) {
+            case SENT -> EditResult.SYNCED;
+            case TRANSIENT -> EditResult.RETRY;
+            // 4xx: сообщение удалено/нельзя изменить — прекращаем попытки.
+            case REJECTED -> EditResult.GIVE_UP;
+        };
+    }
+
+    /** Удаляет пост из канала (для удалённой с сайта новости). */
+    public EditResult deletePost(Article article) {
+        return switch (send(HttpMethod.DELETE, messageUri(article.getDiscordMessageId()), null, null).result()) {
+            case SENT -> EditResult.SYNCED;
+            case TRANSIENT -> EditResult.RETRY;
+            // «Unknown Message» / нельзя удалить — считаем обработанным (больше не пытаемся).
+            case REJECTED -> EditResult.GIVE_UP;
+        };
+    }
+
+    /**
+     * Собирает список сообщений: первое включает жирный заголовок и первый кусок описания (≤ MESSAGE_LIMIT),
+     * остальные — продолжение описания (≤ MESSAGE_LIMIT).
+     */
+    private List<String> buildMessages(Article article) {
+        String title = nullToEmpty(article.getTitle());
+        // Заголовок — литеральный текст: экранируем markdown-метасимволы (в т.ч. `[`/`]`, чтобы `[текст](url)`
+        // в названии не стал ссылкой), чтобы разметка в названии не ломала жирную «шапку» поста (тело,
+        // наоборот, несёт намеренную разметку и не экранируется).
+        String head = StringUtils.hasText(title) ? "**" + escapeMarkdown(title) + "**" : "";
+        int firstBodyLimit = Math.max(0, MESSAGE_LIMIT - head.length() - 2);
+        List<String> bodyChunks = formatter.toMarkdownChunks(description(article), firstBodyLimit, MESSAGE_LIMIT);
+
+        List<String> messages = new ArrayList<>();
+        String firstBody = bodyChunks.isEmpty() ? "" : bodyChunks.get(0);
+        String first = StringUtils.hasText(firstBody)
+                ? (head.isEmpty() ? firstBody : head + "\n\n" + firstBody)
+                : head;
+        // Пустое первое сообщение не шлём (Discord отвергнет content=""): если заголовок пуст и первый
+        // кусок описания «отложен» (пустой), пост начнётся с первого непустого куска.
+        if (StringUtils.hasText(first)) {
+            messages.add(first);
+        }
+        for (int i = 1; i < bodyChunks.size(); i++) {
+            if (StringUtils.hasText(bodyChunks.get(i))) {
+                messages.add(bodyChunks.get(i));
+            }
+        }
+        return messages;
+    }
+
+    /**
+     * Пытается отправить первое сообщение с обложкой файлом. {@code null} — обложки нет (это не S3-путь
+     * или объекта нет) — тогда уходим текстом. Временный сбой чтения из S3 пробрасывается наружу
+     * (планировщик освободит запись и повторит).
+     */
+    private SendOutcome trySendPhoto(Article article, String content) {
+        byte[] bytes = imageSource.bytes(article.getPreviewImageUrl());
+        if (bytes == null) {
+            return null;
+        }
+        return sendMessageWithImage(content, bytes, imageSource.filename(article.getPreviewImageUrl()));
+    }
+
+    private SendOutcome sendMessageWithImage(String content, byte[] image, String filename) {
+        MultipartBodyBuilder builder = new MultipartBodyBuilder();
+        // Текст и настройки — JSON-частью payload_json, картинка — отдельным файлом (files[0]).
+        builder.part("payload_json", toJson(messagePayload(content)), MediaType.APPLICATION_JSON);
+        builder.part("files[0]", new ByteArrayResource(image) {
+            @Override
+            public String getFilename() {
+                return filename;
+            }
+        });
+        return send(HttpMethod.POST, sendUri(), builder.build(), MediaType.MULTIPART_FORM_DATA);
+    }
+
+    private SendOutcome sendMessage(String content) {
+        return send(HttpMethod.POST, sendUri(), messagePayload(content), MediaType.APPLICATION_JSON);
+    }
+
+    private Map<String, Object> messagePayload(String content) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("content", content);
+        // Не пинговать @everyone/@here/роли, если они случайно окажутся в тексте новости.
+        payload.put("allowed_mentions", Map.of("parse", List.of()));
+        return payload;
+    }
+
+    private SendOutcome send(HttpMethod method, URI uri, Object body, MediaType contentType) {
+        try {
+            RestClient.RequestBodySpec request = discordRestClient.method(method).uri(uri);
+            RestClient.ResponseSpec response = body != null
+                    ? request.contentType(contentType).body(body).retrieve()
+                    : request.retrieve();
+            JsonNode json = response.body(JsonNode.class);
+            // Discord возвращает id сообщения строкой (снежинка) — на POST ?wait=true и на PATCH.
+            String messageId = json != null ? json.path("id").asText(null) : null;
+            return new SendOutcome(SendResult.SENT, messageId);
+        } catch (RestClientResponseException ex) {
+            log.warn("Discord {} вернул {}: {}", method, ex.getStatusCode(), ex.getResponseBodyAsString());
+            boolean retriable = ex.getStatusCode().value() == 429 || ex.getStatusCode().is5xxServerError();
+            return new SendOutcome(retriable ? SendResult.TRANSIENT : SendResult.REJECTED, null);
+        } catch (RestClientException ex) {
+            // Сеть/таймаут (в т.ч. потерянный ответ на уже доставленный запрос) — считаем временным.
+            // Логируем причину (IOException), а НЕ ex.getMessage(): RestClient вшивает в него полный URL
+            // запроса, а весь URL вебхука (вместе с токеном) — это целиком секрет доступа к каналу.
+            Throwable cause = ex.getCause();
+            log.warn("Не удалось вызвать Discord {}: {}", method,
+                    cause != null ? cause.getMessage() : ex.getClass().getSimpleName());
+            return new SendOutcome(SendResult.TRANSIENT, null);
+        }
+    }
+
+    /** Адрес отправки нового сообщения: сам вебхук с {@code ?wait=true} (чтобы вернулся id сообщения). */
+    private URI sendUri() {
+        return URI.create(properties.getWebhookUrl() + "?wait=true");
+    }
+
+    /** Адрес правки/удаления конкретного сообщения вебхука. */
+    private URI messageUri(String messageId) {
+        return URI.create(properties.getWebhookUrl() + "/messages/" + messageId);
+    }
+
+    private String toJson(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("Не удалось сериализовать пейлоад Discord", ex);
+        }
+    }
+
+    /** Разметка описания: превью, если оно даёт непустой текст; иначе основной текст. */
+    private String description(Article article) {
+        return StringUtils.hasText(formatter.toPlain(article.getPreview()))
+                ? article.getPreview()
+                : article.getContent();
+    }
+
+    private static String nullToEmpty(String s) {
+        return s == null ? "" : s;
+    }
+
+    /**
+     * Экранирует markdown-метасимволы Discord обратным слэшем — для литерального текста (заголовок),
+     * который не должен интерпретироваться как разметка. Аналог {@code escape()} в TelegramPublisher.
+     */
+    private static String escapeMarkdown(String s) {
+        StringBuilder sb = new StringBuilder(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c == '\\' || c == '*' || c == '_' || c == '~' || c == '|' || c == '`' || c == '>'
+                    || c == '[' || c == ']') {
+                sb.append('\\');
+            }
+            sb.append(c);
+        }
+        return sb.toString();
+    }
+
+    /** Итог вызова вебхука: результат и id сообщения (при успехе отправки). */
+    private record SendOutcome(SendResult result, String messageId) {
+    }
+}

--- a/src/main/java/club/ttg/dnd5/domain/article/service/TelegramHtmlFormatter.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/service/TelegramHtmlFormatter.java
@@ -1,0 +1,402 @@
+package club.ttg.dnd5.domain.article.service;
+
+import club.ttg.dnd5.domain.vttg.service.VttgMarkupConverter;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Приводит разметку статьи/новости к тексту для Telegram.
+ * <p>
+ * Контент хранится массивом блоков: строки-абзацы и узлы-объекты (цитата/список/таблица/заголовок).
+ * {@link VttgMarkupConverter#toText} разворачивает блок в промежуточный markdown-подобный текст
+ * ({@code **жирный**}, {@code *курсив*}, {@code [метка](url)}) и при этом теряет обёртку цитаты —
+ * поэтому цитату ({@code type: quote}) мы выделяем на уровне блоков и оборачиваем в Telegram
+ * {@code <blockquote>}. Остальное переводим в Telegram-HTML: {@code <b>/<i>/<u>/<s>/<a>}. Всё, что
+ * Telegram не поддерживает, схлопывается в обычный текст — сырые токены наружу не попадают.
+ */
+@RequiredArgsConstructor
+@Component
+public class TelegramHtmlFormatter {
+
+    /** Вид блока контента. */
+    private enum Kind { NORMAL, QUOTE, HEADING, SEPARATOR }
+
+    /** Типы блочных узлов (алиасы фронтового диалекта). */
+    private static final Set<String> QUOTE_TYPES = Set.of("quote", "blockquote", "q");
+    private static final Set<String> HEADING_TYPES = Set.of("heading", "h");
+    private static final Set<String> SEPARATOR_TYPES = Set.of("separator", "hr");
+    /** Разделитель (в Telegram нет горизонтальной черты). */
+    private static final String DIVIDER = "———";
+
+    private static final Pattern MD_BOLD = Pattern.compile("\\*\\*(.+?)\\*\\*", Pattern.DOTALL);
+    private static final Pattern MD_ITALIC = Pattern.compile("\\*(.+?)\\*", Pattern.DOTALL);
+    private static final Pattern MD_LINK = Pattern.compile("\\[([^\\]]+)]\\(([^)]+)\\)");
+    /** Самый внутренний тег {@code {@name content}} (content без вложенных фигурных скобок; может быть пустым). */
+    private static final Pattern TAG = Pattern.compile("\\{@(\\w+)\\s*([^{}]*)}");
+    /** Открывающий/закрывающий Telegram-тег (только те, что мы вставляем) — для проверки вложенности. */
+    private static final Pattern HTML_TAG = Pattern.compile("</?(b|i|u|s|a|code|tg-spoiler)\\b[^>]*>");
+    private static final int MAX_NESTING = 8;
+
+    /** Инлайн-маркер {@code {@type тело}} (тело без вложенных фигурных скобок). */
+    private static final Pattern MARKER = Pattern.compile("\\{@([\\w-]+)\\s+([^{}]*)}");
+    /** Тип ссылки-раздела → путь раздела на сайте (по фронтовой MARKER_URL_MAP). */
+    private static final Map<String, String> SECTION_PATHS = Map.ofEntries(
+            Map.entry("class", "classes"), Map.entry("spell", "spells"), Map.entry("feat", "feats"),
+            Map.entry("background", "backgrounds"), Map.entry("magicItem", "magic-items"),
+            Map.entry("magic-item", "magic-items"), Map.entry("item", "items"),
+            Map.entry("creature", "bestiary"), Map.entry("bestiary", "bestiary"),
+            Map.entry("glossary", "glossary"));
+    /** Обычная (внешняя/произвольная) ссылка. */
+    private static final Set<String> LINK_TYPES = Set.of("link", "a");
+
+    private final VttgMarkupConverter markupConverter;
+    private final ObjectMapper objectMapper;
+
+    @Value("${app.url:https://ttg.club}")
+    private String appUrl;
+
+    /** Разметка → обычный текст без форматирования (для оценки видимой длины). */
+    public String toPlain(String markup) {
+        StringBuilder sb = new StringBuilder();
+        for (Rendered block : render(markup)) {
+            if (sb.length() > 0) {
+                sb.append("\n\n");
+            }
+            sb.append(block.plain());
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Разметка → список сообщений Telegram-HTML: первое ≤ {@code firstLimit} видимых символов (подпись
+     * к фото или первое сообщение), последующие ≤ {@code restLimit}. Режем по границам блоков (абзацев);
+     * блок крупнее {@code restLimit} дробим по словам плоским текстом. Так длинная новость не обрезается,
+     * а досылается частями. Первый кусок может быть пустым — тогда подпись к фото = только заголовок.
+     */
+    public List<String> toHtmlChunks(String markup, int firstLimit, int restLimit) {
+        List<String> chunks = new ArrayList<>();
+        StringBuilder cur = new StringBuilder();
+        int curVis = 0;
+        for (Rendered block : render(markup)) {
+            List<Rendered> pieces = block.visibleLength() <= restLimit
+                    ? List.of(block)
+                    : splitPlain(block.plain(), restLimit);
+            for (Rendered piece : pieces) {
+                int limit = chunks.isEmpty() ? firstLimit : restLimit;
+                if (curVis == 0) {
+                    if (piece.visibleLength() > limit) {
+                        // Не влезает в первый кусок (подпись) — оставляем его пустым, кладём со следующего.
+                        chunks.add("");
+                    }
+                    cur.append(piece.html());
+                    curVis = piece.visibleLength();
+                } else if (curVis + 2 + piece.visibleLength() <= limit) {
+                    cur.append("\n\n").append(piece.html());
+                    curVis += 2 + piece.visibleLength();
+                } else {
+                    chunks.add(cur.toString());
+                    cur.setLength(0);
+                    cur.append(piece.html());
+                    curVis = piece.visibleLength();
+                }
+            }
+        }
+        if (cur.length() > 0 || chunks.isEmpty()) {
+            chunks.add(cur.toString());
+        }
+        return chunks;
+    }
+
+    /** Один отрендеренный блок: HTML, его плоский текст и видимая длина (по плоскому тексту). */
+    private record Rendered(String html, String plain, int visibleLength) {
+    }
+
+    private List<Rendered> render(String markup) {
+        List<Rendered> out = new ArrayList<>();
+        for (Block block : blocks(markup)) {
+            if (block.kind() == Kind.SEPARATOR) {
+                out.add(new Rendered(DIVIDER, DIVIDER, DIVIDER.length()));
+                continue;
+            }
+            String text = clean(markupConverter.toText(preprocessLinks(block.markup())));
+            if (text.isEmpty()) {
+                continue;
+            }
+            String plain = plainFrom(text);
+            String tagized = tagize(text);
+            String html = switch (block.kind()) {
+                case QUOTE -> "<blockquote>" + tagized + "</blockquote>";
+                // Заголовок → жирная строка; внутренний <b> убираем, чтобы не вкладывать <b> в <b>.
+                case HEADING -> "<b>" + tagized.replace("<b>", "").replace("</b>", "") + "</b>";
+                default -> tagized;
+            };
+            out.add(new Rendered(html, plain, plain.length()));
+        }
+        return out;
+    }
+
+    /** Дробит плоский текст на куски ≤ limit по границам слов (формат теряется — только для огромных блоков). */
+    private static List<Rendered> splitPlain(String plain, int limit) {
+        List<Rendered> pieces = new ArrayList<>();
+        String rest = plain.strip();
+        while (!rest.isEmpty()) {
+            if (rest.length() <= limit) {
+                pieces.add(new Rendered(escape(rest), rest, rest.length()));
+                break;
+            }
+            int cut = rest.lastIndexOf(' ', limit);
+            if (cut <= 0) {
+                cut = limit;
+            }
+            if (Character.isHighSurrogate(rest.charAt(cut - 1))) {
+                cut--;
+            }
+            String piece = rest.substring(0, cut).strip();
+            pieces.add(new Rendered(escape(piece), piece, piece.length()));
+            rest = rest.substring(cut).strip();
+        }
+        return pieces;
+    }
+
+    /**
+     * Пред-обработка ДО {@link VttgMarkupConverter#toText}: маркеры-ссылки {@code {@type label | url:...}}
+     * → markdown {@code [label](абсолютный url)}. Нужна потому, что toText теряет ссылки: у обычного
+     * {@code {@link}} выкидывает url, а секции со спейсовым {@code | url:} не распознаёт. Остальные маркеры
+     * ({@code {@b}}/{@code {@u}}/…) не трогаем — их разберут toText и {@link #applyTags}.
+     */
+    private String preprocessLinks(String markup) {
+        if (markup == null || markup.indexOf("{@") < 0) {
+            return markup;
+        }
+        Matcher matcher = MARKER.matcher(markup);
+        StringBuilder result = new StringBuilder();
+        while (matcher.find()) {
+            String href = href(matcher.group(1), matcher.group(2));
+            String replacement = href != null
+                    ? "[" + label(matcher.group(2)) + "](" + href + ")"
+                    : matcher.group();
+            matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(result);
+        return result.toString();
+    }
+
+    /** Абсолютный href для маркера-ссылки; {@code null}, если это не ссылка (нет url или не тот тип). */
+    private String href(String type, String body) {
+        int pipe = body.indexOf('|');
+        if (pipe < 0) {
+            return null;
+        }
+        String attrs = body.substring(pipe + 1);
+        String url = attr(attrs, "url");
+        if (url == null) {
+            url = attr(attrs, "href");
+        }
+        if (url == null) {
+            return null;
+        }
+        if (LINK_TYPES.contains(type)) {
+            // Обычная ссылка: абсолютную оставляем, относительный роут сайта достраиваем.
+            return url.startsWith("http://") || url.startsWith("https://")
+                    ? url
+                    : site() + (url.startsWith("/") ? url : "/" + url);
+        }
+        String section = SECTION_PATHS.get(type);
+        return section != null ? site() + "/" + section + "/" + url : null;
+    }
+
+    private static String label(String body) {
+        int pipe = body.indexOf('|');
+        return (pipe < 0 ? body : body.substring(0, pipe)).trim();
+    }
+
+    private static String attr(String attrs, String key) {
+        for (String part : attrs.split("\\|")) {
+            String trimmed = part.trim();
+            if (trimmed.startsWith(key + ":")) {
+                return trimmed.substring(key.length() + 1).trim();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * База для абсолютных ссылок на разделы сайта. Ссылки идут в публичный канал, поэтому нужен
+     * полноценный публичный URL: если {@code app.url} без схемы или localhost (локальная разработка) —
+     * ведём на боевой сайт (иначе href вида {@code localhost/spells/…} Telegram не сделает кликабельным).
+     */
+    private String site() {
+        String url = appUrl == null ? "" : appUrl.trim();
+        boolean usable = (url.startsWith("http://") || url.startsWith("https://")) && !url.contains("localhost");
+        if (!usable) {
+            url = "https://ttg.club";
+        }
+        return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+    }
+
+    /** Блок контента: исходная разметка блока и его вид. */
+    private record Block(String markup, Kind kind) {
+    }
+
+    /**
+     * Разбивает контент на блоки. Хранимая форма — JSON-массив: строки-абзацы и узлы-объекты
+     * (цитата/заголовок/разделитель — по {@code type}). Не-массив (обычная строка) — один блок.
+     */
+    private List<Block> blocks(String markup) {
+        if (!StringUtils.hasText(markup)) {
+            return List.of();
+        }
+        try {
+            JsonNode root = objectMapper.readTree(markup);
+            if (root.isArray()) {
+                List<Block> list = new ArrayList<>();
+                for (JsonNode element : root) {
+                    list.add(new Block(element.toString(), kindOf(element)));
+                }
+                return list;
+            }
+        } catch (Exception ignored) {
+            // Не JSON — обычная строка-разметка, обрабатываем одним блоком.
+        }
+        return List.of(new Block(markup, Kind.NORMAL));
+    }
+
+    private static Kind kindOf(JsonNode element) {
+        if (!element.isObject()) {
+            return Kind.NORMAL;
+        }
+        String type = element.path("type").asText();
+        if (QUOTE_TYPES.contains(type)) {
+            return Kind.QUOTE;
+        }
+        if (HEADING_TYPES.contains(type)) {
+            return Kind.HEADING;
+        }
+        if (SEPARATOR_TYPES.contains(type)) {
+            return Kind.SEPARATOR;
+        }
+        return Kind.NORMAL;
+    }
+
+    /** Нормализует результат toText: {@code <br>} → перевод строки; сырую JSON-разметку считаем пустой. */
+    private String clean(String text) {
+        if (!StringUtils.hasText(text)) {
+            return "";
+        }
+        text = text.replace("<br>", "\n").strip();
+        return looksLikeJson(text) ? "" : text;
+    }
+
+    /** markdown-подобный текст блока → Telegram-HTML; при кривой вложенности — экранированный плоский текст. */
+    private String tagize(String text) {
+        String html = applyTags(applyMarkdown(escape(text)), true);
+        // Перекрывающийся markdown (напр. «**жирный *курсив***») даёт невалидную вложенность, которую
+        // Telegram отвергнет (400). В таком случае жертвуем форматированием ради доставки поста.
+        return wellFormed(html) ? html : escape(plainFrom(text));
+    }
+
+    private String plainFrom(String text) {
+        text = MD_BOLD.matcher(text).replaceAll("$1");
+        text = MD_ITALIC.matcher(text).replaceAll("$1");
+        text = MD_LINK.matcher(text).replaceAll("$1");
+        return applyTags(text, false);
+    }
+
+    private String applyMarkdown(String text) {
+        text = MD_BOLD.matcher(text).replaceAll("<b>$1</b>");
+        text = MD_ITALIC.matcher(text).replaceAll("<i>$1</i>");
+
+        Matcher link = MD_LINK.matcher(text);
+        StringBuilder result = new StringBuilder();
+        while (link.find()) {
+            String label = link.group(1);
+            String url = link.group(2).replace("\"", "&quot;");
+            link.appendReplacement(result, Matcher.quoteReplacement("<a href=\"" + url + "\">" + label + "</a>"));
+        }
+        link.appendTail(result);
+        return result.toString();
+    }
+
+    /**
+     * Переводит литеральные теги {@code {@name ...}} в HTML (или в текст), раскрывая вложенность
+     * изнутри наружу. {@code html=false} — просто снимает теги, оставляя содержимое.
+     */
+    private String applyTags(String text, boolean html) {
+        for (int pass = 0; pass < MAX_NESTING && text.indexOf("{@") >= 0; pass++) {
+            Matcher matcher = TAG.matcher(text);
+            if (!matcher.find()) {
+                break;
+            }
+            matcher.reset();
+            StringBuilder result = new StringBuilder();
+            while (matcher.find()) {
+                String tag = matcher.group(1).toLowerCase();
+                String content = matcher.group(2);
+                matcher.appendReplacement(result, Matcher.quoteReplacement(wrap(tag, content, html)));
+            }
+            matcher.appendTail(result);
+            text = result.toString();
+        }
+        return text;
+    }
+
+    private String wrap(String tag, String content, boolean html) {
+        if (!html || !StringUtils.hasText(content)) {
+            return content;
+        }
+        return switch (tag) {
+            case "b", "bold" -> tagged("b", content);
+            case "i", "italic" -> tagged("i", content);
+            case "u", "underline" -> tagged("u", content);
+            case "s", "strike", "strikethrough" -> tagged("s", content);
+            case "kbd", "code" -> tagged("code", content);
+            case "spoiler" -> tagged("tg-spoiler", content);
+            case "h", "heading" -> tagged("b", content);
+            // sup/sub/highlight/mark/badge/roll/dice/separator и прочее Telegram не поддерживает —
+            // оставляем только содержимое (без тега), чтобы ничего не текло сырым.
+            default -> content;
+        };
+    }
+
+    private static String tagged(String tag, String content) {
+        return "<" + tag + ">" + content + "</" + tag + ">";
+    }
+
+    /** Проверяет, что вставленные теги b/i/u/s/a правильно вложены и закрыты. */
+    private static boolean wellFormed(String html) {
+        Deque<String> stack = new ArrayDeque<>();
+        Matcher matcher = HTML_TAG.matcher(html);
+        while (matcher.find()) {
+            String name = matcher.group(1);
+            if (matcher.group().startsWith("</")) {
+                if (stack.isEmpty() || !stack.pop().equals(name)) {
+                    return false;
+                }
+            } else {
+                stack.push(name);
+            }
+        }
+        return stack.isEmpty();
+    }
+
+    private static String escape(String s) {
+        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+    }
+
+    private static boolean looksLikeJson(String s) {
+        return (s.startsWith("{") && s.endsWith("}")) || (s.startsWith("[") && s.endsWith("]"));
+    }
+}

--- a/src/main/java/club/ttg/dnd5/domain/article/service/TelegramImageSource.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/service/TelegramImageSource.java
@@ -1,0 +1,67 @@
+package club.ttg.dnd5.domain.article.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+
+/**
+ * Достаёт байты обложки новости из S3, чтобы залить их в Telegram файлом (а не ссылкой).
+ * previewImageUrl хранится как относительный путь {@code /s3/<key>}; публичного URL у объекта нет
+ * (bucket закрыт), поэтому картинку читаем напрямую из S3 — доступ у сервиса уже есть.
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class TelegramImageSource {
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private final S3Client s3Client;
+
+    /**
+     * Байты обложки по {@code previewImageUrl} вида {@code /s3/<key>}.
+     * <p>
+     * Различает «нет картинки» и «временный сбой»: {@code null} — это не S3-путь ИЛИ объекта нет
+     * (NoSuchKey) — тогда пост уйдёт текстом. Временный сбой чтения (таймаут/5xx/сеть) пробрасываем,
+     * чтобы планировщик повторил весь пост и не потерял обложку.
+     *
+     * @return байты объекта; {@code null}, если картинки нет.
+     * @throws RuntimeException при временном сбое чтения из S3.
+     */
+    public byte[] bytes(String previewImageUrl) {
+        String key = key(previewImageUrl);
+        if (key == null) {
+            return null;
+        }
+        try {
+            return s3Client.getObjectAsBytes(request -> request.bucket(bucket).key(key)).asByteArray();
+        } catch (NoSuchKeyException ex) {
+            log.warn("Обложка {} не найдена в S3 — пост уйдёт текстом", key);
+            return null;
+        }
+    }
+
+    /** Имя файла для Telegram (по расширению определяет тип). */
+    public String filename(String previewImageUrl) {
+        String key = key(previewImageUrl);
+        if (key == null) {
+            return "cover";
+        }
+        int slash = key.lastIndexOf('/');
+        return slash >= 0 ? key.substring(slash + 1) : key;
+    }
+
+    /** {@code /s3/articles/x.webp} → {@code articles/x.webp}; для абсолютных/внешних URL — {@code null}. */
+    private static String key(String previewImageUrl) {
+        if (!StringUtils.hasText(previewImageUrl)) {
+            return null;
+        }
+        int marker = previewImageUrl.indexOf("/s3/");
+        return marker >= 0 ? previewImageUrl.substring(marker + 4) : null;
+    }
+}

--- a/src/main/java/club/ttg/dnd5/domain/article/service/TelegramPublisher.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/service/TelegramPublisher.java
@@ -1,0 +1,285 @@
+package club.ttg.dnd5.domain.article.service;
+
+import club.ttg.dnd5.config.properties.TelegramProperties;
+import club.ttg.dnd5.domain.article.model.Article;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Отправляет и синхронизирует пост статьи / новости в Telegram-канале через Bot API.
+ * <p>
+ * Ничего не знает про БД и транзакции — только строит текст/пейлоад и делает HTTP-вызов. Длинный пост не
+ * обрезается: первый кусок идёт в подпись к фото (≤1024) или в первое сообщение (≤4096), остальное
+ * досылается отдельными сообщениями (≤4096). Текст поста — Telegram-HTML (см. {@link TelegramHtmlFormatter}),
+ * обложку заливаем файлом из S3 (см. {@link TelegramImageSource}). Итог отправки — явный статус, чтобы
+ * планировщик отличал «повторить» (временный сбой) от «сдаться» (перманентный отказ Telegram).
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class TelegramPublisher {
+
+    /** Лимиты Bot API: подпись к фото и обычное сообщение (в символах). */
+    private static final int CAPTION_LIMIT = 1024;
+    private static final int MESSAGE_LIMIT = 4096;
+
+    /** Итог одного вызова Bot API. */
+    private enum SendResult {
+        /** 2xx — отправлено. */
+        SENT,
+        /** 4xx (кроме 429) — запрос неверен навсегда (битая картинка/разметка/чат/«не изменено»): повтор бесполезен. */
+        REJECTED,
+        /** 429/5xx/сеть/таймаут — временно: имеет смысл повторить. */
+        TRANSIENT
+    }
+
+    /** Итог отправки нового поста (messageId — id ПЕРВОГО сообщения: фото/основного). */
+    public record PublishResult(Status status, Long messageId, boolean photo) {
+        public enum Status { POSTED, RETRY, GIVE_UP }
+
+        static PublishResult posted(Long messageId, boolean photo) {
+            return new PublishResult(Status.POSTED, messageId, photo);
+        }
+
+        static PublishResult retry() {
+            return new PublishResult(Status.RETRY, null, false);
+        }
+
+        static PublishResult giveUp() {
+            return new PublishResult(Status.GIVE_UP, null, false);
+        }
+    }
+
+    /** Итог синхронизации правки поста. */
+    public enum EditResult { SYNCED, RETRY, GIVE_UP }
+
+    private final RestClient telegramRestClient;
+    private final TelegramProperties properties;
+    private final TelegramHtmlFormatter formatter;
+    private final TelegramImageSource imageSource;
+
+    /**
+     * Отправляет новый пост в канал (при необходимости — несколькими сообщениями).
+     */
+    public PublishResult publish(Article article) {
+        if (!StringUtils.hasText(article.getTitle()) && !StringUtils.hasText(formatter.toPlain(description(article)))) {
+            log.warn("Пустой заголовок и текст — пропускаю отправку {} в Telegram", article.getUrl());
+            return PublishResult.giveUp();
+        }
+
+        boolean wantPhoto = StringUtils.hasText(article.getPreviewImageUrl());
+        List<String> messages = buildMessages(article, wantPhoto ? CAPTION_LIMIT : MESSAGE_LIMIT);
+
+        // Первое сообщение: фото с подписью либо текст.
+        SendOutcome first = null;
+        boolean photo = false;
+        if (wantPhoto) {
+            SendOutcome sent = trySendPhoto(article, messages.get(0));
+            if (sent != null) {
+                if (sent.result() == SendResult.SENT) {
+                    first = sent;
+                    photo = true;
+                } else if (sent.result() == SendResult.TRANSIENT) {
+                    // Временный сбой (фото/S3) — не теряем обложку, повторим весь пост.
+                    return PublishResult.retry();
+                } else {
+                    log.info("sendPhoto отклонён Telegram для {} — отправляю текстом", article.getUrl());
+                }
+            }
+        }
+        if (first == null) {
+            // Фото не отправляли (нет/отклонено) — текстом; лимит первого сообщения теперь 4096.
+            messages = buildMessages(article, MESSAGE_LIMIT);
+            first = send("sendMessage", messagePayload(messages.get(0)));
+        }
+
+        if (first.result() != SendResult.SENT) {
+            return first.result() == SendResult.TRANSIENT ? PublishResult.retry() : PublishResult.giveUp();
+        }
+        Long firstId = first.messageId();
+
+        // Хвост — отдельными сообщениями (best-effort: если не ушло, пост неполный, но не дублируем первое).
+        for (int i = 1; i < messages.size(); i++) {
+            if (send("sendMessage", messagePayload(messages.get(i))).result() != SendResult.SENT) {
+                log.warn("Не отправлено хвостовое сообщение {}/{} для {} — пост неполный",
+                        i, messages.size() - 1, article.getUrl());
+            }
+        }
+        return PublishResult.posted(firstId, photo);
+    }
+
+    /**
+     * Синхронизирует пост с обновлённой новостью: правит caption (если пост с фото) или text ПЕРВОГО
+     * сообщения на месте. Картинку в посте не трогаем — при смене обложки её меняют вручную. Хвостовые
+     * сообщения многочастного поста правка тоже не трогает (правится только первое).
+     */
+    public EditResult editPost(Article article) {
+        boolean photo = article.isTelegramPhoto();
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("chat_id", properties.getChatId());
+        payload.put("message_id", article.getTelegramMessageId());
+        payload.put(photo ? "caption" : "text",
+                buildMessages(article, photo ? CAPTION_LIMIT : MESSAGE_LIMIT).get(0));
+        payload.put("parse_mode", properties.getParseMode());
+
+        return switch (send(photo ? "editMessageCaption" : "editMessageText", payload).result()) {
+            case SENT -> EditResult.SYNCED;
+            case TRANSIENT -> EditResult.RETRY;
+            // 4xx: «message is not modified» (уже синхронно), пост удалён и т.п. — прекращаем попытки.
+            case REJECTED -> EditResult.GIVE_UP;
+        };
+    }
+
+    /** Удаляет пост из канала (для удалённой с сайта новости). */
+    public EditResult deletePost(Article article) {
+        return switch (send("deleteMessage", deletePayload(article.getTelegramMessageId())).result()) {
+            case SENT -> EditResult.SYNCED;
+            case TRANSIENT -> EditResult.RETRY;
+            // «message to delete not found» / нельзя удалить — считаем обработанным (больше не пытаемся).
+            case REJECTED -> EditResult.GIVE_UP;
+        };
+    }
+
+    private Map<String, Object> deletePayload(Long messageId) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("chat_id", properties.getChatId());
+        payload.put("message_id", messageId);
+        return payload;
+    }
+
+    /**
+     * Собирает список сообщений: первое включает жирный заголовок и первый кусок описания (≤ firstLimit),
+     * остальные — продолжение описания (≤ MESSAGE_LIMIT).
+     */
+    private List<String> buildMessages(Article article, int firstLimit) {
+        String title = nullToEmpty(article.getTitle());
+        String head = "<b>" + escape(title) + "</b>";
+        int firstBodyLimit = Math.max(0, firstLimit - title.length() - 2);
+        List<String> bodyChunks = formatter.toHtmlChunks(description(article), firstBodyLimit, MESSAGE_LIMIT);
+
+        List<String> messages = new ArrayList<>();
+        String firstBody = bodyChunks.isEmpty() ? "" : bodyChunks.get(0);
+        messages.add(StringUtils.hasText(firstBody) ? head + "\n\n" + firstBody : head);
+        for (int i = 1; i < bodyChunks.size(); i++) {
+            if (StringUtils.hasText(bodyChunks.get(i))) {
+                messages.add(bodyChunks.get(i));
+            }
+        }
+        return messages;
+    }
+
+    /**
+     * Пытается отправить первое сообщение с обложкой. Обложку из S3 заливаем файлом; для внешнего
+     * абсолютного URL отдаём ссылку. {@code null} — обложки нет (уходим в текст).
+     */
+    private SendOutcome trySendPhoto(Article article, String caption) {
+        String url = article.getPreviewImageUrl();
+        if (!StringUtils.hasText(url)) {
+            return null;
+        }
+        byte[] bytes = imageSource.bytes(url);
+        if (bytes != null) {
+            return sendPhotoBytes(bytes, imageSource.filename(url), caption);
+        }
+        if (url.startsWith("http://") || url.startsWith("https://")) {
+            return send("sendPhoto", photoUrlPayload(url, caption));
+        }
+        return null;
+    }
+
+    private SendOutcome sendPhotoBytes(byte[] image, String filename, String caption) {
+        MultipartBodyBuilder builder = new MultipartBodyBuilder();
+        builder.part("chat_id", properties.getChatId());
+        if (StringUtils.hasText(caption)) {
+            builder.part("caption", caption);
+            builder.part("parse_mode", properties.getParseMode());
+        }
+        builder.part("photo", new ByteArrayResource(image) {
+            @Override
+            public String getFilename() {
+                return filename;
+            }
+        });
+        return sendBody("sendPhoto", builder.build(), MediaType.MULTIPART_FORM_DATA);
+    }
+
+    private Map<String, Object> photoUrlPayload(String url, String caption) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("chat_id", properties.getChatId());
+        payload.put("photo", url);
+        payload.put("caption", caption);
+        payload.put("parse_mode", properties.getParseMode());
+        return payload;
+    }
+
+    private Map<String, Object> messagePayload(String text) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("chat_id", properties.getChatId());
+        payload.put("text", text);
+        payload.put("parse_mode", properties.getParseMode());
+        return payload;
+    }
+
+    private SendOutcome send(String method, Map<String, Object> payload) {
+        return sendBody(method, payload, MediaType.APPLICATION_JSON);
+    }
+
+    private SendOutcome sendBody(String method, Object body, MediaType contentType) {
+        try {
+            JsonNode response = telegramRestClient.post()
+                    // Токен — часть пути (…/bot<token>/method). В шаблон не оборачиваем,
+                    // чтобы ':' в токене не был percent-энкоднут.
+                    .uri("/bot" + properties.getBotToken() + "/" + method)
+                    .contentType(contentType)
+                    .body(body)
+                    .retrieve()
+                    .body(JsonNode.class);
+            Long messageId = response != null ? response.path("result").path("message_id").asLong() : null;
+            return new SendOutcome(SendResult.SENT, messageId);
+        } catch (RestClientResponseException ex) {
+            log.warn("Telegram {} вернул {}: {}", method, ex.getStatusCode(), ex.getResponseBodyAsString());
+            boolean retriable = ex.getStatusCode().value() == 429 || ex.getStatusCode().is5xxServerError();
+            return new SendOutcome(retriable ? SendResult.TRANSIENT : SendResult.REJECTED, null);
+        } catch (RestClientException ex) {
+            // Сеть/таймаут (в т.ч. потерянный ответ на уже доставленный запрос) — считаем временным.
+            log.warn("Не удалось вызвать Telegram {}: {}", method, ex.getMessage());
+            return new SendOutcome(SendResult.TRANSIENT, null);
+        }
+    }
+
+    /** Разметка описания: превью, если оно даёт непустой текст; иначе основной текст. */
+    private String description(Article article) {
+        return StringUtils.hasText(formatter.toPlain(article.getPreview()))
+                ? article.getPreview()
+                : article.getContent();
+    }
+
+    private static String nullToEmpty(String s) {
+        return s == null ? "" : s;
+    }
+
+    private static String escape(String s) {
+        if (s == null) {
+            return "";
+        }
+        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+    }
+
+    /** Итог вызова Bot API: результат и id сообщения (при успехе отправки). */
+    private record SendOutcome(SendResult result, Long messageId) {
+    }
+}

--- a/src/main/java/club/ttg/dnd5/domain/article/service/TelegramPublisher.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/service/TelegramPublisher.java
@@ -25,7 +25,7 @@ import java.util.Map;
  * Ничего не знает про БД и транзакции — только строит текст/пейлоад и делает HTTP-вызов. Длинный пост не
  * обрезается: первый кусок идёт в подпись к фото (≤1024) или в первое сообщение (≤4096), остальное
  * досылается отдельными сообщениями (≤4096). Текст поста — Telegram-HTML (см. {@link TelegramHtmlFormatter}),
- * обложку заливаем файлом из S3 (см. {@link TelegramImageSource}). Итог отправки — явный статус, чтобы
+ * обложку заливаем файлом из S3 (см. {@link ArticleImageSource}). Итог отправки — явный статус, чтобы
  * планировщик отличал «повторить» (временный сбой) от «сдаться» (перманентный отказ Telegram).
  */
 @Slf4j
@@ -70,7 +70,7 @@ public class TelegramPublisher {
     private final RestClient telegramRestClient;
     private final TelegramProperties properties;
     private final TelegramHtmlFormatter formatter;
-    private final TelegramImageSource imageSource;
+    private final ArticleImageSource imageSource;
 
     /**
      * Отправляет новый пост в канал (при необходимости — несколькими сообщениями).
@@ -256,7 +256,11 @@ public class TelegramPublisher {
             return new SendOutcome(retriable ? SendResult.TRANSIENT : SendResult.REJECTED, null);
         } catch (RestClientException ex) {
             // Сеть/таймаут (в т.ч. потерянный ответ на уже доставленный запрос) — считаем временным.
-            log.warn("Не удалось вызвать Telegram {}: {}", method, ex.getMessage());
+            // Логируем причину (IOException), а НЕ ex.getMessage(): RestClient вшивает в него полный URL
+            // запроса, а в пути — токен бота (…/bot<token>/…). Причина URL не содержит.
+            Throwable cause = ex.getCause();
+            log.warn("Не удалось вызвать Telegram {}: {}", method,
+                    cause != null ? cause.getMessage() : ex.getClass().getSimpleName());
             return new SendOutcome(SendResult.TRANSIENT, null);
         }
     }

--- a/src/main/java/club/ttg/dnd5/domain/article/service/VkPublisher.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/service/VkPublisher.java
@@ -1,0 +1,363 @@
+package club.ttg.dnd5.domain.article.service;
+
+import club.ttg.dnd5.config.properties.VkProperties;
+import club.ttg.dnd5.domain.article.model.Article;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+
+import java.net.URI;
+import java.util.Set;
+
+/**
+ * Отправляет и синхронизирует пост статьи / новости на стене сообщества ВКонтакте — через ключ доступа
+ * сообщества («API-ключ группы»), без бота.
+ * <p>
+ * Ничего не знает про БД и транзакции — только строит текст и делает HTTP-вызовы. Пост — обычный текст
+ * (VK не рендерит форматирование, см. {@link VkTextFormatter}): заголовок + текст, обложку заливаем на
+ * стену файлом из S3 (см. {@link ArticleImageSource}). В отличие от Telegram/Discord пост один (стена — это
+ * лента, дробить новость на несколько записей неуместно): очень длинный текст усекаем до лимита VK.
+ * <p>
+ * Пост уходит от имени сообщества ({@code wall.post}, {@code owner_id=-<groupId>}, {@code from_group=1});
+ * возвращённый {@code post_id} нужен для правки ({@code wall.edit}) и удаления ({@code wall.delete}).
+ * <p>
+ * Особенность VK: сервер отвечает HTTP 200 даже на ошибку — она лежит в теле в {@code error.error_code}.
+ * Часть кодов временные (повторить), часть — перманентные (сдаться), чтобы планировщик не долбил стену.
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class VkPublisher {
+
+    /** Практический лимит длины текста поста на стене VK (символы). Реальный предел ~16384 — берём с запасом. */
+    private static final int MESSAGE_LIMIT = 16000;
+
+    /** Коды ошибок VK, при которых имеет смысл повторить (временные). Остальное — перманентный отказ. */
+    private static final Set<Integer> TRANSIENT_ERROR_CODES = Set.of(
+            1,  // Unknown error occurred — VK рекомендует повторить позже
+            6,  // Too many requests per second
+            9,  // Flood control
+            10, // Internal server error
+            14  // Captcha needed (для серверного постинга редкость; повторим позже)
+    );
+
+    /** Итог одного вызова VK API. */
+    private enum SendResult {
+        /** Успех (в теле есть {@code response} и нет {@code error}). */
+        SENT,
+        /** Перманентный отказ VK (битые параметры / нет доступа / неверный токен) — повтор бесполезен. */
+        REJECTED,
+        /** Временный сбой (retryable error_code / 429 / 5xx / сеть / таймаут) — имеет смысл повторить. */
+        TRANSIENT
+    }
+
+    /** Итог отправки нового поста. */
+    public record PublishResult(Status status, Long postId, String attachment) {
+        public enum Status { POSTED, RETRY, GIVE_UP }
+
+        static PublishResult posted(Long postId, String attachment) {
+            return new PublishResult(Status.POSTED, postId, attachment);
+        }
+
+        static PublishResult retry() {
+            return new PublishResult(Status.RETRY, null, null);
+        }
+
+        static PublishResult giveUp() {
+            return new PublishResult(Status.GIVE_UP, null, null);
+        }
+    }
+
+    /** Итог синхронизации правки / удаления поста. */
+    public enum EditResult { SYNCED, RETRY, GIVE_UP }
+
+    private final RestClient vkRestClient;
+    private final VkProperties properties;
+    private final VkTextFormatter formatter;
+    private final ArticleImageSource imageSource;
+
+    /**
+     * Отправляет новый пост на стену сообщества (одной записью). Обложка — best-effort: если её не удалось
+     * залить по перманентной причине (напр. групповой токен не имеет доступа к загрузке фото — ошибка 27),
+     * пост уходит текстом.
+     */
+    public PublishResult publish(Article article) {
+        String message = buildMessage(article);
+        if (!StringUtils.hasText(message)) {
+            log.warn("Пустой заголовок и текст — пропускаю отправку {} в VK", article.getUrl());
+            return PublishResult.giveUp();
+        }
+
+        Cover cover = uploadCover(article);
+        if (cover.retryNeeded()) {
+            // Временный сбой загрузки обложки/чтения из S3 — не теряем обложку, повторим весь пост.
+            return PublishResult.retry();
+        }
+        String attachment = cover.attachment();
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("owner_id", ownerId());
+        params.add("from_group", "1");
+        params.add("message", message);
+        if (attachment != null) {
+            params.add("attachments", attachment);
+        }
+        ApiOutcome outcome = callMethod("wall.post", params);
+        return switch (outcome.result()) {
+            case SENT -> {
+                Long postId = postId(outcome.response());
+                if (postId == null) {
+                    // Успех без post_id (не должно случаться) — пост опубликован, но править/удалять его
+                    // мы уже не сможем. Помечаем отправленным (без id), чтобы не запостить повторно.
+                    log.warn("VK не вернул post_id для {} — правка/удаление поста будут недоступны", article.getUrl());
+                }
+                yield PublishResult.posted(postId, attachment);
+            }
+            case TRANSIENT -> PublishResult.retry();
+            case REJECTED -> PublishResult.giveUp();
+        };
+    }
+
+    /**
+     * Синхронизирует пост с обновлённой новостью: правит текст на месте ({@code wall.edit}). Сохранённую
+     * строку вложения (обложку) пере-передаём, потому что {@code wall.edit} без {@code attachments} может
+     * очистить вложения — так фото остаётся на месте. Текстовый пост правим без {@code attachments}.
+     */
+    public EditResult editPost(Article article) {
+        String message = buildMessage(article);
+        if (!StringUtils.hasText(message)) {
+            // Правка сделала запись пустой — корректной альтернативы нет: прекращаем попытки (флаг снимет поллер).
+            return EditResult.GIVE_UP;
+        }
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("owner_id", ownerId());
+        params.add("post_id", String.valueOf(article.getVkPostId()));
+        params.add("message", message);
+        if (StringUtils.hasText(article.getVkAttachment())) {
+            params.add("attachments", article.getVkAttachment());
+        }
+        return switch (callMethod("wall.edit", params).result()) {
+            case SENT -> EditResult.SYNCED;
+            case TRANSIENT -> EditResult.RETRY;
+            // Пост удалён/нельзя изменить — прекращаем попытки.
+            case REJECTED -> EditResult.GIVE_UP;
+        };
+    }
+
+    /** Удаляет пост со стены (для удалённой с сайта новости). */
+    public EditResult deletePost(Article article) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("owner_id", ownerId());
+        params.add("post_id", String.valueOf(article.getVkPostId()));
+        return switch (callMethod("wall.delete", params).result()) {
+            case SENT -> EditResult.SYNCED;
+            case TRANSIENT -> EditResult.RETRY;
+            // Поста уже нет / нельзя удалить — считаем обработанным (больше не пытаемся).
+            case REJECTED -> EditResult.GIVE_UP;
+        };
+    }
+
+    /** Собирает текст поста: заголовок + текст описания, усечённые до лимита VK. */
+    private String buildMessage(Article article) {
+        String title = article.getTitle() == null ? "" : article.getTitle().strip();
+        String body = formatter.toText(description(article));
+        String combined;
+        if (StringUtils.hasText(title)) {
+            combined = StringUtils.hasText(body) ? title + "\n\n" + body : title;
+        } else {
+            combined = body;
+        }
+        return truncate(combined, MESSAGE_LIMIT);
+    }
+
+    /**
+     * Заливает обложку на стену сообщества (3 шага VK: {@code photos.getWallUploadServer} → загрузка файла →
+     * {@code photos.saveWallPhoto}) и возвращает строку вложения {@code photo<owner_id>_<id>}. Best-effort:
+     * нет картинки или перманентный отказ VK (напр. ошибка 27 для группового токена) → {@link Cover#none()}
+     * (пост уйдёт текстом); временный сбой → {@link Cover#retry()} (повторить весь пост).
+     */
+    private Cover uploadCover(Article article) {
+        if (!StringUtils.hasText(article.getPreviewImageUrl())) {
+            return Cover.none();
+        }
+        // Байты обложки из S3: null — картинки нет; временный сбой чтения пробрасывается наружу
+        // (планировщик освободит запись и повторит).
+        byte[] bytes = imageSource.bytes(article.getPreviewImageUrl());
+        if (bytes == null) {
+            return Cover.none();
+        }
+
+        MultiValueMap<String, String> serverParams = new LinkedMultiValueMap<>();
+        serverParams.add("group_id", properties.getGroupId());
+        ApiOutcome server = callMethod("photos.getWallUploadServer", serverParams);
+        if (server.result() == SendResult.TRANSIENT) {
+            return Cover.retry();
+        }
+        if (server.result() == SendResult.REJECTED) {
+            log.info("VK отказал в загрузке обложки для {} — отправляю текстом", article.getUrl());
+            return Cover.none();
+        }
+        String uploadUrl = server.response() != null ? server.response().path("upload_url").asText(null) : null;
+        if (!StringUtils.hasText(uploadUrl)) {
+            return Cover.none();
+        }
+
+        ApiOutcome uploaded = uploadFile(uploadUrl, bytes, imageSource.filename(article.getPreviewImageUrl()));
+        if (uploaded.result() == SendResult.TRANSIENT) {
+            return Cover.retry();
+        }
+        if (uploaded.result() == SendResult.REJECTED || uploaded.response() == null) {
+            return Cover.none();
+        }
+        String photo = uploaded.response().path("photo").asText("");
+        // Пустой photo (или "[]") — VK не принял файл: постим без обложки.
+        if (!StringUtils.hasText(photo) || "[]".equals(photo)) {
+            return Cover.none();
+        }
+
+        MultiValueMap<String, String> saveParams = new LinkedMultiValueMap<>();
+        saveParams.add("group_id", properties.getGroupId());
+        saveParams.add("server", String.valueOf(uploaded.response().path("server").asInt()));
+        saveParams.add("photo", photo);
+        saveParams.add("hash", uploaded.response().path("hash").asText(""));
+        ApiOutcome saved = callMethod("photos.saveWallPhoto", saveParams);
+        if (saved.result() == SendResult.TRANSIENT) {
+            return Cover.retry();
+        }
+        JsonNode arr = saved.response();
+        if (saved.result() == SendResult.REJECTED || arr == null || !arr.isArray() || arr.isEmpty()) {
+            return Cover.none();
+        }
+        JsonNode photoObj = arr.get(0);
+        // owner_id для группы уже отрицательный → вложение вида photo-<groupId>_<id>.
+        long ownerId = photoObj.path("owner_id").asLong();
+        long id = photoObj.path("id").asLong();
+        return Cover.of("photo" + ownerId + "_" + id);
+    }
+
+    /** Вызов метода VK API: POST form-urlencoded, добавляет {@code access_token} и {@code v}, разбирает ошибку. */
+    private ApiOutcome callMethod(String method, MultiValueMap<String, String> params) {
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>(params);
+        form.add("access_token", properties.getAccessToken());
+        form.add("v", properties.getApiVersion());
+        URI uri = URI.create(properties.getApiUrl() + "/" + method);
+        try {
+            JsonNode json = vkRestClient.post().uri(uri)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(form)
+                    .retrieve()
+                    .body(JsonNode.class);
+            if (json != null && json.has("error")) {
+                JsonNode error = json.get("error");
+                int code = error.path("error_code").asInt();
+                log.warn("VK {} вернул ошибку {}: {}", method, code, error.path("error_msg").asText());
+                return new ApiOutcome(
+                        TRANSIENT_ERROR_CODES.contains(code) ? SendResult.TRANSIENT : SendResult.REJECTED, null);
+            }
+            return new ApiOutcome(SendResult.SENT, json != null ? json.get("response") : null);
+        } catch (RestClientResponseException ex) {
+            log.warn("VK {} HTTP {}: {}", method, ex.getStatusCode(), ex.getResponseBodyAsString());
+            boolean retriable = ex.getStatusCode().value() == 429 || ex.getStatusCode().is5xxServerError();
+            return new ApiOutcome(retriable ? SendResult.TRANSIENT : SendResult.REJECTED, null);
+        } catch (RestClientException ex) {
+            // Сеть/таймаут — временный сбой. Логируем причину, а не ex.getMessage() (в него RestClient
+            // вшивает URL запроса — на всякий случай не тащим его в лог).
+            Throwable cause = ex.getCause();
+            log.warn("Не удалось вызвать VK {}: {}", method,
+                    cause != null ? cause.getMessage() : ex.getClass().getSimpleName());
+            return new ApiOutcome(SendResult.TRANSIENT, null);
+        }
+    }
+
+    /** Загрузка файла обложки на выданный VK upload-сервер (multipart, поле {@code photo}). */
+    private ApiOutcome uploadFile(String uploadUrl, byte[] bytes, String filename) {
+        MultipartBodyBuilder builder = new MultipartBodyBuilder();
+        builder.part("photo", new ByteArrayResource(bytes) {
+            @Override
+            public String getFilename() {
+                return filename;
+            }
+        });
+        try {
+            JsonNode json = vkRestClient.post().uri(URI.create(uploadUrl))
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .body(builder.build())
+                    .retrieve()
+                    .body(JsonNode.class);
+            return new ApiOutcome(SendResult.SENT, json);
+        } catch (RestClientResponseException ex) {
+            log.warn("VK upload обложки HTTP {}", ex.getStatusCode());
+            boolean retriable = ex.getStatusCode().value() == 429 || ex.getStatusCode().is5xxServerError();
+            return new ApiOutcome(retriable ? SendResult.TRANSIENT : SendResult.REJECTED, null);
+        } catch (RestClientException ex) {
+            Throwable cause = ex.getCause();
+            log.warn("Не удалось загрузить обложку в VK: {}",
+                    cause != null ? cause.getMessage() : ex.getClass().getSimpleName());
+            return new ApiOutcome(SendResult.TRANSIENT, null);
+        }
+    }
+
+    /** {@code post_id} из ответа wall.post; {@code null}, если его нет (или 0 — недопустимый id). */
+    private static Long postId(JsonNode response) {
+        if (response == null) {
+            return null;
+        }
+        long id = response.path("post_id").asLong(0);
+        return id == 0 ? null : id;
+    }
+
+    private String ownerId() {
+        return "-" + properties.getGroupId();
+    }
+
+    /** Разметка описания: превью, если оно даёт непустой текст; иначе основной текст. */
+    private String description(Article article) {
+        return StringUtils.hasText(formatter.toText(article.getPreview()))
+                ? article.getPreview()
+                : article.getContent();
+    }
+
+    /** Усекает текст до {@code limit} символов по границе слова (плюс «…»), не разрывая суррогатную пару. */
+    private static String truncate(String text, int limit) {
+        if (text.length() <= limit) {
+            return text;
+        }
+        int cut = text.lastIndexOf(' ', limit - 1);
+        if (cut <= 0) {
+            cut = limit - 1;
+        }
+        if (Character.isHighSurrogate(text.charAt(cut - 1))) {
+            cut--;
+        }
+        return text.substring(0, cut).stripTrailing() + "…";
+    }
+
+    /** Итог загрузки обложки: {@code retryNeeded} — повторить весь пост; иначе строка вложения ({@code null} — без обложки). */
+    private record Cover(boolean retryNeeded, String attachment) {
+        static Cover retry() {
+            return new Cover(true, null);
+        }
+
+        static Cover none() {
+            return new Cover(false, null);
+        }
+
+        static Cover of(String attachment) {
+            return new Cover(false, attachment);
+        }
+    }
+
+    /** Итог вызова VK API: результат и полезная нагрузка ({@code response} для методов, тело — для загрузки). */
+    private record ApiOutcome(SendResult result, JsonNode response) {
+    }
+}

--- a/src/main/java/club/ttg/dnd5/domain/article/service/VkTextFormatter.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/service/VkTextFormatter.java
@@ -1,0 +1,303 @@
+package club.ttg.dnd5.domain.article.service;
+
+import club.ttg.dnd5.domain.vttg.service.VttgMarkupConverter;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Приводит разметку статьи/новости к плоскому тексту для стены ВКонтакте.
+ * <p>
+ * Пост на стене VK — это обычный текст без форматирования: жирный/курсив/подчёркивание VK в постах не
+ * рендерит, поэтому все markdown-маркеры и теги {@code {@..}} снимаются, оставляя только содержимое.
+ * Контент хранится массивом блоков (строки-абзацы и узлы-объекты: цитата/заголовок/разделитель);
+ * {@link VttgMarkupConverter#toText} разворачивает блок в промежуточный markdown-подобный текст, из которого
+ * мы убираем {@code **}/{@code *} и раскрываем ссылки.
+ * <p>
+ * Ссылки: внешние URL VK не умеет «маскировать» (подмена текста ссылкой работает только для внутренних
+ * vk.com-ссылок), зато любой сырой URL в тексте VK делает кликабельным автоматически. Поэтому ссылку
+ * рендерим как {@code метка (url)} (или просто {@code url}, если метки нет). Внутренние ссылки на разделы
+ * сайта достраиваются до абсолютного URL.
+ */
+@RequiredArgsConstructor
+@Component
+public class VkTextFormatter {
+
+    /** Вид блока контента. */
+    private enum Kind { NORMAL, QUOTE, HEADING, SEPARATOR }
+
+    /** Типы блочных узлов (алиасы фронтового диалекта). */
+    private static final Set<String> QUOTE_TYPES = Set.of("quote", "blockquote", "q");
+    private static final Set<String> HEADING_TYPES = Set.of("heading", "h");
+    private static final Set<String> SEPARATOR_TYPES = Set.of("separator", "hr");
+    /** Разделитель (в VK нет горизонтальной черты). */
+    private static final String DIVIDER = "———";
+
+    private static final Pattern MD_BOLD = Pattern.compile("\\*\\*(.+?)\\*\\*", Pattern.DOTALL);
+    private static final Pattern MD_ITALIC = Pattern.compile("\\*(.+?)\\*", Pattern.DOTALL);
+    private static final Pattern MD_LINK = Pattern.compile("\\[([^\\]]+)]\\(([^)]+)\\)");
+    /** Самый внутренний тег {@code {@name content}} (content без вложенных фигурных скобок; может быть пустым). */
+    private static final Pattern TAG = Pattern.compile("\\{@(\\w+)\\s*([^{}]*)}");
+    private static final int MAX_NESTING = 8;
+
+    /** Инлайн-маркер {@code {@type тело}} (тело без вложенных фигурных скобок). */
+    private static final Pattern MARKER = Pattern.compile("\\{@([\\w-]+)\\s+([^{}]*)}");
+    /** Тип ссылки-раздела → путь раздела на сайте (по фронтовой MARKER_URL_MAP). */
+    private static final Map<String, String> SECTION_PATHS = Map.ofEntries(
+            Map.entry("class", "classes"), Map.entry("spell", "spells"), Map.entry("feat", "feats"),
+            Map.entry("background", "backgrounds"), Map.entry("magicItem", "magic-items"),
+            Map.entry("magic-item", "magic-items"), Map.entry("item", "items"),
+            Map.entry("creature", "bestiary"), Map.entry("bestiary", "bestiary"),
+            Map.entry("glossary", "glossary"));
+    /** Обычная (внешняя/произвольная) ссылка. */
+    private static final Set<String> LINK_TYPES = Set.of("link", "a");
+
+    private final VttgMarkupConverter markupConverter;
+    private final ObjectMapper objectMapper;
+
+    @Value("${app.url:https://ttg.club}")
+    private String appUrl;
+
+    /**
+     * Разметка → плоский текст для стены VK: блоки (абзац / цитата / заголовок / разделитель) склеены
+     * пустой строкой. Пустой результат ({@code ""}) означает, что постить нечего.
+     */
+    public String toText(String markup) {
+        StringBuilder sb = new StringBuilder();
+        for (String block : render(markup)) {
+            if (sb.length() > 0) {
+                sb.append("\n\n");
+            }
+            sb.append(block);
+        }
+        return sb.toString();
+    }
+
+    private List<String> render(String markup) {
+        List<String> out = new ArrayList<>();
+        for (Block block : blocks(markup)) {
+            if (block.kind() == Kind.SEPARATOR) {
+                out.add(DIVIDER);
+                continue;
+            }
+            String text = clean(markupConverter.toText(preprocessLinks(block.markup())));
+            if (text.isEmpty()) {
+                continue;
+            }
+            String plain = plainFrom(text);
+            // Заголовок VK ничем не выделить (нет форматирования) — остаётся отдельным абзацем; цитата —
+            // с префиксом «» » к каждой строке (единственный доступный в плоском тексте маркер цитаты).
+            out.add(block.kind() == Kind.QUOTE ? quote(plain) : plain);
+        }
+        return out;
+    }
+
+    /** Оборачивает блок в цитату: префикс {@code » } к каждой строке (в т.ч. пустой). */
+    private static String quote(String text) {
+        String[] lines = text.split("\n", -1);
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < lines.length; i++) {
+            if (i > 0) {
+                sb.append('\n');
+            }
+            sb.append("» ").append(lines[i]);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * markdown-подобный текст блока → плоский текст VK: раскрываем ссылки в {@code метка (url)}, снимаем
+     * {@code **}/{@code *} и литеральные теги {@code {@..}} (оставляя содержимое).
+     * <p>
+     * Ссылки вырезаем в плейсхолдеры ДО снятия эмфазиса и возвращаем ПОСЛЕ: иначе {@code *} внутри URL
+     * (напр. {@code .../a*b*c}) попал бы под {@link #MD_ITALIC} и адрес бы испортился. Из метки эмфазис
+     * снимаем (VK его всё равно не рендерит), URL оставляем как есть.
+     */
+    private String plainFrom(String text) {
+        List<String> links = new ArrayList<>();
+        Matcher link = MD_LINK.matcher(text);
+        StringBuilder masked = new StringBuilder();
+        while (link.find()) {
+            String label = stripEmphasis(link.group(1).trim());
+            String url = link.group(2).trim();
+            links.add((label.isEmpty() || label.equals(url)) ? url : label + " (" + url + ")");
+            // Плейсхолдер без markdown-метасимволов — переживёт снятие эмфазиса нетронутым (\0 в тексте не встречается).
+            link.appendReplacement(masked, Matcher.quoteReplacement("\u0000" + (links.size() - 1) + "\u0000"));
+        }
+        link.appendTail(masked);
+
+        String result = stripTags(stripEmphasis(masked.toString()));
+        for (int i = 0; i < links.size(); i++) {
+            result = result.replace("\u0000" + i + "\u0000", links.get(i));
+        }
+        return result;
+    }
+
+    /** Снимает markdown-эмфазис {@code **жирный**}/{@code *курсив*} (VK его не рендерит), оставляя содержимое. */
+    private static String stripEmphasis(String text) {
+        text = MD_BOLD.matcher(text).replaceAll("$1");
+        text = MD_ITALIC.matcher(text).replaceAll("$1");
+        return text;
+    }
+
+    /** Снимает литеральные теги {@code {@name ...}}, оставляя их содержимое; раскрывает вложенность изнутри наружу. */
+    private String stripTags(String text) {
+        for (int pass = 0; pass < MAX_NESTING && text.indexOf("{@") >= 0; pass++) {
+            Matcher matcher = TAG.matcher(text);
+            if (!matcher.find()) {
+                break;
+            }
+            matcher.reset();
+            StringBuilder result = new StringBuilder();
+            while (matcher.find()) {
+                matcher.appendReplacement(result, Matcher.quoteReplacement(matcher.group(2)));
+            }
+            matcher.appendTail(result);
+            text = result.toString();
+        }
+        return text;
+    }
+
+    /**
+     * Пред-обработка ДО {@link VttgMarkupConverter#toText}: маркеры-ссылки {@code {@type label | url:...}}
+     * → markdown {@code [label](абсолютный url)}. Нужна потому, что toText теряет ссылки: у обычного
+     * {@code {@link}} выкидывает url, а секции со спейсовым {@code | url:} не распознаёт. Остальные маркеры
+     * ({@code {@b}}/{@code {@u}}/…) не трогаем — их снимет {@link #stripTags}.
+     */
+    private String preprocessLinks(String markup) {
+        if (markup == null || markup.indexOf("{@") < 0) {
+            return markup;
+        }
+        Matcher matcher = MARKER.matcher(markup);
+        StringBuilder result = new StringBuilder();
+        while (matcher.find()) {
+            String href = href(matcher.group(1), matcher.group(2));
+            String replacement = href != null
+                    ? "[" + label(matcher.group(2)) + "](" + href + ")"
+                    : matcher.group();
+            matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(result);
+        return result.toString();
+    }
+
+    /** Абсолютный href для маркера-ссылки; {@code null}, если это не ссылка (нет url или не тот тип). */
+    private String href(String type, String body) {
+        int pipe = body.indexOf('|');
+        if (pipe < 0) {
+            return null;
+        }
+        String attrs = body.substring(pipe + 1);
+        String url = attr(attrs, "url");
+        if (url == null) {
+            url = attr(attrs, "href");
+        }
+        if (url == null) {
+            return null;
+        }
+        if (LINK_TYPES.contains(type)) {
+            // Обычная ссылка: абсолютную оставляем, относительный роут сайта достраиваем.
+            return url.startsWith("http://") || url.startsWith("https://")
+                    ? url
+                    : site() + (url.startsWith("/") ? url : "/" + url);
+        }
+        String section = SECTION_PATHS.get(type);
+        return section != null ? site() + "/" + section + "/" + url : null;
+    }
+
+    private static String label(String body) {
+        int pipe = body.indexOf('|');
+        return (pipe < 0 ? body : body.substring(0, pipe)).trim();
+    }
+
+    private static String attr(String attrs, String key) {
+        for (String part : attrs.split("\\|")) {
+            String trimmed = part.trim();
+            if (trimmed.startsWith(key + ":")) {
+                return trimmed.substring(key.length() + 1).trim();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * База для абсолютных ссылок на разделы сайта. Ссылки идут в публичное сообщество, поэтому нужен
+     * полноценный публичный URL: если {@code app.url} без схемы или localhost (локальная разработка) —
+     * ведём на боевой сайт (иначе относительный href будет неполноценным).
+     */
+    private String site() {
+        String url = appUrl == null ? "" : appUrl.trim();
+        boolean usable = (url.startsWith("http://") || url.startsWith("https://")) && !url.contains("localhost");
+        if (!usable) {
+            url = "https://ttg.club";
+        }
+        return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+    }
+
+    /** Блок контента: исходная разметка блока и его вид. */
+    private record Block(String markup, Kind kind) {
+    }
+
+    /**
+     * Разбивает контент на блоки. Хранимая форма — JSON-массив: строки-абзацы и узлы-объекты
+     * (цитата/заголовок/разделитель — по {@code type}). Не-массив (обычная строка) — один блок.
+     */
+    private List<Block> blocks(String markup) {
+        if (!StringUtils.hasText(markup)) {
+            return List.of();
+        }
+        try {
+            JsonNode root = objectMapper.readTree(markup);
+            if (root.isArray()) {
+                List<Block> list = new ArrayList<>();
+                for (JsonNode element : root) {
+                    list.add(new Block(element.toString(), kindOf(element)));
+                }
+                return list;
+            }
+        } catch (Exception ignored) {
+            // Не JSON — обычная строка-разметка, обрабатываем одним блоком.
+        }
+        return List.of(new Block(markup, Kind.NORMAL));
+    }
+
+    private static Kind kindOf(JsonNode element) {
+        if (!element.isObject()) {
+            return Kind.NORMAL;
+        }
+        String type = element.path("type").asText();
+        if (QUOTE_TYPES.contains(type)) {
+            return Kind.QUOTE;
+        }
+        if (HEADING_TYPES.contains(type)) {
+            return Kind.HEADING;
+        }
+        if (SEPARATOR_TYPES.contains(type)) {
+            return Kind.SEPARATOR;
+        }
+        return Kind.NORMAL;
+    }
+
+    /** Нормализует результат toText: {@code <br>} → перевод строки; сырую JSON-разметку считаем пустой. */
+    private String clean(String text) {
+        if (!StringUtils.hasText(text)) {
+            return "";
+        }
+        text = text.replace("<br>", "\n").strip();
+        return looksLikeJson(text) ? "" : text;
+    }
+
+    private static boolean looksLikeJson(String s) {
+        return (s.startsWith("{") && s.endsWith("}")) || (s.startsWith("[") && s.endsWith("]"));
+    }
+}

--- a/src/main/java/club/ttg/dnd5/domain/common/model/SectionType.java
+++ b/src/main/java/club/ttg/dnd5/domain/common/model/SectionType.java
@@ -18,6 +18,7 @@ public enum SectionType {
     GLOSSARY("glossary"),
     CLASS("classes"),
     SOURCE("sources"),
+    ARTICLE("articles"),
     TOKEN_BORDER("tokenator/border");
 
     @JsonValue

--- a/src/main/java/club/ttg/dnd5/domain/common/rest/controller/DictionariesController.java
+++ b/src/main/java/club/ttg/dnd5/domain/common/rest/controller/DictionariesController.java
@@ -784,6 +784,23 @@ public class DictionariesController {
         return dictionariesService.getSourceTypes();
     }
 
+    @Operation(summary = "Типы статей / новостей")
+    @GetMapping("/article/types")
+    @ApiResponse(
+            responseCode = "200",
+            content = @Content(mediaType = "application/json",
+                    examples = @ExampleObject("""
+                            [
+                              { "label": "Новость", "value": "NEWS" },
+                              { "label": "Статья", "value": "ARTICLE" }
+                            ]
+                            """)
+            )
+    )
+    public Collection<SelectOptionDto> getArticleTypes() {
+        return dictionariesService.getArticleTypes();
+    }
+
     @Operation(summary = "Типы нотификаций")
     @GetMapping("/notification/types")
     @ApiResponse(

--- a/src/main/java/club/ttg/dnd5/domain/common/service/DictionariesService.java
+++ b/src/main/java/club/ttg/dnd5/domain/common/service/DictionariesService.java
@@ -1,5 +1,6 @@
 package club.ttg.dnd5.domain.common.service;
 
+import club.ttg.dnd5.domain.article.model.ArticleType;
 import club.ttg.dnd5.domain.beastiary.model.action.AttackType;
 import club.ttg.dnd5.domain.character_class.model.CasterType;
 import club.ttg.dnd5.domain.common.dictionary.*;
@@ -83,6 +84,12 @@ public class DictionariesService {
                 .label(label)
                 .value(value)
                 .build();
+    }
+
+    public Collection<SelectOptionDto> getArticleTypes() {
+        return Arrays.stream(ArticleType.values())
+                .map(type -> createBaseOptionDTO(type.getName(), type.name()))
+                .collect(Collectors.toList());
     }
 
     public Collection<DiceOptionDto> getDices() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -66,6 +66,13 @@ telegram.api-url=${TELEGRAM_API_URL:https://api.telegram.org}
 # Период опроса «пора постить» (ISO-8601 duration).
 telegram.poll-interval=${TELEGRAM_POLL_INTERVAL:PT1M}
 
+# Discord (автопубликация статей / новостей в канал через входящий вебхук). Секрет — из окружения:
+# в Dokploy через переменную окружения сервиса, локально — в local.env.
+# Интеграция включена, когда задан webhook-url; иначе ничего не отправляется.
+discord.webhook-url=${DISCORD_WEBHOOK_URL:}
+# Период опроса «пора постить» (ISO-8601 duration).
+discord.poll-interval=${DISCORD_POLL_INTERVAL:PT1M}
+
 # JPA
 spring.jpa.generate-ddl=false
 spring.jpa.hibernate.ddl-auto=validate

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -73,6 +73,16 @@ discord.webhook-url=${DISCORD_WEBHOOK_URL:}
 # Период опроса «пора постить» (ISO-8601 duration).
 discord.poll-interval=${DISCORD_POLL_INTERVAL:PT1M}
 
+# VK (автопубликация статей / новостей на стену сообщества через ключ доступа сообщества, без бота).
+# Секреты — из окружения: в Dokploy через переменные окружения сервиса, локально — в local.env.
+# Интеграция включена, когда заданы access-token и group-id; иначе ничего не отправляется.
+vk.access-token=${VK_ACCESS_TOKEN:}
+vk.group-id=${VK_GROUP_ID:}
+vk.api-url=${VK_API_URL:https://api.vk.com/method}
+vk.api-version=${VK_API_VERSION:5.199}
+# Период опроса «пора постить» (ISO-8601 duration).
+vk.poll-interval=${VK_POLL_INTERVAL:PT1M}
+
 # JPA
 spring.jpa.generate-ddl=false
 spring.jpa.hibernate.ddl-auto=validate

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -57,6 +57,15 @@ subscriber-service.base-url=${SUBSCRIBER_API_URL:http://localhost:8093}
 # Общий секрет межсервисных вызовов (внутренние ручки + клиент subscriber-service)
 internal.service-secret=${INTERNAL_SERVICE_SECRET:}
 
+# Telegram (автопубликация статей / новостей в канал). Секреты — из окружения:
+# в Dokploy через переменные окружения сервиса, локально — в local.env.
+# Интеграция включена, когда заданы bot-token и chat-id; иначе ничего не отправляется.
+telegram.bot-token=${TELEGRAM_BOT_TOKEN:}
+telegram.chat-id=${TELEGRAM_CHAT_ID:}
+telegram.api-url=${TELEGRAM_API_URL:https://api.telegram.org}
+# Период опроса «пора постить» (ISO-8601 duration).
+telegram.poll-interval=${TELEGRAM_POLL_INTERVAL:PT1M}
+
 # JPA
 spring.jpa.generate-ddl=false
 spring.jpa.hibernate.ddl-auto=validate

--- a/src/main/resources/db/changelog/2026/07/06-01-article-type-and-deleted.yaml
+++ b/src/main/resources/db/changelog/2026/07/06-01-article-type-and-deleted.yaml
@@ -1,0 +1,43 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-06-01-add-type-to-article
+      author: Peterko
+      changes:
+        - addColumn:
+            tableName: article
+            columns:
+              - column:
+                  name: type
+                  type: VARCHAR(255)
+        - update:
+            tableName: article
+            columns:
+              - column:
+                  name: type
+                  value: NEWS
+            where: type IS NULL
+        - addNotNullConstraint:
+            tableName: article
+            columnName: type
+            columnDataType: VARCHAR(255)
+  - changeSet:
+      id: 2026-07-06-02-harden-article-deleted
+      author: Peterko
+      changes:
+        - update:
+            tableName: article
+            columns:
+              - column:
+                  name: deleted
+                  valueBoolean: false
+            where: deleted IS NULL
+        - addDefaultValue:
+            tableName: article
+            columnName: deleted
+            columnDataType: BOOLEAN
+            defaultValueBoolean: false
+        - addNotNullConstraint:
+            tableName: article
+            columnName: deleted
+            columnDataType: BOOLEAN
+            defaultNullValue: false

--- a/src/main/resources/db/changelog/2026/07/06-02-add-draft-to-article.yaml
+++ b/src/main/resources/db/changelog/2026/07/06-02-add-draft-to-article.yaml
@@ -1,0 +1,24 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-06-03-add-draft-to-article
+      author: Peterko
+      changes:
+        - addColumn:
+            tableName: article
+            columns:
+              - column:
+                  name: draft
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+        - update:
+            tableName: article
+            columns:
+              - column:
+                  name: draft
+                  valueBoolean: false
+            where: draft IS NULL
+        - addNotNullConstraint:
+            tableName: article
+            columnName: draft
+            columnDataType: BOOLEAN
+            defaultNullValue: false

--- a/src/main/resources/db/changelog/2026/07/07-01-add-accessible-by-link-to-article.yaml
+++ b/src/main/resources/db/changelog/2026/07/07-01-add-accessible-by-link-to-article.yaml
@@ -1,0 +1,24 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-07-01-add-accessible-by-link-to-article
+      author: Peterko
+      changes:
+        - addColumn:
+            tableName: article
+            columns:
+              - column:
+                  name: accessible_by_link
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+        - update:
+            tableName: article
+            columns:
+              - column:
+                  name: accessible_by_link
+                  valueBoolean: false
+            where: accessible_by_link IS NULL
+        - addNotNullConstraint:
+            tableName: article
+            columnName: accessible_by_link
+            columnDataType: BOOLEAN
+            defaultNullValue: false

--- a/src/main/resources/db/changelog/2026/07/07-02-add-active-to-article.yaml
+++ b/src/main/resources/db/changelog/2026/07/07-02-add-active-to-article.yaml
@@ -1,0 +1,32 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-07-02-add-active-to-article
+      author: Peterko
+      changes:
+        - addColumn:
+            tableName: article
+            columns:
+              - column:
+                  name: active
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+        # Существующие опубликованные (не черновики) записи считаем активными.
+        - update:
+            tableName: article
+            columns:
+              - column:
+                  name: active
+                  valueBoolean: true
+            where: draft = false
+        - update:
+            tableName: article
+            columns:
+              - column:
+                  name: active
+                  valueBoolean: false
+            where: active IS NULL
+        - addNotNullConstraint:
+            tableName: article
+            columnName: active
+            columnDataType: BOOLEAN
+            defaultNullValue: false

--- a/src/main/resources/db/changelog/2026/07/08-01-add-telegram-posted-at-to-article.yaml
+++ b/src/main/resources/db/changelog/2026/07/08-01-add-telegram-posted-at-to-article.yaml
@@ -1,0 +1,23 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-08-01-add-telegram-posted-at-to-article
+      author: Peterko
+      changes:
+        # Момент отправки записи в Telegram-канал. NULL = ещё не отправлена.
+        # Флаг идемпотентности: планировщик постит только записи с NULL и проставляет время.
+        - addColumn:
+            tableName: article
+            columns:
+              - column:
+                  name: telegram_posted_at
+                  type: DATETIME
+        # Backfill: уже опубликованные (живые) записи считаем «отправленными», чтобы при
+        # включении интеграции планировщик не залил канал старыми новостями. Черновики и
+        # запланированные на будущее оставляем NULL — они уйдут в канал в момент публикации.
+        - update:
+            tableName: article
+            columns:
+              - column:
+                  name: telegram_posted_at
+                  valueComputed: now()
+            where: draft = false AND active = true AND publish_date_time < now()

--- a/src/main/resources/db/changelog/2026/07/08-02-add-publish-to-telegram-to-article.yaml
+++ b/src/main/resources/db/changelog/2026/07/08-02-add-publish-to-telegram-to-article.yaml
@@ -1,0 +1,26 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-08-02-add-publish-to-telegram-to-article
+      author: Peterko
+      changes:
+        # Галочка «опубликовать в Telegram» на записи. По умолчанию false — существующие
+        # и новые записи в канал не уходят, пока автор явно не включит отправку.
+        - addColumn:
+            tableName: article
+            columns:
+              - column:
+                  name: publish_to_telegram
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+        - update:
+            tableName: article
+            columns:
+              - column:
+                  name: publish_to_telegram
+                  valueBoolean: false
+            where: publish_to_telegram IS NULL
+        - addNotNullConstraint:
+            tableName: article
+            columnName: publish_to_telegram
+            columnDataType: BOOLEAN
+            defaultNullValue: false

--- a/src/main/resources/db/changelog/2026/07/08-03-add-telegram-sync-to-article.yaml
+++ b/src/main/resources/db/changelog/2026/07/08-03-add-telegram-sync-to-article.yaml
@@ -1,0 +1,52 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-08-03-add-telegram-sync-to-article
+      author: Peterko
+      changes:
+        # id сообщения в канале — чтобы редактировать пост при правке новости. NULL = ещё не отправлено.
+        - addColumn:
+            tableName: article
+            columns:
+              - column:
+                  name: telegram_message_id
+                  type: BIGINT
+        # Пост отправлен как фото (с обложкой) — тогда правим caption, иначе text.
+        - addColumn:
+            tableName: article
+            columns:
+              - column:
+                  name: telegram_photo
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+        - update:
+            tableName: article
+            columns:
+              - column:
+                  name: telegram_photo
+                  valueBoolean: false
+            where: telegram_photo IS NULL
+        - addNotNullConstraint:
+            tableName: article
+            columnName: telegram_photo
+            columnDataType: BOOLEAN
+            defaultNullValue: false
+        # Новость изменена после отправки — нужно синхронизировать пост в канале.
+        - addColumn:
+            tableName: article
+            columns:
+              - column:
+                  name: telegram_dirty
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+        - update:
+            tableName: article
+            columns:
+              - column:
+                  name: telegram_dirty
+                  valueBoolean: false
+            where: telegram_dirty IS NULL
+        - addNotNullConstraint:
+            tableName: article
+            columnName: telegram_dirty
+            columnDataType: BOOLEAN
+            defaultNullValue: false

--- a/src/main/resources/db/changelog/2026/07/09-01-add-discord-posted-at-to-article.yaml
+++ b/src/main/resources/db/changelog/2026/07/09-01-add-discord-posted-at-to-article.yaml
@@ -1,0 +1,23 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-09-01-add-discord-posted-at-to-article
+      author: Peterko
+      changes:
+        # Момент отправки записи в Discord-канал. NULL = ещё не отправлена.
+        # Флаг идемпотентности: планировщик постит только записи с NULL и проставляет время.
+        - addColumn:
+            tableName: article
+            columns:
+              - column:
+                  name: discord_posted_at
+                  type: DATETIME
+        # Backfill: уже опубликованные (живые) записи считаем «отправленными», чтобы при
+        # включении интеграции планировщик не залил канал старыми новостями. Черновики и
+        # запланированные на будущее оставляем NULL — они уйдут в канал в момент публикации.
+        - update:
+            tableName: article
+            columns:
+              - column:
+                  name: discord_posted_at
+                  valueComputed: now()
+            where: draft = false AND active = true AND publish_date_time < now()

--- a/src/main/resources/db/changelog/2026/07/09-02-add-publish-to-discord-to-article.yaml
+++ b/src/main/resources/db/changelog/2026/07/09-02-add-publish-to-discord-to-article.yaml
@@ -1,0 +1,26 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-09-02-add-publish-to-discord-to-article
+      author: Peterko
+      changes:
+        # Галочка «опубликовать в Discord» на записи. По умолчанию false — существующие
+        # и новые записи в канал не уходят, пока автор явно не включит отправку.
+        - addColumn:
+            tableName: article
+            columns:
+              - column:
+                  name: publish_to_discord
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+        - update:
+            tableName: article
+            columns:
+              - column:
+                  name: publish_to_discord
+                  valueBoolean: false
+            where: publish_to_discord IS NULL
+        - addNotNullConstraint:
+            tableName: article
+            columnName: publish_to_discord
+            columnDataType: BOOLEAN
+            defaultNullValue: false

--- a/src/main/resources/db/changelog/2026/07/09-03-add-discord-sync-to-article.yaml
+++ b/src/main/resources/db/changelog/2026/07/09-03-add-discord-sync-to-article.yaml
@@ -1,0 +1,34 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-09-03-add-discord-sync-to-article
+      author: Peterko
+      changes:
+        # id сообщения в канале (Discord-снежинка) — чтобы редактировать/удалять пост при правке
+        # или удалении новости. Строка, а не число: снежинка приходит строкой в JSON и используется
+        # как сегмент пути вебхука. NULL = ещё не отправлено.
+        - addColumn:
+            tableName: article
+            columns:
+              - column:
+                  name: discord_message_id
+                  type: VARCHAR(32)
+        # Новость изменена после отправки — нужно синхронизировать пост в канале.
+        - addColumn:
+            tableName: article
+            columns:
+              - column:
+                  name: discord_dirty
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+        - update:
+            tableName: article
+            columns:
+              - column:
+                  name: discord_dirty
+                  valueBoolean: false
+            where: discord_dirty IS NULL
+        - addNotNullConstraint:
+            tableName: article
+            columnName: discord_dirty
+            columnDataType: BOOLEAN
+            defaultNullValue: false

--- a/src/main/resources/db/changelog/2026/07/10-01-add-vk-posted-at-to-article.yaml
+++ b/src/main/resources/db/changelog/2026/07/10-01-add-vk-posted-at-to-article.yaml
@@ -1,0 +1,23 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-10-01-add-vk-posted-at-to-article
+      author: Peterko
+      changes:
+        # Момент отправки записи на стену сообщества VK. NULL = ещё не отправлена.
+        # Флаг идемпотентности: планировщик постит только записи с NULL и проставляет время.
+        - addColumn:
+            tableName: article
+            columns:
+              - column:
+                  name: vk_posted_at
+                  type: DATETIME
+        # Backfill: уже опубликованные (живые) записи считаем «отправленными», чтобы при
+        # включении интеграции планировщик не залил стену старыми новостями. Черновики и
+        # запланированные на будущее оставляем NULL — они уйдут на стену в момент публикации.
+        - update:
+            tableName: article
+            columns:
+              - column:
+                  name: vk_posted_at
+                  valueComputed: now()
+            where: draft = false AND active = true AND publish_date_time < now()

--- a/src/main/resources/db/changelog/2026/07/10-02-add-publish-to-vk-to-article.yaml
+++ b/src/main/resources/db/changelog/2026/07/10-02-add-publish-to-vk-to-article.yaml
@@ -1,0 +1,26 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-10-02-add-publish-to-vk-to-article
+      author: Peterko
+      changes:
+        # Галочка «опубликовать в VK» на записи. По умолчанию false — существующие
+        # и новые записи на стену не уходят, пока автор явно не включит отправку.
+        - addColumn:
+            tableName: article
+            columns:
+              - column:
+                  name: publish_to_vk
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+        - update:
+            tableName: article
+            columns:
+              - column:
+                  name: publish_to_vk
+                  valueBoolean: false
+            where: publish_to_vk IS NULL
+        - addNotNullConstraint:
+            tableName: article
+            columnName: publish_to_vk
+            columnDataType: BOOLEAN
+            defaultNullValue: false

--- a/src/main/resources/db/changelog/2026/07/10-03-add-vk-sync-to-article.yaml
+++ b/src/main/resources/db/changelog/2026/07/10-03-add-vk-sync-to-article.yaml
@@ -1,0 +1,41 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-10-03-add-vk-sync-to-article
+      author: Peterko
+      changes:
+        # id поста на стене (числовой post_id) — чтобы редактировать/удалять пост при правке
+        # или удалении новости. NULL = ещё не отправлено.
+        - addColumn:
+            tableName: article
+            columns:
+              - column:
+                  name: vk_post_id
+                  type: BIGINT
+        # Строка вложения-обложки (photo<owner_id>_<id>) — пере-передаётся в wall.edit, чтобы правка
+        # текста не убрала фото с поста. NULL = пост без обложки.
+        - addColumn:
+            tableName: article
+            columns:
+              - column:
+                  name: vk_attachment
+                  type: VARCHAR(64)
+        # Новость изменена после отправки — нужно синхронизировать пост на стене.
+        - addColumn:
+            tableName: article
+            columns:
+              - column:
+                  name: vk_dirty
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+        - update:
+            tableName: article
+            columns:
+              - column:
+                  name: vk_dirty
+                  valueBoolean: false
+            where: vk_dirty IS NULL
+        - addNotNullConstraint:
+            tableName: article
+            columnName: vk_dirty
+            columnDataType: BOOLEAN
+            defaultNullValue: false

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -235,3 +235,9 @@ databaseChangeLog:
       file: db/changelog/2026/07/08-02-add-publish-to-telegram-to-article.yaml
   - include:
       file: db/changelog/2026/07/08-03-add-telegram-sync-to-article.yaml
+  - include:
+      file: db/changelog/2026/07/09-01-add-discord-posted-at-to-article.yaml
+  - include:
+      file: db/changelog/2026/07/09-02-add-publish-to-discord-to-article.yaml
+  - include:
+      file: db/changelog/2026/07/09-03-add-discord-sync-to-article.yaml

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -241,3 +241,9 @@ databaseChangeLog:
       file: db/changelog/2026/07/09-02-add-publish-to-discord-to-article.yaml
   - include:
       file: db/changelog/2026/07/09-03-add-discord-sync-to-article.yaml
+  - include:
+      file: db/changelog/2026/07/10-01-add-vk-posted-at-to-article.yaml
+  - include:
+      file: db/changelog/2026/07/10-02-add-publish-to-vk-to-article.yaml
+  - include:
+      file: db/changelog/2026/07/10-03-add-vk-sync-to-article.yaml

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -221,3 +221,11 @@ databaseChangeLog:
       file: db/changelog/2026/06/26-02-add-source-code-to-subscription.yaml
   - include:
       file: db/changelog/2026/06/27-01-drop-subscription-domain.yaml
+  - include:
+      file: db/changelog/2026/07/06-01-article-type-and-deleted.yaml
+  - include:
+      file: db/changelog/2026/07/06-02-add-draft-to-article.yaml
+  - include:
+      file: db/changelog/2026/07/07-01-add-accessible-by-link-to-article.yaml
+  - include:
+      file: db/changelog/2026/07/07-02-add-active-to-article.yaml

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -229,3 +229,9 @@ databaseChangeLog:
       file: db/changelog/2026/07/07-01-add-accessible-by-link-to-article.yaml
   - include:
       file: db/changelog/2026/07/07-02-add-active-to-article.yaml
+  - include:
+      file: db/changelog/2026/07/08-01-add-telegram-posted-at-to-article.yaml
+  - include:
+      file: db/changelog/2026/07/08-02-add-publish-to-telegram-to-article.yaml
+  - include:
+      file: db/changelog/2026/07/08-03-add-telegram-sync-to-article.yaml


### PR DESCRIPTION
## Что делает PR

Развивает раздел статей/новостей: добавляет типы и статусы контента, доступ по прямой
ссылке, поиск и обложки, а также автопубликацию в внешние каналы — Telegram, Discord и
сообщество ВКонтакте.

## Изменения

### Модель статей/новостей
- Типы контента (`ArticleType`) и статусы публикации (`ArticleStatus`): черновик,
  публикация, флаги `active` / `deleted` (мягкое удаление).
- Доступ к материалу по прямой ссылке (`accessibleByLink`).
- Поиск по статьям и обложки материалов, расширенные DTO/маппер и репозиторий.
- Новый `SectionType` и словарь типов статей в `DictionariesController` / `DictionariesService`.

### Автопубликация в каналы
Единый механизм: опрос по расписанию («пора постить», ISO-8601 `poll-interval`),
opt-in через флаги `publishToTelegram` / `publishToDiscord` / `publishToVk`, отметки
времени публикации и синхронизация правок/удаления.
- **Telegram** — постинг в канал через bot-token/chat-id, `TelegramHtmlFormatter`,
  `TelegramPublisher`, планировщик.
- **Discord** — постинг в канал через входящий вебхук, `DiscordMarkdownFormatter`,
  `DiscordPublisher`, планировщик.
- **VK** — постинг на стену сообщества через ключ доступа сообщества (без бота),
  `VkTextFormatter`, `VkPublisher`, планировщик.
- Общий `ArticleImageSource` для обложек постов.

### Конфигурация
- Новые конфиги и properties-классы: `TelegramConfig`/`TelegramProperties`,
  `DiscordConfig`/`DiscordProperties`, `VkConfig`/`VkProperties`.
- Настройки в `application.properties`; все секреты — из окружения (Dokploy /
  локально `local.env`). Интеграция включается только при заданных ключах, иначе
  ничего не отправляется.

### БД
- 14 changeset'ов Liquibase (`2026/07`): типы, статусы, `accessibleByLink`, `active`,
  а также поля `*_posted_at`, `publish_to_*` и таблицы синхронизации для каждого канала.

## Переменные окружения
- `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`
- `DISCORD_WEBHOOK_URL`
- `VK_ACCESS_TOKEN`, `VK_GROUP_ID`

## Заметки для ревью
- **VK**: групповой токен работает только на постинг (ошибка 27 блокирует
  редактирование/удаление/обложку); полный цикл синхронизации требует пользовательский
  токен с правами администратора.
- Ничего не публикуется, пока не заданы соответствующие секреты — существующее
  поведение не меняется при пустой конфигурации.
