### PR TITLE
feat(article, tracker): публикация статей с автопостингом (TG, Discord, VK) и трекер инициативы

### DIFF
--- a/src/main/java/club/ttg/dnd5/config/properties/TrackerProperties.java
+++ b/src/main/java/club/ttg/dnd5/config/properties/TrackerProperties.java
@@ -1,0 +1,35 @@
+package club.ttg.dnd5.config.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+/**
+ * Настройки трекера инициативы (инструмент).
+ * <p>
+ * Лимит «один трекер анониму» невозможно строго обеспечить на сервере — у анонима нет
+ * идентичности, его трекер держит клиент (id + ключ в localStorage). Поэтому сервер
+ * защищается от абьюза: ограничивает создание анонимных трекеров по IP и удаляет
+ * анонимные трекеры без активности по TTL.
+ */
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "tracker")
+public class TrackerProperties {
+
+    /** Сколько анонимных трекеров можно создать с одного IP за окно {@link #anonymousCreateWindow}. */
+    private int anonymousCreateLimit = 10;
+
+    /** Окно лимита создания анонимных трекеров. */
+    private Duration anonymousCreateWindow = Duration.ofHours(1);
+
+    /** Срок жизни анонимного трекера с момента последней активности; дальше — физическое удаление. */
+    private Duration anonymousTtl = Duration.ofDays(14);
+
+    /** TTL простаивающих bucket'ов лимитера создания (очистка карты в памяти). */
+    private Duration bucketIdleTtl = Duration.ofHours(2);
+}

--- a/src/main/java/club/ttg/dnd5/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/repository/ArticleRepository.java
@@ -333,6 +333,15 @@ public interface ArticleRepository extends JpaRepository<Article, UUID> {
     void markVkSent(@Param("id") UUID id, @Param("postId") Long postId, @Param("attachment") String attachment);
 
     /**
+     * Сохраняет строку вложения-обложки для уже опубликованного поста — обложку залили при синхронизации
+     * правки (пост изначально ушёл текстом). Точечный UPDATE только по vk_attachment: не трогает updatedAt и
+     * прочие vk_*-поля, чтобы не сорвать claim/compare-and-clear.
+     */
+    @Modifying
+    @Query("UPDATE Article a SET a.vkAttachment = :attachment WHERE a.id = :id")
+    void updateVkAttachment(@Param("id") UUID id, @Param("attachment") String attachment);
+
+    /**
      * Снимает флаг правки — только если запись не изменилась с момента загрузки (updatedAt совпадает).
      * Compare-and-clear: правка, прилетевшая во время отправки на стену, сдвинет updatedAt, clear не сработает,
      * и синхронизация повторится на следующем тике с самым свежим текстом.

--- a/src/main/java/club/ttg/dnd5/domain/article/service/ArticleService.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/service/ArticleService.java
@@ -225,6 +225,16 @@ public class ArticleService {
     }
 
     /**
+     * Сохраняет строку вложения-обложки, залитой при синхронизации правки (пост изначально ушёл текстом,
+     * обложку добавили позже). Отдельная короткая транзакция; {@code updatedAt} не трогает — чтобы не сорвать
+     * compare-and-clear флага {@code vkDirty}.
+     */
+    @Transactional
+    public void saveVkAttachment(UUID id, String attachment) {
+        articleRepository.updateVkAttachment(id, attachment);
+    }
+
+    /**
      * Снимает флаг правки после синхронизации — только если запись не изменилась с момента загрузки
      * (updatedAt совпадает). Иначе правку, прилетевшую во время отправки, не теряем: флаг остаётся.
      */

--- a/src/main/java/club/ttg/dnd5/domain/article/service/ArticleVkPublicationScheduler.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/service/ArticleVkPublicationScheduler.java
@@ -99,19 +99,24 @@ public class ArticleVkPublicationScheduler {
         List<Article> dirty = articleRepository.findDirtyForVk(Instant.now(), batch);
         int synced = 0;
         for (Article article : dirty) {
-            VkPublisher.EditResult result;
+            VkPublisher.EditOutcome outcome;
             try {
-                result = vkPublisher.editPost(article);
+                outcome = vkPublisher.editPost(article);
             } catch (RuntimeException ex) {
                 log.warn("Ошибка синхронизации поста {} в VK — повторю на следующем тике", article.getUrl(), ex);
                 continue;
             }
-            if (result != VkPublisher.EditResult.RETRY) {
+            // Обложка, залитая во время правки (пост изначально ушёл текстом, картинку добавили позже) —
+            // сохраняем строку вложения, чтобы следующие правки её пере-передавали и не заливали фото заново.
+            if (outcome.newAttachment() != null) {
+                articleService.saveVkAttachment(article.getId(), outcome.newAttachment());
+            }
+            if (outcome.status() != VkPublisher.EditResult.RETRY) {
                 // SYNCED или GIVE_UP — снимаем флаг, но только если запись не изменилась в окне отправки
                 // (иначе свежая правка сдвинула updatedAt, флаг останется и синхронизируется следующим тиком).
                 articleService.clearVkDirty(article.getId(), article.getUpdatedAt());
             }
-            if (result == VkPublisher.EditResult.SYNCED) {
+            if (outcome.status() == VkPublisher.EditResult.SYNCED) {
                 synced++;
             }
         }

--- a/src/main/java/club/ttg/dnd5/domain/article/service/VkPublisher.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/service/VkPublisher.java
@@ -81,6 +81,17 @@ public class VkPublisher {
     /** Итог синхронизации правки / удаления поста. */
     public enum EditResult { SYNCED, RETRY, GIVE_UP }
 
+    /**
+     * Итог синхронизации правки поста: статус + строка вложения-обложки, если её залили прямо во время правки
+     * ({@code null} — обложку не трогали). Ненулевой {@code newAttachment} планировщик сохраняет в БД, чтобы
+     * следующие правки её пере-передавали и не заливали фото заново.
+     */
+    public record EditOutcome(EditResult status, String newAttachment) {
+        static EditOutcome of(EditResult status) {
+            return new EditOutcome(status, null);
+        }
+    }
+
     private final RestClient vkRestClient;
     private final VkProperties properties;
     private final VkTextFormatter formatter;
@@ -131,27 +142,50 @@ public class VkPublisher {
     /**
      * Синхронизирует пост с обновлённой новостью: правит текст на месте ({@code wall.edit}). Сохранённую
      * строку вложения (обложку) пере-передаём, потому что {@code wall.edit} без {@code attachments} может
-     * очистить вложения — так фото остаётся на месте. Текстовый пост правим без {@code attachments}.
+     * очистить вложения — так фото остаётся на месте.
+     * <p>
+     * Если сохранённой обложки нет ({@code vkAttachment} пуст), а у новости картинка теперь есть — заливаем
+     * её прямо сейчас и до-прикрепляем. Это закрывает случаи, когда пост изначально ушёл текстом: обложку
+     * добавили уже после первой публикации, либо первая публикация не смогла её залить (напр. позже сменили
+     * ключ сообщества на пользовательский токен админа). Залитую строку вложения возвращаем в
+     * {@link EditOutcome#newAttachment()} — планировщик сохранит её, чтобы не заливать фото на каждой правке.
      */
-    public EditResult editPost(Article article) {
+    public EditOutcome editPost(Article article) {
         String message = buildMessage(article);
         if (!StringUtils.hasText(message)) {
             // Правка сделала запись пустой — корректной альтернативы нет: прекращаем попытки (флаг снимет поллер).
-            return EditResult.GIVE_UP;
+            return EditOutcome.of(EditResult.GIVE_UP);
         }
+
+        String attachment = article.getVkAttachment();
+        String uploadedAttachment = null;
+        if (!StringUtils.hasText(attachment)) {
+            Cover cover = uploadCover(article);
+            if (cover.retryNeeded()) {
+                // Временный сбой загрузки обложки — правку отложим, повторим весь проход на следующем тике.
+                return EditOutcome.of(EditResult.RETRY);
+            }
+            // null — обложки нет либо VK отказал (напр. ошибка 27 для группового токена): правим текст без фото.
+            attachment = cover.attachment();
+            uploadedAttachment = cover.attachment();
+        }
+
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("owner_id", ownerId());
         params.add("post_id", String.valueOf(article.getVkPostId()));
         params.add("message", message);
-        if (StringUtils.hasText(article.getVkAttachment())) {
-            params.add("attachments", article.getVkAttachment());
+        if (StringUtils.hasText(attachment)) {
+            params.add("attachments", attachment);
         }
-        return switch (callMethod("wall.edit", params).result()) {
+        EditResult status = switch (callMethod("wall.edit", params).result()) {
             case SENT -> EditResult.SYNCED;
             case TRANSIENT -> EditResult.RETRY;
             // Пост удалён/нельзя изменить — прекращаем попытки.
             case REJECTED -> EditResult.GIVE_UP;
         };
+        // Свежезалитую обложку сохраняем в любом исходе (даже при RETRY): фото уже в альбоме сообщества,
+        // повторная правка пере-прикрепит его по сохранённой строке, а не зальёт файл заново.
+        return new EditOutcome(status, uploadedAttachment);
     }
 
     /** Удаляет пост со стены (для удалённой с сайта новости). */
@@ -190,10 +224,12 @@ public class VkPublisher {
         if (!StringUtils.hasText(article.getPreviewImageUrl())) {
             return Cover.none();
         }
-        // Байты обложки из S3: null — картинки нет; временный сбой чтения пробрасывается наружу
-        // (планировщик освободит запись и повторит).
+        // Байты обложки из S3: null — картинки нет (не S3-путь, напр. внешний URL, или объекта нет в бакете);
+        // временный сбой чтения пробрасывается наружу (планировщик освободит запись и повторит).
         byte[] bytes = imageSource.bytes(article.getPreviewImageUrl());
         if (bytes == null) {
+            log.info("Не удалось прочитать байты обложки {} для {} — отправляю текстом",
+                    article.getPreviewImageUrl(), article.getUrl());
             return Cover.none();
         }
 
@@ -217,11 +253,15 @@ public class VkPublisher {
             return Cover.retry();
         }
         if (uploaded.result() == SendResult.REJECTED || uploaded.response() == null) {
+            log.info("VK отклонил файл обложки при загрузке для {} — отправляю текстом", article.getUrl());
             return Cover.none();
         }
         String photo = uploaded.response().path("photo").asText("");
-        // Пустой photo (или "[]") — VK не принял файл: постим без обложки.
+        // Пустой photo (или "[]") — VK не принял файл (частая причина — формат/размер/пропорции картинки,
+        // которые ВК фильтрует строже Telegram/Discord): постим без обложки.
         if (!StringUtils.hasText(photo) || "[]".equals(photo)) {
+            log.info("VK не принял картинку обложки для {} (формат/размер/пропорции?) — отправляю текстом",
+                    article.getUrl());
             return Cover.none();
         }
 
@@ -236,6 +276,7 @@ public class VkPublisher {
         }
         JsonNode arr = saved.response();
         if (saved.result() == SendResult.REJECTED || arr == null || !arr.isArray() || arr.isEmpty()) {
+            log.info("VK не сохранил обложку (saveWallPhoto) для {} — отправляю текстом", article.getUrl());
             return Cover.none();
         }
         JsonNode photoObj = arr.get(0);

--- a/src/main/java/club/ttg/dnd5/domain/beastiary/rest/mapper/CreatureMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/beastiary/rest/mapper/CreatureMapper.java
@@ -14,8 +14,8 @@ import club.ttg.dnd5.domain.beastiary.rest.dto.AbilitiesResponse;
 import club.ttg.dnd5.domain.beastiary.rest.dto.AbilityResponse;
 import club.ttg.dnd5.domain.beastiary.rest.dto.BonusDto;
 import club.ttg.dnd5.domain.beastiary.rest.dto.CreatureRequest;
+import club.ttg.dnd5.domain.beastiary.service.CreatureInitiativeCalculator;
 import club.ttg.dnd5.domain.source.model.Source;
-import club.ttg.dnd5.domain.common.dictionary.Ability;
 import club.ttg.dnd5.domain.common.dictionary.ChallengeRating;
 import club.ttg.dnd5.domain.common.dictionary.Condition;
 import club.ttg.dnd5.domain.common.dictionary.CreatureTreasure;
@@ -278,9 +278,7 @@ public interface CreatureMapper {
 
     @Named("toInit")
     default BonusDto toInit(Creature creature) {
-        var mod = creature.getAbilities().getMod(Ability.DEXTERITY);
-        var pb = ChallengeRating.getPb(creature.getExperience());
-        var initiative = mod + pb * creature.getInitiative().getMultiplier();
+        var initiative = CreatureInitiativeCalculator.initiativeBonus(creature);
         String sign = initiative >= 0 ? "+" : "";
         return BonusDto.builder()
                 .value(String.format("%s%d", sign, initiative))

--- a/src/main/java/club/ttg/dnd5/domain/beastiary/service/CreatureInitiativeCalculator.java
+++ b/src/main/java/club/ttg/dnd5/domain/beastiary/service/CreatureInitiativeCalculator.java
@@ -1,0 +1,29 @@
+package club.ttg.dnd5.domain.beastiary.service;
+
+import club.ttg.dnd5.domain.beastiary.model.Creature;
+import club.ttg.dnd5.domain.common.dictionary.Ability;
+import club.ttg.dnd5.domain.common.dictionary.ChallengeRating;
+
+/**
+ * Расчёт бонуса инициативы существа: модификатор ЛОВ + бонус мастерства (по опыту) × множитель
+ * инициативы из статблока. Единая точка расчёта для карточки существа и трекера инициативы.
+ */
+public final class CreatureInitiativeCalculator {
+
+    private CreatureInitiativeCalculator() {
+        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+    }
+
+    public static int initiativeBonus(Creature creature) {
+        int mod = 0;
+        if (creature.getAbilities() != null && creature.getAbilities().getDexterity() != null) {
+            mod = creature.getAbilities().getMod(Ability.DEXTERITY);
+        }
+        int multiplier = creature.getInitiative() != null ? creature.getInitiative().getMultiplier() : 0;
+        if (multiplier == 0) {
+            return mod;
+        }
+        long experience = creature.getExperience() != null ? creature.getExperience() : 0L;
+        return mod + ChallengeRating.getPb(experience) * multiplier;
+    }
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/tracker/model/InitiativeParticipant.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/tracker/model/InitiativeParticipant.java
@@ -1,0 +1,93 @@
+package club.ttg.dnd5.domain.tool.tracker.model;
+
+import club.ttg.dnd5.domain.common.model.Timestamped;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+/**
+ * Участник трекера инициативы: игрок (имя + бонус вручную) или существо из бестиария.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "initiative_participant",
+        indexes = {
+                @Index(name = "initiative_participant_tracker_index", columnList = "tracker_id")
+        })
+public class InitiativeParticipant extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "tracker_id", nullable = false)
+    private UUID trackerId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ParticipantType type;
+
+    @Column(nullable = false)
+    private String name;
+
+    /**
+     * Бонус инициативы: игроку задаёт пользователь, существу — снапшот из бестиария
+     * на момент добавления (правка бестиария не влияет на идущий бой).
+     */
+    @Column(name = "initiative_bonus", nullable = false)
+    private int initiativeBonus;
+
+    /**
+     * Слаг существа в бестиарии. Ссылка мягкая, без FK — по конвенции проекта на bestiary
+     * никто не ссылается; нужна фронту для перехода к статблоку. NULL — игрок.
+     */
+    @Column(name = "creature_url")
+    private String creatureUrl;
+
+    /**
+     * Результат броска d20. NULL — инициатива ещё не брошена.
+     */
+    @Column(name = "initiative_roll")
+    private Integer initiativeRoll;
+
+    /**
+     * Итог инициативы: бросок + бонус. NULL — инициатива ещё не брошена.
+     */
+    @Column(name = "initiative_total")
+    private Integer initiativeTotal;
+
+    /**
+     * «Монетка» финального тай-брейка: случайное число, назначаемое при броске. Хранится,
+     * чтобы порядок хода был детерминированным — участник, добавленный в идущий бой,
+     * не пересортировывает остальных.
+     */
+    @Column(name = "tie_roll")
+    private Integer tieRoll;
+
+    /**
+     * Порядковый номер добавления в трекер: стабильный порядок списка до броска
+     * и последний тай-брейк после.
+     */
+    @Column(nullable = false)
+    private int seq;
+
+    /**
+     * Повержен: участник остаётся в списке (виден, помечен мёртвым), но пропускается в порядке хода.
+     * Снимается при завершении боя (reset).
+     */
+    @Column(nullable = false)
+    private boolean dead;
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/tracker/model/InitiativeTracker.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/tracker/model/InitiativeTracker.java
@@ -1,0 +1,83 @@
+package club.ttg.dnd5.domain.tool.tracker.model;
+
+import club.ttg.dnd5.domain.common.model.Timestamped;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+/**
+ * Трекер инициативы (инструмент): энкаунтер с участниками, порядком хода и раундами.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "initiative_tracker",
+        indexes = {
+                @Index(name = "initiative_tracker_owner_username_index", columnList = "owner_username")
+        })
+public class InitiativeTracker extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private String name;
+
+    /**
+     * Логин владельца. NULL — анонимный трекер: владельца нет, доступ только по ключу
+     * {@link #accessKey}; такие трекеры удаляются по TTL без активности.
+     */
+    @Column(name = "owner_username")
+    private String ownerUsername;
+
+    /**
+     * Секретный ключ доступа. Возвращается клиенту при создании; аноним хранит его в localStorage
+     * и передаёт в заголовке X-Tracker-Key. Для трекера с владельцем не используется —
+     * доступ проверяется по логину из JWT.
+     */
+    @Column(name = "access_key", nullable = false)
+    private UUID accessKey;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TrackerStatus status;
+
+    /**
+     * Номер раунда боя: 0 — бой не начат, с 1 — идёт бой.
+     */
+    @Column(nullable = false)
+    private int round;
+
+    /**
+     * Опция «новая инициатива каждый раунд»: если true — при переходе на новый раунд всем живым
+     * участникам инициатива перебрасывается заново, и порядок хода пересобирается.
+     */
+    @Column(name = "reroll_each_round", nullable = false)
+    private boolean rerollEachRound;
+
+    /**
+     * id участника, чей сейчас ход. NULL — бой не начат (или текущий участник был единственным и удалён).
+     */
+    @Column(name = "current_participant_id")
+    private UUID currentParticipantId;
+
+    /**
+     * Мягкое удаление: трекер скрыт из списка, но остаётся в истории создания владельца.
+     * Анонимные трекеры удаляются физически (истории у анонима нет).
+     */
+    @Column(nullable = false)
+    private boolean deleted;
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/tracker/model/ParticipantType.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/tracker/model/ParticipantType.java
@@ -1,0 +1,13 @@
+package club.ttg.dnd5.domain.tool.tracker.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ParticipantType {
+    PLAYER("Игрок"),
+    CREATURE("Существо");
+
+    private final String name;
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/tracker/model/TrackerStatus.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/tracker/model/TrackerStatus.java
@@ -1,0 +1,13 @@
+package club.ttg.dnd5.domain.tool.tracker.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum TrackerStatus {
+    PREPARING("Подготовка"),
+    ACTIVE("Бой");
+
+    private final String name;
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/tracker/repository/InitiativeParticipantRepository.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/tracker/repository/InitiativeParticipantRepository.java
@@ -1,0 +1,32 @@
+package club.ttg.dnd5.domain.tool.tracker.repository;
+
+import club.ttg.dnd5.domain.tool.tracker.model.InitiativeParticipant;
+import club.ttg.dnd5.domain.tool.tracker.model.ParticipantType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface InitiativeParticipantRepository extends JpaRepository<InitiativeParticipant, UUID> {
+
+    List<InitiativeParticipant> findAllByTrackerId(UUID trackerId);
+
+    Optional<InitiativeParticipant> findByIdAndTrackerId(UUID id, UUID trackerId);
+
+    long countByTrackerIdAndType(UUID trackerId, ParticipantType type);
+
+    @Query("SELECT COALESCE(MAX(p.seq), 0) FROM InitiativeParticipant p WHERE p.trackerId = :trackerId")
+    int findMaxSeq(@Param("trackerId") UUID trackerId);
+
+    /**
+     * Физически удаляет всех участников трекера — при мягком удалении трекера с владельцем:
+     * в истории остаётся только строка трекера, участники недоступны и не должны копиться.
+     */
+    @Modifying
+    @Query("DELETE FROM InitiativeParticipant p WHERE p.trackerId = :trackerId")
+    void deleteAllByTrackerId(@Param("trackerId") UUID trackerId);
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/tracker/repository/InitiativeTrackerRepository.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/tracker/repository/InitiativeTrackerRepository.java
@@ -1,0 +1,41 @@
+package club.ttg.dnd5.domain.tool.tracker.repository;
+
+import club.ttg.dnd5.domain.tool.tracker.model.InitiativeTracker;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public interface InitiativeTrackerRepository extends JpaRepository<InitiativeTracker, UUID> {
+
+    long countByOwnerUsernameAndDeletedFalse(String ownerUsername);
+
+    List<InitiativeTracker> findAllByOwnerUsernameOrderByCreatedAtDesc(String ownerUsername);
+
+    List<InitiativeTracker> findAllByOwnerUsernameAndDeletedFalseOrderByCreatedAtDesc(String ownerUsername);
+
+    /** Удалённые трекеры пользователя, свежие первее — для ограничения размера истории. */
+    List<InitiativeTracker> findAllByOwnerUsernameAndDeletedTrueOrderByUpdatedAtDesc(String ownerUsername);
+
+    /**
+     * Отметка активности трекера для TTL-очистки анонимных: операции только с участниками
+     * (добавление/правка/удаление) не меняют строку трекера, поэтому updated_at обновляется явно.
+     */
+    @Modifying
+    @Query("UPDATE InitiativeTracker t SET t.updatedAt = :now WHERE t.id = :id")
+    void touch(@Param("id") UUID id, @Param("now") Instant now);
+
+    /**
+     * Удаляет анонимные трекеры без активности (владельца нет, клиент мог потерять ключ).
+     * Участники удаляются каскадом на уровне БД (FK ON DELETE CASCADE).
+     *
+     * @return количество удалённых трекеров
+     */
+    @Modifying
+    @Query("DELETE FROM InitiativeTracker t WHERE t.ownerUsername IS NULL AND t.updatedAt < :cutoff")
+    int deleteStaleAnonymous(@Param("cutoff") Instant cutoff);
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/tracker/rest/controller/InitiativeTrackerController.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/tracker/rest/controller/InitiativeTrackerController.java
@@ -1,0 +1,172 @@
+package club.ttg.dnd5.domain.tool.tracker.rest.controller;
+
+import club.ttg.dnd5.domain.tool.tracker.rest.dto.ParticipantAddRequest;
+import club.ttg.dnd5.domain.tool.tracker.rest.dto.ParticipantUpdateRequest;
+import club.ttg.dnd5.domain.tool.tracker.rest.dto.TrackerDetailedResponse;
+import club.ttg.dnd5.domain.tool.tracker.rest.dto.TrackerRequest;
+import club.ttg.dnd5.domain.tool.tracker.rest.dto.TrackerShortResponse;
+import club.ttg.dnd5.domain.tool.tracker.service.InitiativeTrackerService;
+import club.ttg.dnd5.domain.tool.tracker.service.TrackerCreationRateLimiter;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+import static club.ttg.dnd5.domain.tool.tracker.service.InitiativeTrackerService.TRACKER_KEY_HEADER;
+
+/**
+ * Доступ: трекер с владельцем — только владельцу (JWT); анонимный трекер — по секретному
+ * ключу из заголовка {@code X-Tracker-Key}, который возвращается один раз при создании.
+ */
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v2/tools/initiative")
+@Tag(name = "Трекер инициативы",
+        description = "REST API трекера инициативы: сборка энкаунтера, броски инициативы и порядок ходов")
+public class InitiativeTrackerController {
+
+    private final InitiativeTrackerService trackerService;
+
+    @Operation(summary = "Создание трекера: авторизованному — до 10; анониму ключ доступа "
+            + "возвращается один раз в поле accessKey (сохранить на клиенте)")
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    public TrackerDetailedResponse create(@RequestBody(required = false) @Valid final TrackerRequest request,
+                                          final HttpServletRequest httpRequest) {
+        return trackerService.create(request, TrackerCreationRateLimiter.resolveClientIp(httpRequest));
+    }
+
+    @Operation(summary = "Трекеры текущего пользователя с датами создания (история); "
+            + "includeDeleted=true — вместе с удалёнными")
+    @GetMapping
+    public List<TrackerShortResponse> findMine(
+            @RequestParam(required = false, defaultValue = "false")
+            @Schema(description = "Включить удалённые трекеры (полная история)") final boolean includeDeleted) {
+        return trackerService.findMine(includeDeleted);
+    }
+
+    @Operation(summary = "Трекер с участниками в порядке хода")
+    @GetMapping("/{id}")
+    public TrackerDetailedResponse findById(
+            @PathVariable final UUID id,
+            @RequestHeader(value = TRACKER_KEY_HEADER, required = false) final String trackerKey) {
+        return trackerService.findById(id, trackerKey);
+    }
+
+    @Operation(summary = "Обновление трекера: имя и/или опция «новая инициатива каждый раунд» "
+            + "(rerollEachRound). Применяются только переданные поля")
+    @PutMapping("/{id}")
+    public TrackerDetailedResponse updateSettings(
+            @PathVariable final UUID id,
+            @RequestBody @Valid final TrackerRequest request,
+            @RequestHeader(value = TRACKER_KEY_HEADER, required = false) final String trackerKey) {
+        return trackerService.updateSettings(id, request, trackerKey);
+    }
+
+    @Operation(summary = "Удаление трекера: у владельца — мягкое (остаётся в истории, хранятся "
+            + "последние 30 удалённых, участники вычищаются), анонимный удаляется полностью")
+    @DeleteMapping("/{id}")
+    public void delete(
+            @PathVariable final UUID id,
+            @RequestHeader(value = TRACKER_KEY_HEADER, required = false) final String trackerKey) {
+        trackerService.delete(id, trackerKey);
+    }
+
+    @Operation(summary = "Добавление участников: игрок (name + initiativeBonus) или существа из "
+            + "бестиария (creatureUrl + count). В идущем бою новичок сразу получает бросок инициативы. "
+            + "Лимиты: 50 игроков и 100 существ на трекер")
+    @PostMapping("/{id}/participants")
+    public TrackerDetailedResponse addParticipants(
+            @PathVariable final UUID id,
+            @RequestBody @Valid final ParticipantAddRequest request,
+            @RequestHeader(value = TRACKER_KEY_HEADER, required = false) final String trackerKey) {
+        return trackerService.addParticipants(id, request, trackerKey);
+    }
+
+    @Operation(summary = "Правка участника: имя, бонус инициативы, ручной результат d20, признак "
+            + "«повержен» (dead). Применяются только заполненные поля. Работает и во время боя — "
+            + "порядок хода пересобирается")
+    @PutMapping("/{id}/participants/{participantId}")
+    public TrackerDetailedResponse updateParticipant(
+            @PathVariable final UUID id,
+            @PathVariable final UUID participantId,
+            @RequestBody @Valid final ParticipantUpdateRequest request,
+            @RequestHeader(value = TRACKER_KEY_HEADER, required = false) final String trackerKey) {
+        return trackerService.updateParticipant(id, participantId, request, trackerKey);
+    }
+
+    @Operation(summary = "Прокинуть инициативу одному участнику (d20 + бонус). Бой не начинает, "
+            + "остальных не трогает — для броска по одному")
+    @PostMapping("/{id}/participants/{participantId}/roll")
+    public TrackerDetailedResponse rollParticipant(
+            @PathVariable final UUID id,
+            @PathVariable final UUID participantId,
+            @RequestHeader(value = TRACKER_KEY_HEADER, required = false) final String trackerKey) {
+        return trackerService.rollParticipant(id, participantId, trackerKey);
+    }
+
+    @Operation(summary = "Удаление участника из трекера; если сейчас его ход — ход переходит следующему живому")
+    @DeleteMapping("/{id}/participants/{participantId}")
+    public TrackerDetailedResponse deleteParticipant(
+            @PathVariable final UUID id,
+            @PathVariable final UUID participantId,
+            @RequestHeader(value = TRACKER_KEY_HEADER, required = false) final String trackerKey) {
+        return trackerService.deleteParticipant(id, participantId, trackerKey);
+    }
+
+    @Operation(summary = "Прокинуть инициативу всем: d20 + бонус каждому участнику, сортировка по "
+            + "правилам D&D (бонус инициативы, затем «монетка»). Бой НЕ начинает — старт отдельным "
+            + "действием (/start). В подготовке статус остаётся PREPARING (ход не назначается); "
+            + "в идущем бою это ре-ролл — раунд с начала, ход первому живому")
+    @PostMapping("/{id}/roll")
+    public TrackerDetailedResponse rollInitiative(
+            @PathVariable final UUID id,
+            @RequestHeader(value = TRACKER_KEY_HEADER, required = false) final String trackerKey) {
+        return trackerService.rollInitiative(id, trackerKey);
+    }
+
+    @Operation(summary = "Начать бой, сохранив уже введённые броски: у кого инициатива уже задана "
+            + "(ручной ввод или бросок) — итог переходит в бой как есть; остальным инициатива 0 "
+            + "(без доброса d20 и без бонуса). Порядок по итогу, не брошенные (0) — в конце. Ход "
+            + "первому живому (в отличие от /roll — случайный d20 + бонус всем и полная сортировка)")
+    @PostMapping("/{id}/start")
+    public TrackerDetailedResponse start(
+            @PathVariable final UUID id,
+            @RequestHeader(value = TRACKER_KEY_HEADER, required = false) final String trackerKey) {
+        return trackerService.start(id, trackerKey);
+    }
+
+    @Operation(summary = "Следующий ход; после последнего участника — новый раунд и ход первому")
+    @PostMapping("/{id}/turn/next")
+    public TrackerDetailedResponse nextTurn(
+            @PathVariable final UUID id,
+            @RequestHeader(value = TRACKER_KEY_HEADER, required = false) final String trackerKey) {
+        return trackerService.nextTurn(id, trackerKey);
+    }
+
+    @Operation(summary = "Завершить бой: броски очищаются, состав участников сохраняется, "
+            + "трекер возвращается в подготовку")
+    @PostMapping("/{id}/reset")
+    public TrackerDetailedResponse reset(
+            @PathVariable final UUID id,
+            @RequestHeader(value = TRACKER_KEY_HEADER, required = false) final String trackerKey) {
+        return trackerService.reset(id, trackerKey);
+    }
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/tracker/rest/dto/ParticipantAddRequest.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/tracker/rest/dto/ParticipantAddRequest.java
@@ -1,0 +1,47 @@
+package club.ttg.dnd5.domain.tool.tracker.rest.dto;
+
+import club.ttg.dnd5.domain.tool.tracker.model.ParticipantType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class ParticipantAddRequest {
+
+    @NotNull
+    @Schema(description = "Тип участника: PLAYER (игрок) или CREATURE (существо из бестиария)")
+    private ParticipantType type;
+
+    @Nullable
+    @Size(max = 100)
+    @Schema(description = "Имя: для игрока обязательно; для существа — переопределяет название из бестиария")
+    private String name;
+
+    @Nullable
+    @Min(-20)
+    @Max(30)
+    @Schema(description = "Бонус инициативы игрока (по умолчанию 0). Для существа не учитывается — "
+            + "берётся из статблока бестиария")
+    private Integer initiativeBonus;
+
+    @Nullable
+    @Schema(description = "Слаг существа из бестиария (обязателен для type=CREATURE)")
+    private String creatureUrl;
+
+    @Nullable
+    @Min(1)
+    @Max(100)
+    @Schema(description = "Сколько существ добавить одной пачкой (только для CREATURE, по умолчанию 1). "
+            + "Имена нумеруются автоматически: «Гоблин 1», «Гоблин 2», ...")
+    private Integer count;
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/tracker/rest/dto/ParticipantResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/tracker/rest/dto/ParticipantResponse.java
@@ -1,0 +1,55 @@
+package club.ttg.dnd5.domain.tool.tracker.rest.dto;
+
+import club.ttg.dnd5.domain.tool.tracker.model.ParticipantType;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ParticipantResponse {
+
+    @NotNull
+    @Schema(description = "Идентификатор участника")
+    private UUID id;
+
+    @NotNull
+    @Schema(description = "Тип участника (ключ): PLAYER или CREATURE")
+    private ParticipantType type;
+
+    @NotNull
+    @Schema(description = "Человеко-читаемый тип: «Игрок» или «Существо»")
+    private String typeName;
+
+    @NotNull
+    @Schema(description = "Имя участника")
+    private String name;
+
+    @Schema(description = "Бонус инициативы")
+    private int initiativeBonus;
+
+    @Schema(description = "Повержен: остаётся в списке, но пропускается в порядке хода")
+    private boolean dead;
+
+    @Nullable
+    @Schema(description = "Результат броска d20. NULL — инициатива ещё не брошена")
+    private Integer initiativeRoll;
+
+    @Nullable
+    @Schema(description = "Итог инициативы: бросок + бонус. NULL — инициатива ещё не брошена")
+    private Integer initiativeTotal;
+
+    @Nullable
+    @Schema(description = "Слаг существа в бестиарии (для перехода к статблоку). NULL — игрок")
+    private String creatureUrl;
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/tracker/rest/dto/ParticipantUpdateRequest.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/tracker/rest/dto/ParticipantUpdateRequest.java
@@ -1,0 +1,44 @@
+package club.ttg.dnd5.domain.tool.tracker.rest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Правка участника: применяются только заполненные поля, null — «не менять».
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class ParticipantUpdateRequest {
+
+    @Nullable
+    @Size(max = 100)
+    @Schema(description = "Новое имя участника")
+    private String name;
+
+    @Nullable
+    @Min(-20)
+    @Max(30)
+    @Schema(description = "Новый бонус инициативы (итог пересчитается, если бросок уже сделан)")
+    private Integer initiativeBonus;
+
+    @Nullable
+    @Min(1)
+    @Max(20)
+    @Schema(description = "Ручной результат броска d20 — если игрок кидает живые кости, мастер вносит "
+            + "выпавшее значение; итог считается как бросок + бонус")
+    private Integer initiativeRoll;
+
+    @Nullable
+    @Schema(description = "Пометить участника мёртвым/живым: true — повержен (остаётся в списке, "
+            + "но пропускается в порядке хода), false — вернуть в бой")
+    private Boolean dead;
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/tracker/rest/dto/TrackerDetailedResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/tracker/rest/dto/TrackerDetailedResponse.java
@@ -1,0 +1,66 @@
+package club.ttg.dnd5.domain.tool.tracker.rest.dto;
+
+import club.ttg.dnd5.domain.tool.tracker.model.TrackerStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TrackerDetailedResponse {
+
+    @NotNull
+    @Schema(description = "Идентификатор трекера")
+    private UUID id;
+
+    @NotNull
+    @Schema(description = "Название трекера")
+    private String name;
+
+    @NotNull
+    @Schema(description = "Статус (ключ): PREPARING или ACTIVE")
+    private TrackerStatus status;
+
+    @NotNull
+    @Schema(description = "Человеко-читаемый статус: «Подготовка» или «Бой»")
+    private String statusName;
+
+    @Schema(description = "Номер раунда боя: 0 — бой не начат")
+    private int round;
+
+    @Schema(description = "Новая инициатива каждый раунд (опция)")
+    private boolean rerollEachRound;
+
+    @Nullable
+    @Schema(description = "id участника, чей сейчас ход. NULL — бой не начат")
+    private UUID currentParticipantId;
+
+    @Nullable
+    @Schema(description = "Секретный ключ доступа к анонимному трекеру: сохраните его на клиенте "
+            + "и передавайте в заголовке X-Tracker-Key. Для трекера с владельцем не используется")
+    private UUID accessKey;
+
+    @Nullable
+    @Schema(description = "Дата создания")
+    private Instant createdAt;
+
+    @Nullable
+    @Schema(description = "Дата последнего изменения")
+    private Instant updatedAt;
+
+    @NotNull
+    @Schema(description = "Участники в порядке хода; не бросавшие инициативу — в конце, в порядке добавления")
+    private List<ParticipantResponse> participants;
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/tracker/rest/dto/TrackerRequest.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/tracker/rest/dto/TrackerRequest.java
@@ -1,0 +1,26 @@
+package club.ttg.dnd5.domain.tool.tracker.rest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class TrackerRequest {
+
+    @Nullable
+    @Size(max = 100)
+    @Schema(description = "Название трекера (по умолчанию — «Новый трекер»)")
+    private String name;
+
+    @Nullable
+    @Schema(description = "Опция «новая инициатива каждый раунд»: true — перебрасывать инициативу всем "
+            + "живым в начале каждого раунда. При обновлении null — не менять; при создании по умолчанию false")
+    private Boolean rerollEachRound;
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/tracker/rest/dto/TrackerShortResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/tracker/rest/dto/TrackerShortResponse.java
@@ -1,0 +1,53 @@
+package club.ttg.dnd5.domain.tool.tracker.rest.dto;
+
+import club.ttg.dnd5.domain.tool.tracker.model.TrackerStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class TrackerShortResponse {
+
+    @NotNull
+    @Schema(description = "Идентификатор трекера")
+    private UUID id;
+
+    @NotNull
+    @Schema(description = "Название трекера")
+    private String name;
+
+    @NotNull
+    @Schema(description = "Статус (ключ): PREPARING или ACTIVE")
+    private TrackerStatus status;
+
+    @NotNull
+    @Schema(description = "Человеко-читаемый статус: «Подготовка» или «Бой»")
+    private String statusName;
+
+    @Schema(description = "Номер раунда боя: 0 — бой не начат")
+    private int round;
+
+    @Schema(description = "Новая инициатива каждый раунд (опция)")
+    private boolean rerollEachRound;
+
+    @Schema(description = "Трекер удалён (виден только в истории при includeDeleted=true)")
+    private boolean deleted;
+
+    @Nullable
+    @Schema(description = "Дата создания (история создания трекеров)")
+    private Instant createdAt;
+
+    @Nullable
+    @Schema(description = "Дата последнего изменения")
+    private Instant updatedAt;
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/tracker/rest/mapper/InitiativeTrackerMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/tracker/rest/mapper/InitiativeTrackerMapper.java
@@ -1,0 +1,57 @@
+package club.ttg.dnd5.domain.tool.tracker.rest.mapper;
+
+import club.ttg.dnd5.domain.tool.tracker.model.InitiativeParticipant;
+import club.ttg.dnd5.domain.tool.tracker.model.InitiativeTracker;
+import club.ttg.dnd5.domain.tool.tracker.rest.dto.ParticipantResponse;
+import club.ttg.dnd5.domain.tool.tracker.rest.dto.TrackerDetailedResponse;
+import club.ttg.dnd5.domain.tool.tracker.rest.dto.TrackerShortResponse;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+import java.util.Collection;
+import java.util.List;
+
+@Mapper(unmappedTargetPolicy = ReportingPolicy.ERROR, componentModel = "spring")
+public interface InitiativeTrackerMapper {
+
+    /**
+     * Ответ на создание — единственный, в котором отдаётся секретный ключ доступа
+     * {@code accessKey} (аноним сохраняет его на клиенте).
+     */
+    @Mapping(source = "tracker.id", target = "id")
+    @Mapping(source = "tracker.name", target = "name")
+    @Mapping(source = "tracker.status", target = "status")
+    @Mapping(source = "tracker.status.name", target = "statusName")
+    @Mapping(source = "tracker.round", target = "round")
+    @Mapping(source = "tracker.rerollEachRound", target = "rerollEachRound")
+    @Mapping(source = "tracker.currentParticipantId", target = "currentParticipantId")
+    @Mapping(source = "tracker.accessKey", target = "accessKey")
+    @Mapping(source = "tracker.createdAt", target = "createdAt")
+    @Mapping(source = "tracker.updatedAt", target = "updatedAt")
+    @Mapping(source = "participants", target = "participants")
+    TrackerDetailedResponse toCreatedResponse(InitiativeTracker tracker, List<InitiativeParticipant> participants);
+
+    @Mapping(source = "tracker.id", target = "id")
+    @Mapping(source = "tracker.name", target = "name")
+    @Mapping(source = "tracker.status", target = "status")
+    @Mapping(source = "tracker.status.name", target = "statusName")
+    @Mapping(source = "tracker.round", target = "round")
+    @Mapping(source = "tracker.rerollEachRound", target = "rerollEachRound")
+    @Mapping(source = "tracker.currentParticipantId", target = "currentParticipantId")
+    @Mapping(target = "accessKey", ignore = true)
+    @Mapping(source = "tracker.createdAt", target = "createdAt")
+    @Mapping(source = "tracker.updatedAt", target = "updatedAt")
+    @Mapping(source = "participants", target = "participants")
+    TrackerDetailedResponse toDetailedResponse(InitiativeTracker tracker, List<InitiativeParticipant> participants);
+
+    @Mapping(source = "status.name", target = "statusName")
+    TrackerShortResponse toShortResponse(InitiativeTracker tracker);
+
+    List<TrackerShortResponse> toShortResponseList(Collection<InitiativeTracker> trackers);
+
+    @Mapping(source = "type.name", target = "typeName")
+    ParticipantResponse toParticipantResponse(InitiativeParticipant participant);
+
+    List<ParticipantResponse> toParticipantResponseList(Collection<InitiativeParticipant> participants);
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/tracker/service/InitiativeCombatService.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/tracker/service/InitiativeCombatService.java
@@ -1,0 +1,266 @@
+package club.ttg.dnd5.domain.tool.tracker.service;
+
+import club.ttg.dnd5.domain.tool.tracker.model.InitiativeParticipant;
+import club.ttg.dnd5.domain.tool.tracker.model.InitiativeTracker;
+import club.ttg.dnd5.domain.tool.tracker.model.TrackerStatus;
+import club.ttg.dnd5.exception.ApiException;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Боевая логика трекера инициативы: броски d20, порядок хода и переключение ходов.
+ * <p>
+ * Порядок хода по правилам D&D: больший итог инициативы первее; при равном итоге первее
+ * больший бонус инициативы; при полном равенстве — «монетка» ({@code tieRoll}, случайное
+ * число, назначаемое при броске). «Монетка» хранится, поэтому порядок детерминирован:
+ * участник, добавленный в идущий бой, не пересортировывает остальных.
+ * <p>
+ * Повержённые ({@code dead}) участники остаются в списке (и в сортировке), но пропускаются
+ * при передаче хода.
+ */
+@Service
+public class InitiativeCombatService {
+
+    /**
+     * Бросает d20 всем участникам (полный ре-ролл) и пересобирает порядок, но бой НЕ начинает —
+     * старт выделен в отдельное действие ({@link #start}). Статус-агностично: в подготовке трекер
+     * остаётся {@code PREPARING} и ход не назначается; в идущем бою это «ре-ролл» — раунд
+     * возвращается к 1, ход переходит первому живому.
+     */
+    public void rollAll(InitiativeTracker tracker, List<InitiativeParticipant> participants) {
+        if (participants.isEmpty()) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "Добавьте участников перед броском инициативы");
+        }
+        participants.forEach(this::roll);
+        if (tracker.getStatus() == TrackerStatus.ACTIVE) {
+            tracker.setRound(1);
+            InitiativeParticipant first = firstAlive(participants);
+            tracker.setCurrentParticipantId(first != null ? first.getId() : null);
+        }
+    }
+
+    /**
+     * Начинает бой, сохраняя уже введённые броски: участнику с готовым броском
+     * ({@code initiativeRoll != null}) итог инициативы не меняется — переходит в бой как есть;
+     * участнику без броска ставится {@code initiativeTotal = 0} (без доброса d20 и без учёта
+     * бонуса; сам бонус в записи сохраняется на случай последующего броска). Порядок хода — по
+     * итогу инициативы (не брошенные, 0, — в конце, в порядке добавления {@code seq}); инициативу
+     * этим участникам мастер задаёт вручную или бросками по ходу боя. Ход — первому живому; все
+     * повержены — текущего хода нет.
+     */
+    public void start(InitiativeTracker tracker, List<InitiativeParticipant> participants) {
+        if (participants.isEmpty()) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "Добавьте участников перед началом боя");
+        }
+        participants.stream()
+                .filter(participant -> participant.getInitiativeRoll() == null)
+                .forEach(participant -> participant.setInitiativeTotal(0));
+        startBattle(tracker, participants);
+    }
+
+    /** Бросает участнику d20 и назначает «монетку» тай-брейка. */
+    public void roll(InitiativeParticipant participant) {
+        participant.setInitiativeRoll(ThreadLocalRandom.current().nextInt(1, 21));
+        participant.setTieRoll(ThreadLocalRandom.current().nextInt());
+        recalculateTotal(participant);
+    }
+
+    /**
+     * Пересчитывает итог инициативы (бросок + бонус) после правки броска или бонуса;
+     * без броска итога нет. Броску, внесённому вручную, назначается недостающая «монетка».
+     */
+    public void recalculateTotal(InitiativeParticipant participant) {
+        if (participant.getInitiativeRoll() == null) {
+            participant.setInitiativeTotal(null);
+            return;
+        }
+        if (participant.getTieRoll() == null) {
+            participant.setTieRoll(ThreadLocalRandom.current().nextInt());
+        }
+        participant.setInitiativeTotal(participant.getInitiativeRoll() + participant.getInitiativeBonus());
+    }
+
+    /**
+     * Передаёт ход следующему живому по порядку, пропуская повержённых; после последнего — новый
+     * раунд и ход первому живому. Если у трекера включён {@code rerollEachRound}, на новом раунде
+     * всем живым инициатива перебрасывается заново. Все повержены — текущего хода не остаётся.
+     */
+    public void nextTurn(InitiativeTracker tracker, List<InitiativeParticipant> participants) {
+        if (tracker.getStatus() != TrackerStatus.ACTIVE) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "Бой не начат — сначала прокиньте инициативу");
+        }
+        List<InitiativeParticipant> order = sort(participants);
+        if (order.isEmpty()) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "В трекере нет участников");
+        }
+        int currentIndex = indexOf(order, tracker.getCurrentParticipantId());
+        NextTurn result = nextAlive(order, currentIndex, null);
+        if (result.participant() == null) {
+            tracker.setCurrentParticipantId(null);
+            return;
+        }
+        InitiativeParticipant next = result.participant();
+        if (result.wrapped()) {
+            tracker.setRound(tracker.getRound() + 1);
+            if (tracker.isRerollEachRound()) {
+                order.stream().filter(participant -> !participant.isDead()).forEach(this::roll);
+                next = firstAlive(participants);
+            }
+        }
+        tracker.setCurrentParticipantId(next != null ? next.getId() : null);
+    }
+
+    /**
+     * Переносит ход с удаляемого участника на следующего живого (вызывается ДО удаления).
+     * Удаляемый ходил последним в раунде — ход первому живому и новый раунд; живых больше
+     * не остаётся — текущего хода нет.
+     */
+    public void onParticipantRemoval(InitiativeTracker tracker,
+                                     List<InitiativeParticipant> participants,
+                                     InitiativeParticipant removed) {
+        if (!removed.getId().equals(tracker.getCurrentParticipantId())) {
+            return;
+        }
+        List<InitiativeParticipant> order = sort(participants);
+        int removedIndex = indexOf(order, removed.getId());
+        NextTurn result = nextAlive(order, removedIndex, removed.getId());
+        if (result.participant() == null) {
+            tracker.setCurrentParticipantId(null);
+            return;
+        }
+        if (result.wrapped()) {
+            tracker.setRound(tracker.getRound() + 1);
+        }
+        tracker.setCurrentParticipantId(result.participant().getId());
+    }
+
+    /**
+     * Возвращает трекер в подготовку: броски очищаются, повержённые «оживают», состав участников
+     * сохраняется.
+     */
+    public void reset(InitiativeTracker tracker, List<InitiativeParticipant> participants) {
+        tracker.setStatus(TrackerStatus.PREPARING);
+        tracker.setRound(0);
+        tracker.setCurrentParticipantId(null);
+        participants.forEach(participant -> {
+            participant.setInitiativeRoll(null);
+            participant.setInitiativeTotal(null);
+            participant.setTieRoll(null);
+            participant.setDead(false);
+        });
+    }
+
+    /** Участники в порядке хода; не бросавшие инициативу — в конце, в порядке добавления. */
+    public static List<InitiativeParticipant> sort(Collection<InitiativeParticipant> participants) {
+        return participants.stream()
+                .sorted(InitiativeCombatService::compareTurnOrder)
+                .toList();
+    }
+
+    private void startBattle(InitiativeTracker tracker, List<InitiativeParticipant> participants) {
+        tracker.setStatus(TrackerStatus.ACTIVE);
+        tracker.setRound(1);
+        InitiativeParticipant first = firstAlive(participants);
+        tracker.setCurrentParticipantId(first != null ? first.getId() : null);
+    }
+
+    private static InitiativeParticipant firstAlive(Collection<InitiativeParticipant> participants) {
+        return sort(participants).stream()
+                .filter(participant -> !participant.isDead())
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * Следующий живой участник после позиции {@code fromIndex} (по кругу), пропуская повержённых
+     * и {@code excludedId} (удаляемого). {@code wrapped} — был ли переход через конец списка
+     * (значит начался новый раунд). {@code participant == null} — живых не осталось.
+     */
+    private static NextTurn nextAlive(List<InitiativeParticipant> order, int fromIndex, UUID excludedId) {
+        int size = order.size();
+        boolean wrapped = false;
+        for (int step = 1; step <= size; step++) {
+            int raw = fromIndex + step;
+            if (raw >= size && fromIndex >= 0) {
+                wrapped = true;
+            }
+            InitiativeParticipant candidate = order.get(((raw % size) + size) % size);
+            if (excludedId != null && excludedId.equals(candidate.getId())) {
+                continue;
+            }
+            if (candidate.isDead()) {
+                continue;
+            }
+            return new NextTurn(candidate, wrapped);
+        }
+        return new NextTurn(null, wrapped);
+    }
+
+    private static int compareTurnOrder(InitiativeParticipant left, InitiativeParticipant right) {
+        if (left.getInitiativeTotal() == null || right.getInitiativeTotal() == null) {
+            if (left.getInitiativeTotal() != null) {
+                return -1;
+            }
+            if (right.getInitiativeTotal() != null) {
+                return 1;
+            }
+            return compareBySeq(left, right);
+        }
+        int byTotal = right.getInitiativeTotal().compareTo(left.getInitiativeTotal());
+        if (byTotal != 0) {
+            return byTotal;
+        }
+        // При равном итоге брошенный участник идёт раньше не брошенного. Инициатива 0 без броска
+        // (tieRoll == null, выставляется при /start) — это заглушка, а не результат броска. Единый
+        // бинарный ключ «брошен ли» ОБЯЗАТЕЛЕН для транзитивности компаратора: без него брошенные с
+        // итогом 0 (низкий бросок при отрицательном бонусе) сравнивались бы между собой по бонусу, а
+        // с не брошенными — по seq, что образует цикл и нарушает контракт Comparator (IllegalArgumentException в sorted()).
+        boolean leftRolled = left.getTieRoll() != null;
+        boolean rightRolled = right.getTieRoll() != null;
+        if (leftRolled != rightRolled) {
+            return leftRolled ? -1 : 1;
+        }
+        // Тай-брейки D&D (бонус, затем «монетка») — только между брошенными; не брошенные с равным
+        // итогом (0) сохраняют порядок добавления (seq).
+        if (leftRolled) {
+            int byBonus = Integer.compare(right.getInitiativeBonus(), left.getInitiativeBonus());
+            if (byBonus != 0) {
+                return byBonus;
+            }
+            int byTieRoll = Integer.compare(right.getTieRoll(), left.getTieRoll());
+            if (byTieRoll != 0) {
+                return byTieRoll;
+            }
+        }
+        return compareBySeq(left, right);
+    }
+
+    /** По номеру добавления; при совпадении (теоретическая гонка добавлений) — по id, чтобы порядок был стабилен. */
+    private static int compareBySeq(InitiativeParticipant left, InitiativeParticipant right) {
+        int bySeq = Integer.compare(left.getSeq(), right.getSeq());
+        if (bySeq != 0 || left.getId() == null || right.getId() == null) {
+            return bySeq;
+        }
+        return left.getId().compareTo(right.getId());
+    }
+
+    private static int indexOf(List<InitiativeParticipant> order, UUID participantId) {
+        if (participantId == null) {
+            return -1;
+        }
+        for (int i = 0; i < order.size(); i++) {
+            if (order.get(i).getId().equals(participantId)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private record NextTurn(InitiativeParticipant participant, boolean wrapped) {
+    }
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/tracker/service/InitiativeTrackerService.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/tracker/service/InitiativeTrackerService.java
@@ -1,0 +1,392 @@
+package club.ttg.dnd5.domain.tool.tracker.service;
+
+import club.ttg.dnd5.domain.beastiary.model.Creature;
+import club.ttg.dnd5.domain.beastiary.repository.CreatureRepository;
+import club.ttg.dnd5.domain.beastiary.service.CreatureInitiativeCalculator;
+import club.ttg.dnd5.domain.tool.tracker.model.InitiativeParticipant;
+import club.ttg.dnd5.domain.tool.tracker.model.InitiativeTracker;
+import club.ttg.dnd5.domain.tool.tracker.model.ParticipantType;
+import club.ttg.dnd5.domain.tool.tracker.model.TrackerStatus;
+import club.ttg.dnd5.domain.tool.tracker.repository.InitiativeParticipantRepository;
+import club.ttg.dnd5.domain.tool.tracker.repository.InitiativeTrackerRepository;
+import club.ttg.dnd5.domain.tool.tracker.rest.dto.ParticipantAddRequest;
+import club.ttg.dnd5.domain.tool.tracker.rest.dto.ParticipantUpdateRequest;
+import club.ttg.dnd5.domain.tool.tracker.rest.dto.TrackerDetailedResponse;
+import club.ttg.dnd5.domain.tool.tracker.rest.dto.TrackerRequest;
+import club.ttg.dnd5.domain.tool.tracker.rest.dto.TrackerShortResponse;
+import club.ttg.dnd5.domain.tool.tracker.rest.mapper.InitiativeTrackerMapper;
+import club.ttg.dnd5.domain.user.model.User;
+import club.ttg.dnd5.exception.ApiException;
+import club.ttg.dnd5.exception.EntityNotFoundException;
+import club.ttg.dnd5.security.SecurityUtils;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Трекер инициативы: создание и доступ, лимиты, состав участников.
+ * Боевая логика (броски, порядок и переключение ходов) — в {@link InitiativeCombatService}.
+ */
+@RequiredArgsConstructor
+@Service
+public class InitiativeTrackerService {
+
+    public static final String TRACKER_KEY_HEADER = "X-Tracker-Key";
+
+    private static final int MAX_TRACKERS_PER_USER = 10;
+    private static final int MAX_PLAYERS_PER_TRACKER = 50;
+    private static final int MAX_CREATURES_PER_TRACKER = 100;
+    private static final int MAX_DELETED_HISTORY_PER_USER = 30;
+    private static final String DEFAULT_NAME = "Новый трекер";
+
+    /** Хвостовой номер в имени существа («Гоблин 12» → 12) для продолжения нумерации. */
+    private static final Pattern TRAILING_NUMBER = Pattern.compile("(\\d{1,6})$");
+
+    private final InitiativeTrackerRepository trackerRepository;
+    private final InitiativeParticipantRepository participantRepository;
+    private final InitiativeCombatService combatService;
+    private final TrackerCreationRateLimiter creationRateLimiter;
+    private final CreatureRepository creatureRepository;
+    private final InitiativeTrackerMapper trackerMapper;
+
+    /**
+     * Создаёт трекер. Авторизованному — до {@value MAX_TRACKERS_PER_USER} неудалённых, владение
+     * по логину из JWT. Анониму — владение по секретному ключу {@code accessKey} (возвращается
+     * в ответе, клиент хранит его в localStorage); создание ограничено по IP.
+     */
+    @Transactional
+    public TrackerDetailedResponse create(TrackerRequest request, String clientIp) {
+        User user = SecurityUtils.getUserOrNull();
+        if (user == null) {
+            creationRateLimiter.checkAnonymousCreation(clientIp);
+        } else if (trackerRepository.countByOwnerUsernameAndDeletedFalse(user.getUsername()) >= MAX_TRACKERS_PER_USER) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, String.format(
+                    "Достигнут лимит трекеров: %d. Удалите один из существующих", MAX_TRACKERS_PER_USER));
+        }
+
+        InitiativeTracker tracker = new InitiativeTracker();
+        tracker.setName(nameOrDefault(request));
+        tracker.setOwnerUsername(user != null ? user.getUsername() : null);
+        tracker.setAccessKey(UUID.randomUUID());
+        tracker.setStatus(TrackerStatus.PREPARING);
+        tracker.setRound(0);
+        tracker.setRerollEachRound(request != null && Boolean.TRUE.equals(request.getRerollEachRound()));
+
+        // Флаш сразу: createdAt/updatedAt генерирует БД при INSERT, без него в ответе были бы null.
+        InitiativeTracker saved = trackerRepository.saveAndFlush(tracker);
+        return trackerMapper.toCreatedResponse(saved, List.of());
+    }
+
+    /**
+     * Трекеры текущего пользователя, новые первее (createdAt — история создания).
+     * {@code includeDeleted=true} — вместе с удалёнными (полная история).
+     */
+    public List<TrackerShortResponse> findMine(boolean includeDeleted) {
+        String username = SecurityUtils.getUser().getUsername();
+        List<InitiativeTracker> trackers = includeDeleted
+                ? trackerRepository.findAllByOwnerUsernameOrderByCreatedAtDesc(username)
+                : trackerRepository.findAllByOwnerUsernameAndDeletedFalseOrderByCreatedAtDesc(username);
+        return trackerMapper.toShortResponseList(trackers);
+    }
+
+    public TrackerDetailedResponse findById(UUID trackerId, String trackerKey) {
+        return toDetailedResponse(getWithAccess(trackerId, trackerKey));
+    }
+
+    /**
+     * Обновление трекера: применяются только заполненные поля (имя, опция ре-ролла каждый раунд),
+     * null — «не менять».
+     */
+    @Transactional
+    public TrackerDetailedResponse updateSettings(UUID trackerId, TrackerRequest request, String trackerKey) {
+        InitiativeTracker tracker = getWithAccess(trackerId, trackerKey);
+        if (StringUtils.hasText(request.getName())) {
+            tracker.setName(request.getName().trim());
+        }
+        if (request.getRerollEachRound() != null) {
+            tracker.setRerollEachRound(request.getRerollEachRound());
+        }
+        return toDetailedResponse(tracker);
+    }
+
+    /**
+     * Удаление: у трекера с владельцем — мягкое (строка остаётся в истории создания), анонимный
+     * трекер удаляется физически вместе с участниками (истории у анонима нет).
+     * <p>
+     * При мягком удалении участники удаляются физически (они больше недоступны), а история
+     * ограничивается последними {@value MAX_DELETED_HISTORY_PER_USER} удалёнными трекерами —
+     * иначе цикл «создать → наполнить → удалить» рос бы в БД без ограничений: лимит
+     * {@value MAX_TRACKERS_PER_USER} считает только неудалённые.
+     */
+    @Transactional
+    public void delete(UUID trackerId, String trackerKey) {
+        InitiativeTracker tracker = getWithAccess(trackerId, trackerKey);
+        if (tracker.getOwnerUsername() == null) {
+            trackerRepository.delete(tracker);
+            return;
+        }
+        participantRepository.deleteAllByTrackerId(tracker.getId());
+        tracker.setDeleted(true);
+        trimDeletedHistory(tracker.getOwnerUsername());
+    }
+
+    private void trimDeletedHistory(String ownerUsername) {
+        List<InitiativeTracker> deleted =
+                trackerRepository.findAllByOwnerUsernameAndDeletedTrueOrderByUpdatedAtDesc(ownerUsername);
+        if (deleted.size() > MAX_DELETED_HISTORY_PER_USER) {
+            trackerRepository.deleteAll(deleted.subList(MAX_DELETED_HISTORY_PER_USER, deleted.size()));
+        }
+    }
+
+    /**
+     * Добавляет игрока (по одному) или существ из бестиария (пачкой). Участник, добавленный
+     * в идущий бой, сразу получает бросок инициативы и встаёт в порядок хода.
+     */
+    @Transactional
+    public TrackerDetailedResponse addParticipants(UUID trackerId, ParticipantAddRequest request, String trackerKey) {
+        InitiativeTracker tracker = getWithAccess(trackerId, trackerKey);
+        List<InitiativeParticipant> added = request.getType() == ParticipantType.PLAYER
+                ? List.of(buildPlayer(tracker, request))
+                : buildCreatures(tracker, request);
+        if (tracker.getStatus() == TrackerStatus.ACTIVE) {
+            added.forEach(combatService::roll);
+        }
+        participantRepository.saveAll(added);
+        touch(tracker);
+        return toDetailedResponse(tracker);
+    }
+
+    /** Правка участника: применяются только заполненные поля запроса. */
+    @Transactional
+    public TrackerDetailedResponse updateParticipant(UUID trackerId,
+                                                     UUID participantId,
+                                                     ParticipantUpdateRequest request,
+                                                     String trackerKey) {
+        InitiativeTracker tracker = getWithAccess(trackerId, trackerKey);
+        InitiativeParticipant participant = getParticipant(trackerId, participantId);
+        if (StringUtils.hasText(request.getName())) {
+            participant.setName(request.getName().trim());
+        }
+        if (request.getInitiativeBonus() != null) {
+            participant.setInitiativeBonus(request.getInitiativeBonus());
+        }
+        if (request.getInitiativeRoll() != null) {
+            participant.setInitiativeRoll(request.getInitiativeRoll());
+        }
+        if (request.getDead() != null) {
+            participant.setDead(request.getDead());
+        }
+        combatService.recalculateTotal(participant);
+        touch(tracker);
+        return toDetailedResponse(tracker);
+    }
+
+    /** Бросает d20 одному участнику (по одному, не начиная бой и не трогая остальных). */
+    @Transactional
+    public TrackerDetailedResponse rollParticipant(UUID trackerId, UUID participantId, String trackerKey) {
+        InitiativeTracker tracker = getWithAccess(trackerId, trackerKey);
+        InitiativeParticipant participant = getParticipant(trackerId, participantId);
+        combatService.roll(participant);
+        touch(tracker);
+        return toDetailedResponse(tracker);
+    }
+
+    @Transactional
+    public TrackerDetailedResponse deleteParticipant(UUID trackerId, UUID participantId, String trackerKey) {
+        InitiativeTracker tracker = getWithAccess(trackerId, trackerKey);
+        InitiativeParticipant participant = getParticipant(trackerId, participantId);
+        combatService.onParticipantRemoval(tracker, participantRepository.findAllByTrackerId(trackerId), participant);
+        participantRepository.delete(participant);
+        touch(tracker);
+        return toDetailedResponse(tracker);
+    }
+
+    /**
+     * Бросает d20 всем участникам и пересобирает порядок, но бой не начинает (для старта —
+     * {@link #start}). В подготовке статус остаётся {@code PREPARING}; в идущем бою — ре-ролл
+     * (раунд с начала, ход первому живому).
+     */
+    @Transactional
+    public TrackerDetailedResponse rollInitiative(UUID trackerId, String trackerKey) {
+        InitiativeTracker tracker = getWithAccess(trackerId, trackerKey);
+        combatService.rollAll(tracker, participantRepository.findAllByTrackerId(trackerId));
+        return toDetailedResponse(tracker);
+    }
+
+    /**
+     * Начинает бой, сохраняя уже введённые броски: у кого инициатива уже задана/брошена — итог
+     * переходит в бой как есть; остальным {@code initiativeTotal = 0} (без доброса d20 и без
+     * бонуса). Инициативу нулевым участникам мастер задаёт вручную (правкой участника) или
+     * бросками по ходу боя. В отличие от {@link #rollInitiative} (случайный d20 + бонус всем и
+     * полная сортировка).
+     */
+    @Transactional
+    public TrackerDetailedResponse start(UUID trackerId, String trackerKey) {
+        InitiativeTracker tracker = getWithAccess(trackerId, trackerKey);
+        combatService.start(tracker, participantRepository.findAllByTrackerId(trackerId));
+        return toDetailedResponse(tracker);
+    }
+
+    @Transactional
+    public TrackerDetailedResponse nextTurn(UUID trackerId, String trackerKey) {
+        InitiativeTracker tracker = getWithAccess(trackerId, trackerKey);
+        combatService.nextTurn(tracker, participantRepository.findAllByTrackerId(trackerId));
+        return toDetailedResponse(tracker);
+    }
+
+    /** Завершает бой: броски очищаются, состав сохраняется, трекер снова в подготовке. */
+    @Transactional
+    public TrackerDetailedResponse reset(UUID trackerId, String trackerKey) {
+        InitiativeTracker tracker = getWithAccess(trackerId, trackerKey);
+        combatService.reset(tracker, participantRepository.findAllByTrackerId(trackerId));
+        return toDetailedResponse(tracker);
+    }
+
+    private InitiativeParticipant buildPlayer(InitiativeTracker tracker, ParticipantAddRequest request) {
+        if (!StringUtils.hasText(request.getName())) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "Укажите имя игрока");
+        }
+        validatePlayerLimit(tracker.getId(), 1);
+        InitiativeParticipant participant =
+                newParticipant(tracker, ParticipantType.PLAYER, participantRepository.findMaxSeq(tracker.getId()) + 1);
+        participant.setName(request.getName().trim());
+        participant.setInitiativeBonus(request.getInitiativeBonus() != null ? request.getInitiativeBonus() : 0);
+        return participant;
+    }
+
+    private List<InitiativeParticipant> buildCreatures(InitiativeTracker tracker, ParticipantAddRequest request) {
+        if (!StringUtils.hasText(request.getCreatureUrl())) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "Укажите существо из бестиария (creatureUrl)");
+        }
+        int count = request.getCount() != null ? request.getCount() : 1;
+        validateCreatureLimit(tracker.getId(), count);
+        Creature creature = creatureRepository.findById(request.getCreatureUrl())
+                .orElseThrow(() -> new EntityNotFoundException(
+                        String.format("Существо с URL: %s не существует", request.getCreatureUrl())));
+
+        // Имя и бонус — снапшот из бестиария на момент добавления: правка бестиария не влияет на бой.
+        int bonus = CreatureInitiativeCalculator.initiativeBonus(creature);
+        String baseName = StringUtils.hasText(request.getName()) ? request.getName().trim() : creature.getName();
+        List<InitiativeParticipant> current = participantRepository.findAllByTrackerId(tracker.getId());
+        int nextNumber = nextCreatureNumber(current, creature.getUrl());
+        int maxSeq = current.stream().mapToInt(InitiativeParticipant::getSeq).max().orElse(0);
+
+        List<InitiativeParticipant> creatures = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            InitiativeParticipant participant = newParticipant(tracker, ParticipantType.CREATURE, maxSeq + i + 1);
+            participant.setName(String.format("%s %d", baseName, nextNumber + i));
+            participant.setInitiativeBonus(bonus);
+            participant.setCreatureUrl(creature.getUrl());
+            creatures.add(participant);
+        }
+        return creatures;
+    }
+
+    /**
+     * Следующий номер для имени существа: максимальный хвостовой номер среди участников этого же
+     * существа + 1. Нумерация по максимуму, а не по количеству — после удаления «Гоблина 2»
+     * следующий станет «Гоблином 4», а не дублем «Гоблина 3».
+     */
+    private static int nextCreatureNumber(List<InitiativeParticipant> participants, String creatureUrl) {
+        int max = 0;
+        for (InitiativeParticipant participant : participants) {
+            if (!creatureUrl.equals(participant.getCreatureUrl())) {
+                continue;
+            }
+            Matcher matcher = TRAILING_NUMBER.matcher(participant.getName());
+            if (matcher.find()) {
+                max = Math.max(max, Integer.parseInt(matcher.group(1)));
+            }
+        }
+        return max + 1;
+    }
+
+    private InitiativeParticipant newParticipant(InitiativeTracker tracker, ParticipantType type, int seq) {
+        InitiativeParticipant participant = new InitiativeParticipant();
+        participant.setTrackerId(tracker.getId());
+        participant.setType(type);
+        participant.setSeq(seq);
+        return participant;
+    }
+
+    private void validatePlayerLimit(UUID trackerId, int toAdd) {
+        if (participantRepository.countByTrackerIdAndType(trackerId, ParticipantType.PLAYER) + toAdd
+                > MAX_PLAYERS_PER_TRACKER) {
+            throw new ApiException(HttpStatus.BAD_REQUEST,
+                    String.format("Достигнут лимит игроков в трекере: %d", MAX_PLAYERS_PER_TRACKER));
+        }
+    }
+
+    private void validateCreatureLimit(UUID trackerId, int toAdd) {
+        if (participantRepository.countByTrackerIdAndType(trackerId, ParticipantType.CREATURE) + toAdd
+                > MAX_CREATURES_PER_TRACKER) {
+            throw new ApiException(HttpStatus.BAD_REQUEST,
+                    String.format("Достигнут лимит существ в трекере: %d", MAX_CREATURES_PER_TRACKER));
+        }
+    }
+
+    private InitiativeTracker getWithAccess(UUID trackerId, String trackerKey) {
+        InitiativeTracker tracker = trackerRepository.findById(trackerId)
+                .filter(found -> !found.isDeleted())
+                .orElseThrow(() -> new EntityNotFoundException(
+                        String.format("Трекер с id %s не существует", trackerId)));
+        requireAccess(tracker, trackerKey);
+        return tracker;
+    }
+
+    /**
+     * Трекер с владельцем доступен только владельцу (по логину из JWT), анонимный — по
+     * секретному ключу из заголовка {@value TRACKER_KEY_HEADER}.
+     */
+    private void requireAccess(InitiativeTracker tracker, String trackerKey) {
+        if (tracker.getOwnerUsername() != null) {
+            User user = SecurityUtils.getUserOrNull();
+            if (user == null || !tracker.getOwnerUsername().equals(user.getUsername())) {
+                throw new ApiException(HttpStatus.FORBIDDEN, "Доступ к трекеру запрещен");
+            }
+            return;
+        }
+        if (trackerKey == null || !trackerKey.trim().equalsIgnoreCase(tracker.getAccessKey().toString())) {
+            throw new ApiException(HttpStatus.FORBIDDEN, "Доступ к трекеру запрещен");
+        }
+    }
+
+    private InitiativeParticipant getParticipant(UUID trackerId, UUID participantId) {
+        return participantRepository.findByIdAndTrackerId(participantId, trackerId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        String.format("Участник с id %s не существует", participantId)));
+    }
+
+    private TrackerDetailedResponse toDetailedResponse(InitiativeTracker tracker) {
+        List<InitiativeParticipant> order =
+                InitiativeCombatService.sort(participantRepository.findAllByTrackerId(tracker.getId()));
+        return trackerMapper.toDetailedResponse(tracker, order);
+    }
+
+    /**
+     * Отметка активности для TTL-очистки анонимных трекеров: операции только с участниками
+     * не меняют строку трекера, поэтому updated_at обновляется явно. Значение дублируется
+     * в загруженную сущность — bulk-update не виден persistence context, а ответ должен
+     * отдавать свежий updatedAt.
+     */
+    private void touch(InitiativeTracker tracker) {
+        Instant now = Instant.now();
+        trackerRepository.touch(tracker.getId(), now);
+        tracker.setUpdatedAt(now);
+    }
+
+    private String nameOrDefault(TrackerRequest request) {
+        return request != null && StringUtils.hasText(request.getName())
+                ? request.getName().trim()
+                : DEFAULT_NAME;
+    }
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/tracker/service/TrackerCleanupScheduler.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/tracker/service/TrackerCleanupScheduler.java
@@ -1,0 +1,38 @@
+package club.ttg.dnd5.domain.tool.tracker.service;
+
+import club.ttg.dnd5.config.properties.TrackerProperties;
+import club.ttg.dnd5.domain.tool.tracker.repository.InitiativeTrackerRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+
+/**
+ * Периодически удаляет анонимные трекеры инициативы без активности.
+ * <p>
+ * У анонимного трекера нет владельца: если клиент потерял ключ (очистил localStorage),
+ * трекер больше никому не доступен и копится мусором. Признак активности — updated_at
+ * строки трекера; операции только с участниками дополнительно «трогают» трекер
+ * (см. {@link InitiativeTrackerRepository#touch}). Трекеры владельцев не удаляются —
+ * они видны в истории пользователя.
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class TrackerCleanupScheduler {
+
+    private final InitiativeTrackerRepository trackerRepository;
+    private final TrackerProperties properties;
+
+    @Transactional
+    @Scheduled(fixedDelayString = "${tracker.cleanup-interval:PT1H}")
+    public void cleanupStaleAnonymous() {
+        int removed = trackerRepository.deleteStaleAnonymous(Instant.now().minus(properties.getAnonymousTtl()));
+        if (removed > 0) {
+            log.info("Удалено анонимных трекеров инициативы без активности: {}", removed);
+        }
+    }
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/tracker/service/TrackerCreationRateLimiter.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/tracker/service/TrackerCreationRateLimiter.java
@@ -1,0 +1,74 @@
+package club.ttg.dnd5.domain.tool.tracker.service;
+
+import club.ttg.dnd5.config.properties.TrackerProperties;
+import club.ttg.dnd5.exception.ApiException;
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Ограничение создания анонимных трекеров инициативы по IP (bucket4j, в памяти).
+ * <p>
+ * Лимит «один трекер анониму» держит клиент (localStorage); сервер этой защитой
+ * лишь пресекает массовое создание мусорных трекеров с одного адреса.
+ */
+@RequiredArgsConstructor
+@Component
+public class TrackerCreationRateLimiter {
+
+    private final TrackerProperties properties;
+
+    private final Map<String, BucketEntry> buckets = new ConcurrentHashMap<>();
+
+    public void checkAnonymousCreation(String clientIp) {
+        BucketEntry entry = buckets.computeIfAbsent(clientIp,
+                ip -> new BucketEntry(newBucket(), new AtomicReference<>(Instant.now())));
+        entry.lastSeen().set(Instant.now());
+        if (!entry.bucket().tryConsume(1)) {
+            throw new ApiException(HttpStatus.TOO_MANY_REQUESTS,
+                    "Слишком много анонимных трекеров. Попробуйте позже или войдите в аккаунт");
+        }
+    }
+
+    /**
+     * IP клиента с учётом X-Forwarded-For — тот же способ, что в
+     * {@link club.ttg.dnd5.config.RateLimitFilter}.
+     */
+    public static String resolveClientIp(HttpServletRequest request) {
+        String forwarded = request.getHeader("X-Forwarded-For");
+        if (forwarded != null && !forwarded.isBlank()) {
+            return forwarded.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+
+    private Bucket newBucket() {
+        Bandwidth limit = Bandwidth.builder()
+                .capacity(properties.getAnonymousCreateLimit())
+                .refillGreedy(properties.getAnonymousCreateLimit(), properties.getAnonymousCreateWindow())
+                .build();
+
+        return Bucket.builder()
+                .addLimit(limit)
+                .build();
+    }
+
+    /** Очистка простаивающих bucket'ов, чтобы карта не росла бесконечно. */
+    @Scheduled(fixedDelayString = "PT30M")
+    public void cleanup() {
+        Instant cutoff = Instant.now().minus(properties.getBucketIdleTtl());
+        buckets.entrySet().removeIf(entry -> entry.getValue().lastSeen().get().isBefore(cutoff));
+    }
+
+    private record BucketEntry(Bucket bucket, AtomicReference<Instant> lastSeen) {
+    }
+}

--- a/src/main/java/club/ttg/dnd5/exception/ExceptionController.java
+++ b/src/main/java/club/ttg/dnd5/exception/ExceptionController.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -14,6 +15,7 @@ import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 import java.io.IOException;
+import java.util.stream.Collectors;
 
 @Slf4j
 @ControllerAdvice
@@ -36,6 +38,15 @@ public class ExceptionController {
     @ExceptionHandler(MissingServletRequestParameterException.class)
     public ResponseEntity<ErrorResponseDto> handleRequestParamException(MissingServletRequestParameterException exception) {
         String message = String.format("Отсутствует необходимый параметр \"%s\"", exception.getParameterName());
+
+        return convertToResponseEntity(HttpStatus.BAD_REQUEST, message);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponseDto> handleMethodArgumentNotValid(MethodArgumentNotValidException exception) {
+        String message = exception.getBindingResult().getFieldErrors().stream()
+                .map(error -> String.format("%s: %s", error.getField(), error.getDefaultMessage()))
+                .collect(Collectors.joining("; "));
 
         return convertToResponseEntity(HttpStatus.BAD_REQUEST, message);
     }

--- a/src/main/java/club/ttg/dnd5/security/SecurityUtils.java
+++ b/src/main/java/club/ttg/dnd5/security/SecurityUtils.java
@@ -42,6 +42,22 @@ public final class SecurityUtils {
     }
 
     /**
+     * Метод возвращает данные пользователя из токена или {@code null}, если запрос анонимный.
+     * Для публичных ручек, поведение которых зависит от наличия авторизации.
+     *
+     * @return Данные пользователя или {@code null}.
+     */
+    public static User getUserOrNull() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (Objects.isNull(authentication) || !(authentication.getPrincipal() instanceof User user)) {
+            return null;
+        }
+
+        return user;
+    }
+
+    /**
      * Метод возвращает стрим ролей пользователя расшифрованные из токена.
      *
      * @return Роли пользователя.

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -83,6 +83,15 @@ vk.api-version=${VK_API_VERSION:5.199}
 # Период опроса «пора постить» (ISO-8601 duration).
 vk.poll-interval=${VK_POLL_INTERVAL:PT1M}
 
+# Трекер инициативы (инструмент). Анонимные трекеры (без владельца) живут tracker.anonymous-ttl
+# с последней активности и затем удаляются планировщиком (период — tracker.cleanup-interval).
+# Создание анонимных трекеров ограничено tracker.anonymous-create-limit на IP
+# за окно tracker.anonymous-create-window (ISO-8601 duration).
+tracker.anonymous-create-limit=10
+tracker.anonymous-create-window=PT1H
+tracker.anonymous-ttl=P14D
+tracker.cleanup-interval=PT1H
+
 # JPA
 spring.jpa.generate-ddl=false
 spring.jpa.hibernate.ddl-auto=validate

--- a/src/main/resources/db/changelog/2026/07/10-04-create-initiative-tracker-table.yaml
+++ b/src/main/resources/db/changelog/2026/07/10-04-create-initiative-tracker-table.yaml
@@ -1,0 +1,72 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-10-04-create-initiative-tracker-table
+      author: Peterko
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            tableName: initiative_tracker
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_initiative_tracker
+                  name: id
+                  type: UUID
+              - column:
+                  name: name
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: owner_username
+                  type: VARCHAR(255)
+              - column:
+                  name: access_key
+                  type: UUID
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: round
+                  type: INT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+              - column:
+                  name: current_participant_id
+                  type: UUID
+              - column:
+                  name: deleted
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME
+              - column:
+                  name: updated_at
+                  type: DATETIME
+              - column:
+                  name: username
+                  type: VARCHAR(255)
+              - column:
+                  name: last_username
+                  type: VARCHAR(255)
+  - changeSet:
+      id: 2026-07-10-04-create-initiative-tracker-index
+      author: Peterko
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createIndex:
+            columns:
+              - column:
+                  name: owner_username
+            indexName: initiative_tracker_owner_username_index
+            tableName: initiative_tracker

--- a/src/main/resources/db/changelog/2026/07/10-05-create-initiative-participant-table.yaml
+++ b/src/main/resources/db/changelog/2026/07/10-05-create-initiative-participant-table.yaml
@@ -1,0 +1,85 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-10-05-create-initiative-participant-table
+      author: Peterko
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            tableName: initiative_participant
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_initiative_participant
+                  name: id
+                  type: UUID
+              - column:
+                  name: tracker_id
+                  type: UUID
+                  constraints:
+                    nullable: false
+              - column:
+                  name: type
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: name
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: initiative_bonus
+                  type: INT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+              - column:
+                  name: creature_url
+                  type: VARCHAR(255)
+              - column:
+                  name: initiative_roll
+                  type: INT
+              - column:
+                  name: initiative_total
+                  type: INT
+              - column:
+                  name: tie_roll
+                  type: INT
+              - column:
+                  name: seq
+                  type: INT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME
+              - column:
+                  name: updated_at
+                  type: DATETIME
+              - column:
+                  name: username
+                  type: VARCHAR(255)
+              - column:
+                  name: last_username
+                  type: VARCHAR(255)
+  - changeSet:
+      id: 2026-07-10-05-create-initiative-participant-index
+      author: Peterko
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createIndex:
+            columns:
+              - column:
+                  name: tracker_id
+            indexName: initiative_participant_tracker_index
+            tableName: initiative_participant
+        - addForeignKeyConstraint:
+            baseTableName: initiative_participant
+            baseColumnNames: tracker_id
+            referencedTableName: initiative_tracker
+            referencedColumnNames: id
+            constraintName: FK_INITIATIVE_PARTICIPANT_ON_TRACKER
+            onDelete: CASCADE

--- a/src/main/resources/db/changelog/2026/07/10-06-add-initiative-battle-options.yaml
+++ b/src/main/resources/db/changelog/2026/07/10-06-add-initiative-battle-options.yaml
@@ -1,0 +1,49 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-10-06-add-reroll-each-round-to-initiative-tracker
+      author: Peterko
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addColumn:
+            tableName: initiative_tracker
+            columns:
+              - column:
+                  name: reroll_each_round
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+        - update:
+            tableName: initiative_tracker
+            columns:
+              - column:
+                  name: reroll_each_round
+                  valueBoolean: false
+            where: reroll_each_round IS NULL
+        - addNotNullConstraint:
+            tableName: initiative_tracker
+            columnName: reroll_each_round
+            columnDataType: BOOLEAN
+            defaultNullValue: false
+  - changeSet:
+      id: 2026-07-10-06-add-dead-to-initiative-participant
+      author: Peterko
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addColumn:
+            tableName: initiative_participant
+            columns:
+              - column:
+                  name: dead
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+        - update:
+            tableName: initiative_participant
+            columns:
+              - column:
+                  name: dead
+                  valueBoolean: false
+            where: dead IS NULL
+        - addNotNullConstraint:
+            tableName: initiative_participant
+            columnName: dead
+            columnDataType: BOOLEAN
+            defaultNullValue: false

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -247,3 +247,9 @@ databaseChangeLog:
       file: db/changelog/2026/07/10-02-add-publish-to-vk-to-article.yaml
   - include:
       file: db/changelog/2026/07/10-03-add-vk-sync-to-article.yaml
+  - include:
+      file: db/changelog/2026/07/10-04-create-initiative-tracker-table.yaml
+  - include:
+      file: db/changelog/2026/07/10-05-create-initiative-participant-table.yaml
+  - include:
+      file: db/changelog/2026/07/10-06-add-initiative-battle-options.yaml

--- a/src/test/java/club/ttg/dnd5/domain/beastiary/service/CreatureInitiativeCalculatorTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/beastiary/service/CreatureInitiativeCalculatorTest.java
@@ -1,0 +1,74 @@
+package club.ttg.dnd5.domain.beastiary.service;
+
+import club.ttg.dnd5.domain.beastiary.model.Creature;
+import club.ttg.dnd5.domain.beastiary.model.CreatureAbilities;
+import club.ttg.dnd5.domain.beastiary.model.CreatureAbility;
+import club.ttg.dnd5.domain.beastiary.model.CreatureInitiative;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CreatureInitiativeCalculatorTest {
+
+    @Test
+    void bonusIsDexterityModifierWhenMultiplierIsZero() {
+        Creature creature = creature(14, (byte) 0, 450L);
+
+        assertEquals(2, CreatureInitiativeCalculator.initiativeBonus(creature));
+    }
+
+    @Test
+    void bonusAddsProficiencyBonusByExperience() {
+        // ЛОВ 18 (+4), опыт 5000 (ПМ 4), множитель 1 → 4 + 4
+        Creature creature = creature(18, (byte) 1, 5_000L);
+
+        assertEquals(8, CreatureInitiativeCalculator.initiativeBonus(creature));
+    }
+
+    @Test
+    void bonusAddsDoubledProficiencyBonusForMultiplierTwo() {
+        // ЛОВ 10 (+0), опыт 25000 (ПМ 6), множитель 2 → 0 + 12
+        Creature creature = creature(10, (byte) 2, 25_000L);
+
+        assertEquals(12, CreatureInitiativeCalculator.initiativeBonus(creature));
+    }
+
+    @Test
+    void negativeDexterityModifierIsPreserved() {
+        Creature creature = creature(6, (byte) 0, 100L);
+
+        assertEquals(-2, CreatureInitiativeCalculator.initiativeBonus(creature));
+    }
+
+    @Test
+    void missingAbilitiesAndInitiativeGiveZero() {
+        Creature creature = new Creature();
+
+        assertEquals(0, CreatureInitiativeCalculator.initiativeBonus(creature));
+    }
+
+    @Test
+    void missingExperienceFallsBackToMinimalProficiencyBonus() {
+        Creature creature = creature(12, (byte) 1, null);
+
+        // ЛОВ 12 (+1), опыт неизвестен (ПМ 2 по умолчанию), множитель 1 → 1 + 2
+        assertEquals(3, CreatureInitiativeCalculator.initiativeBonus(creature));
+    }
+
+    private static Creature creature(int dexterity, byte multiplier, Long experience) {
+        CreatureAbility dex = new CreatureAbility();
+        dex.setValue((short) dexterity);
+
+        CreatureAbilities abilities = new CreatureAbilities();
+        abilities.setDexterity(dex);
+
+        CreatureInitiative initiative = new CreatureInitiative();
+        initiative.setMultiplier(multiplier);
+
+        Creature creature = new Creature();
+        creature.setAbilities(abilities);
+        creature.setInitiative(initiative);
+        creature.setExperience(experience);
+        return creature;
+    }
+}

--- a/src/test/java/club/ttg/dnd5/domain/tool/tracker/service/InitiativeCombatServiceTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/tool/tracker/service/InitiativeCombatServiceTest.java
@@ -1,0 +1,406 @@
+package club.ttg.dnd5.domain.tool.tracker.service;
+
+import club.ttg.dnd5.domain.tool.tracker.model.InitiativeParticipant;
+import club.ttg.dnd5.domain.tool.tracker.model.InitiativeTracker;
+import club.ttg.dnd5.domain.tool.tracker.model.TrackerStatus;
+import club.ttg.dnd5.exception.ApiException;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class InitiativeCombatServiceTest {
+
+    private final InitiativeCombatService service = new InitiativeCombatService();
+
+    @Test
+    void sortOrdersByTotalDescThenBonusDescThenTieRollDesc() {
+        InitiativeParticipant lowTotal = participant(1, 10, 2, 100);
+        InitiativeParticipant highTotal = participant(2, 18, 0, 100);
+        InitiativeParticipant tiedHighBonus = participant(3, 15, 5, 100);
+        InitiativeParticipant tiedLowBonus = participant(4, 15, 1, 100);
+        InitiativeParticipant fullTieWins = participant(5, 15, 1, 999);
+
+        List<InitiativeParticipant> order =
+                InitiativeCombatService.sort(List.of(lowTotal, highTotal, tiedHighBonus, tiedLowBonus, fullTieWins));
+
+        assertEquals(List.of(highTotal, tiedHighBonus, fullTieWins, tiedLowBonus, lowTotal), order);
+    }
+
+    @Test
+    void sortKeepsComparatorContractWhenRolledAndUnrolledShareZeroTotal() {
+        // Брошенные с итогом 0 (низкий бросок при отрицательном бонусе) и не брошенные (0 после
+        // /start, tieRoll == null) при равном итоге не должны ломать контракт Comparator: брошенные
+        // идут раньше (по бонусу ↓), не брошенные — в конце в порядке добавления. Иначе получался бы
+        // цикл (rolledHigh < rolledLow по бонусу, но unrolled между ними по seq) и IllegalArgumentException в sorted().
+        InitiativeParticipant unrolled = unrolled(2);
+        unrolled.setInitiativeTotal(0);
+        InitiativeParticipant rolledLowBonus = participant(1, 0, 1, 5);
+        InitiativeParticipant rolledHighBonus = participant(3, 0, 100, 5);
+
+        List<InitiativeParticipant> order =
+                InitiativeCombatService.sort(List.of(unrolled, rolledLowBonus, rolledHighBonus));
+
+        assertEquals(List.of(rolledHighBonus.getId(), rolledLowBonus.getId(), unrolled.getId()),
+                order.stream().map(InitiativeParticipant::getId).toList());
+    }
+
+    @Test
+    void sortPutsUnrolledParticipantsLastInSeqOrder() {
+        InitiativeParticipant rolled = participant(5, 3, 0, 1);
+        InitiativeParticipant unrolledFirst = unrolled(1);
+        InitiativeParticipant unrolledSecond = unrolled(2);
+
+        List<InitiativeParticipant> order =
+                InitiativeCombatService.sort(List.of(unrolledSecond, rolled, unrolledFirst));
+
+        assertEquals(List.of(rolled, unrolledFirst, unrolledSecond), order);
+    }
+
+    @Test
+    void rollAllAssignsD20AndSortsWithoutStartingWhenPreparing() {
+        InitiativeTracker tracker = tracker();
+        InitiativeParticipant first = unrolled(1);
+        first.setInitiativeBonus(3);
+        InitiativeParticipant second = unrolled(2);
+        second.setInitiativeBonus(-1);
+        List<InitiativeParticipant> participants = List.of(first, second);
+
+        service.rollAll(tracker, participants);
+
+        for (InitiativeParticipant participant : participants) {
+            assertNotNull(participant.getInitiativeRoll());
+            assertTrue(participant.getInitiativeRoll() >= 1 && participant.getInitiativeRoll() <= 20);
+            assertEquals(participant.getInitiativeRoll() + participant.getInitiativeBonus(),
+                    participant.getInitiativeTotal());
+            assertNotNull(participant.getTieRoll());
+        }
+        // Бросок не начинает бой: трекер остаётся в подготовке, ход не назначается
+        assertEquals(TrackerStatus.PREPARING, tracker.getStatus());
+        assertEquals(0, tracker.getRound());
+        assertNull(tracker.getCurrentParticipantId());
+    }
+
+    @Test
+    void rollAllWithoutParticipantsThrows() {
+        assertThrows(ApiException.class, () -> service.rollAll(tracker(), List.of()));
+    }
+
+    @Test
+    void nextTurnAdvancesToNextParticipant() {
+        InitiativeParticipant first = participant(1, 20, 0, 1);
+        InitiativeParticipant second = participant(2, 10, 0, 1);
+        InitiativeTracker tracker = activeTracker(first.getId());
+
+        service.nextTurn(tracker, List.of(first, second));
+
+        assertEquals(second.getId(), tracker.getCurrentParticipantId());
+        assertEquals(1, tracker.getRound());
+    }
+
+    @Test
+    void nextTurnAfterLastParticipantStartsNewRound() {
+        InitiativeParticipant first = participant(1, 20, 0, 1);
+        InitiativeParticipant last = participant(2, 10, 0, 1);
+        InitiativeTracker tracker = activeTracker(last.getId());
+
+        service.nextTurn(tracker, List.of(first, last));
+
+        assertEquals(first.getId(), tracker.getCurrentParticipantId());
+        assertEquals(2, tracker.getRound());
+    }
+
+    @Test
+    void nextTurnWithoutCurrentPointsToFirst() {
+        InitiativeParticipant first = participant(1, 20, 0, 1);
+        InitiativeParticipant second = participant(2, 10, 0, 1);
+        InitiativeTracker tracker = activeTracker(null);
+
+        service.nextTurn(tracker, List.of(second, first));
+
+        assertEquals(first.getId(), tracker.getCurrentParticipantId());
+        assertEquals(1, tracker.getRound());
+    }
+
+    @Test
+    void nextTurnRequiresActiveCombat() {
+        InitiativeTracker tracker = tracker();
+
+        assertThrows(ApiException.class, () -> service.nextTurn(tracker, List.of(participant(1, 10, 0, 1))));
+    }
+
+    @Test
+    void nextTurnWithoutParticipantsThrows() {
+        assertThrows(ApiException.class, () -> service.nextTurn(activeTracker(null), List.of()));
+    }
+
+    @Test
+    void removalOfCurrentParticipantPassesTurnToNext() {
+        InitiativeParticipant current = participant(1, 20, 0, 1);
+        InitiativeParticipant next = participant(2, 10, 0, 1);
+        InitiativeTracker tracker = activeTracker(current.getId());
+
+        service.onParticipantRemoval(tracker, List.of(current, next), current);
+
+        assertEquals(next.getId(), tracker.getCurrentParticipantId());
+        assertEquals(1, tracker.getRound());
+    }
+
+    @Test
+    void removalOfLastCurrentParticipantWrapsToNewRound() {
+        InitiativeParticipant first = participant(1, 20, 0, 1);
+        InitiativeParticipant last = participant(2, 10, 0, 1);
+        InitiativeTracker tracker = activeTracker(last.getId());
+
+        service.onParticipantRemoval(tracker, List.of(first, last), last);
+
+        assertEquals(first.getId(), tracker.getCurrentParticipantId());
+        assertEquals(2, tracker.getRound());
+    }
+
+    @Test
+    void removalOfOnlyParticipantClearsCurrentTurn() {
+        InitiativeParticipant only = participant(1, 20, 0, 1);
+        InitiativeTracker tracker = activeTracker(only.getId());
+
+        service.onParticipantRemoval(tracker, List.of(only), only);
+
+        assertNull(tracker.getCurrentParticipantId());
+    }
+
+    @Test
+    void removalOfNonCurrentParticipantKeepsTurn() {
+        InitiativeParticipant current = participant(1, 20, 0, 1);
+        InitiativeParticipant other = participant(2, 10, 0, 1);
+        InitiativeTracker tracker = activeTracker(current.getId());
+
+        service.onParticipantRemoval(tracker, List.of(current, other), other);
+
+        assertEquals(current.getId(), tracker.getCurrentParticipantId());
+    }
+
+    @Test
+    void resetClearsRollsAndRevivesDeadReturningToPreparing() {
+        InitiativeParticipant participant = participant(1, 15, 2, 42);
+        participant.setDead(true);
+        InitiativeTracker tracker = activeTracker(participant.getId());
+        tracker.setRound(5);
+
+        service.reset(tracker, List.of(participant));
+
+        assertEquals(TrackerStatus.PREPARING, tracker.getStatus());
+        assertEquals(0, tracker.getRound());
+        assertNull(tracker.getCurrentParticipantId());
+        assertNull(participant.getInitiativeRoll());
+        assertNull(participant.getInitiativeTotal());
+        assertNull(participant.getTieRoll());
+        assertFalse(participant.isDead());
+    }
+
+    @Test
+    void nextTurnSkipsDeadParticipants() {
+        InitiativeParticipant first = participant(1, 20, 0, 1);
+        InitiativeParticipant deadMiddle = participant(2, 15, 0, 1);
+        deadMiddle.setDead(true);
+        InitiativeParticipant last = participant(3, 10, 0, 1);
+        InitiativeTracker tracker = activeTracker(first.getId());
+
+        service.nextTurn(tracker, List.of(first, deadMiddle, last));
+
+        // Мёртвый в середине порядка пропущен — ход сразу к третьему
+        assertEquals(last.getId(), tracker.getCurrentParticipantId());
+        assertEquals(1, tracker.getRound());
+    }
+
+    @Test
+    void nextTurnClearsCurrentWhenEveryoneDead() {
+        InitiativeParticipant a = participant(1, 20, 0, 1);
+        a.setDead(true);
+        InitiativeParticipant b = participant(2, 10, 0, 1);
+        b.setDead(true);
+        InitiativeTracker tracker = activeTracker(a.getId());
+
+        service.nextTurn(tracker, List.of(a, b));
+
+        assertNull(tracker.getCurrentParticipantId());
+    }
+
+    @Test
+    void nextTurnRerollsAllAliveOnNewRoundWhenEnabled() {
+        InitiativeParticipant first = participant(1, 20, 0, 1);
+        InitiativeParticipant last = participant(2, 10, 0, 1);
+        List<InitiativeParticipant> participants = List.of(first, last);
+        InitiativeTracker tracker = activeTracker(last.getId());
+        tracker.setRerollEachRound(true);
+
+        service.nextTurn(tracker, participants);
+
+        // Перешли на новый раунд → всем перекинули инициативу, ход первому в НОВОМ порядке
+        assertEquals(2, tracker.getRound());
+        UUID expectedFirst = InitiativeCombatService.sort(participants).getFirst().getId();
+        assertEquals(expectedFirst, tracker.getCurrentParticipantId());
+    }
+
+    @Test
+    void nextTurnKeepsRollsOnNewRoundWhenRerollDisabled() {
+        InitiativeParticipant first = participant(1, 20, 0, 1);
+        InitiativeParticipant last = participant(2, 10, 0, 1);
+        InitiativeTracker tracker = activeTracker(last.getId());
+
+        service.nextTurn(tracker, List.of(first, last));
+
+        assertEquals(2, tracker.getRound());
+        // Без ре-ролла итоги не тронуты
+        assertEquals(20, first.getInitiativeTotal());
+        assertEquals(10, last.getInitiativeTotal());
+        assertEquals(first.getId(), tracker.getCurrentParticipantId());
+    }
+
+    @Test
+    void startKeepsExistingRollsAndZeroesUnrolledInAdditionOrder() {
+        InitiativeParticipant unrolledFirst = unrolled(1);
+        unrolledFirst.setInitiativeBonus(5);
+        InitiativeParticipant rolledHigh = participant(2, 18, 3, 100);
+        InitiativeParticipant unrolledLast = unrolled(3);
+        unrolledLast.setInitiativeBonus(-1);
+        InitiativeParticipant rolledLow = participant(4, 7, 0, 50);
+        InitiativeTracker tracker = tracker();
+        List<InitiativeParticipant> participants = List.of(unrolledFirst, rolledHigh, unrolledLast, rolledLow);
+
+        service.start(tracker, participants);
+
+        // Брошенные — итог и бросок сохранены как есть (не перебрасываются, не обнуляются)
+        assertEquals(18, rolledHigh.getInitiativeTotal());
+        assertNotNull(rolledHigh.getInitiativeRoll());
+        assertEquals(7, rolledLow.getInitiativeTotal());
+        assertNotNull(rolledLow.getInitiativeRoll());
+        // Не брошенные — инициатива 0, без доброса d20 и без бонуса
+        assertEquals(0, unrolledFirst.getInitiativeTotal());
+        assertNull(unrolledFirst.getInitiativeRoll());
+        assertEquals(0, unrolledLast.getInitiativeTotal());
+        assertNull(unrolledLast.getInitiativeRoll());
+        // Бонус в записи сохранён (пригодится, если потом прокинуть)
+        assertEquals(5, unrolledFirst.getInitiativeBonus());
+
+        assertEquals(TrackerStatus.ACTIVE, tracker.getStatus());
+        assertEquals(1, tracker.getRound());
+        // Порядок: брошенные по итогу ↓, затем нулевые в конце в порядке добавления (seq)
+        assertEquals(List.of(rolledHigh.getId(), rolledLow.getId(), unrolledFirst.getId(), unrolledLast.getId()),
+                InitiativeCombatService.sort(participants).stream()
+                        .map(InitiativeParticipant::getId).toList());
+        // Ход — первому живому по порядку хода (брошенный с наибольшим итогом)
+        assertEquals(rolledHigh.getId(), tracker.getCurrentParticipantId());
+    }
+
+    @Test
+    void startSetsCurrentToFirstAliveByAdditionOrderSkippingDead() {
+        InitiativeParticipant deadFirst = unrolled(1);
+        deadFirst.setInitiativeBonus(10);
+        deadFirst.setDead(true);
+        InitiativeParticipant alive = unrolled(2);
+        InitiativeTracker tracker = tracker();
+
+        service.start(tracker, List.of(deadFirst, alive));
+
+        // Мёртвый первый по порядку пропущен, несмотря на высокий бонус
+        assertEquals(alive.getId(), tracker.getCurrentParticipantId());
+        assertEquals(0, alive.getInitiativeTotal());
+    }
+
+    @Test
+    void startClearsCurrentWhenEveryoneDead() {
+        InitiativeParticipant a = unrolled(1);
+        a.setDead(true);
+        InitiativeParticipant b = unrolled(2);
+        b.setDead(true);
+        InitiativeTracker tracker = tracker();
+
+        service.start(tracker, List.of(a, b));
+
+        assertNull(tracker.getCurrentParticipantId());
+        assertEquals(TrackerStatus.ACTIVE, tracker.getStatus());
+        assertEquals(1, tracker.getRound());
+    }
+
+    @Test
+    void startWithoutParticipantsThrows() {
+        assertThrows(ApiException.class, () -> service.start(tracker(), List.of()));
+    }
+
+    @Test
+    void rollAllInActiveCombatReRollsResettingRoundAndCurrentToFirstAlive() {
+        InitiativeParticipant dead = unrolled(1);
+        dead.setDead(true);
+        InitiativeParticipant alive = unrolled(2);
+        InitiativeTracker tracker = activeTracker(dead.getId());
+        tracker.setRound(5);
+
+        service.rollAll(tracker, List.of(dead, alive));
+
+        // Ре-ролл в идущем бою: статус ACTIVE сохраняется, раунд с начала, ход первому живому
+        assertEquals(TrackerStatus.ACTIVE, tracker.getStatus());
+        assertEquals(1, tracker.getRound());
+        assertEquals(alive.getId(), tracker.getCurrentParticipantId());
+    }
+
+    @Test
+    void recalculateTotalAssignsMissingTieRollForManualRoll() {
+        InitiativeParticipant participant = unrolled(1);
+        participant.setInitiativeBonus(4);
+        participant.setInitiativeRoll(17);
+
+        service.recalculateTotal(participant);
+
+        assertEquals(21, participant.getInitiativeTotal());
+        assertNotNull(participant.getTieRoll());
+    }
+
+    @Test
+    void recalculateTotalClearsTotalWithoutRoll() {
+        InitiativeParticipant participant = unrolled(1);
+        participant.setInitiativeTotal(15);
+
+        service.recalculateTotal(participant);
+
+        assertNull(participant.getInitiativeTotal());
+    }
+
+    private static InitiativeTracker tracker() {
+        InitiativeTracker tracker = new InitiativeTracker();
+        tracker.setId(UUID.randomUUID());
+        tracker.setStatus(TrackerStatus.PREPARING);
+        tracker.setRound(0);
+        return tracker;
+    }
+
+    private static InitiativeTracker activeTracker(UUID currentParticipantId) {
+        InitiativeTracker tracker = tracker();
+        tracker.setStatus(TrackerStatus.ACTIVE);
+        tracker.setRound(1);
+        tracker.setCurrentParticipantId(currentParticipantId);
+        return tracker;
+    }
+
+    private static InitiativeParticipant participant(int seq, int total, int bonus, int tieRoll) {
+        InitiativeParticipant participant = unrolled(seq);
+        participant.setInitiativeBonus(bonus);
+        participant.setInitiativeRoll(Math.max(1, total - bonus));
+        participant.setInitiativeTotal(total);
+        participant.setTieRoll(tieRoll);
+        return participant;
+    }
+
+    private static InitiativeParticipant unrolled(int seq) {
+        InitiativeParticipant participant = new InitiativeParticipant();
+        participant.setId(UUID.randomUUID());
+        participant.setSeq(seq);
+        return participant;
+    }
+}

--- a/src/test/java/club/ttg/dnd5/domain/tool/tracker/service/InitiativeTrackerServiceTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/tool/tracker/service/InitiativeTrackerServiceTest.java
@@ -1,0 +1,407 @@
+package club.ttg.dnd5.domain.tool.tracker.service;
+
+import club.ttg.dnd5.domain.beastiary.model.Creature;
+import club.ttg.dnd5.domain.beastiary.model.CreatureAbilities;
+import club.ttg.dnd5.domain.beastiary.model.CreatureAbility;
+import club.ttg.dnd5.domain.beastiary.model.CreatureInitiative;
+import club.ttg.dnd5.domain.beastiary.repository.CreatureRepository;
+import club.ttg.dnd5.domain.tool.tracker.model.InitiativeParticipant;
+import club.ttg.dnd5.domain.tool.tracker.model.InitiativeTracker;
+import club.ttg.dnd5.domain.tool.tracker.model.ParticipantType;
+import club.ttg.dnd5.domain.tool.tracker.model.TrackerStatus;
+import club.ttg.dnd5.domain.tool.tracker.repository.InitiativeParticipantRepository;
+import club.ttg.dnd5.domain.tool.tracker.repository.InitiativeTrackerRepository;
+import club.ttg.dnd5.domain.tool.tracker.rest.dto.ParticipantAddRequest;
+import club.ttg.dnd5.domain.tool.tracker.rest.dto.ParticipantUpdateRequest;
+import club.ttg.dnd5.domain.tool.tracker.rest.dto.TrackerRequest;
+import club.ttg.dnd5.domain.tool.tracker.rest.mapper.InitiativeTrackerMapper;
+import club.ttg.dnd5.domain.user.model.User;
+import club.ttg.dnd5.exception.ApiException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class InitiativeTrackerServiceTest {
+
+    private final InitiativeTrackerRepository trackerRepository = mock(InitiativeTrackerRepository.class);
+    private final InitiativeParticipantRepository participantRepository = mock(InitiativeParticipantRepository.class);
+    private final TrackerCreationRateLimiter creationRateLimiter = mock(TrackerCreationRateLimiter.class);
+    private final CreatureRepository creatureRepository = mock(CreatureRepository.class);
+    private final InitiativeTrackerMapper trackerMapper = mock(InitiativeTrackerMapper.class);
+    private final InitiativeTrackerService service = new InitiativeTrackerService(
+            trackerRepository,
+            participantRepository,
+            new InitiativeCombatService(),
+            creationRateLimiter,
+            creatureRepository,
+            trackerMapper
+    );
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void anonymousCreateChecksRateLimitAndHasNoOwner() {
+        when(trackerRepository.saveAndFlush(any(InitiativeTracker.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.create(new TrackerRequest("Логово дракона", null), "10.0.0.1");
+
+        verify(creationRateLimiter).checkAnonymousCreation("10.0.0.1");
+        ArgumentCaptor<InitiativeTracker> captor = ArgumentCaptor.forClass(InitiativeTracker.class);
+        verify(trackerRepository).saveAndFlush(captor.capture());
+        InitiativeTracker saved = captor.getValue();
+        assertNull(saved.getOwnerUsername());
+        assertNotNull(saved.getAccessKey());
+        assertEquals("Логово дракона", saved.getName());
+        assertEquals(TrackerStatus.PREPARING, saved.getStatus());
+        // Ключ доступа отдаётся только в ответе на создание
+        verify(trackerMapper).toCreatedResponse(saved, List.of());
+    }
+
+    @Test
+    void authorizedCreateSetsOwnerAndSkipsRateLimit() {
+        authenticate("dungeon-master");
+        when(trackerRepository.countByOwnerUsernameAndDeletedFalse("dungeon-master")).thenReturn(9L);
+        when(trackerRepository.saveAndFlush(any(InitiativeTracker.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.create(null, "10.0.0.1");
+
+        verify(creationRateLimiter, never()).checkAnonymousCreation(anyString());
+        ArgumentCaptor<InitiativeTracker> captor = ArgumentCaptor.forClass(InitiativeTracker.class);
+        verify(trackerRepository).saveAndFlush(captor.capture());
+        assertEquals("dungeon-master", captor.getValue().getOwnerUsername());
+        assertEquals("Новый трекер", captor.getValue().getName());
+    }
+
+    @Test
+    void authorizedCreateFailsOnTrackerLimit() {
+        authenticate("dungeon-master");
+        when(trackerRepository.countByOwnerUsernameAndDeletedFalse("dungeon-master")).thenReturn(10L);
+
+        ApiException exception =
+                assertThrows(ApiException.class, () -> service.create(null, "10.0.0.1"));
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatus());
+    }
+
+    @Test
+    void anonymousTrackerRequiresMatchingKey() {
+        InitiativeTracker tracker = anonymousTracker();
+        when(trackerRepository.findById(tracker.getId())).thenReturn(Optional.of(tracker));
+
+        ApiException exception = assertThrows(ApiException.class,
+                () -> service.findById(tracker.getId(), UUID.randomUUID().toString()));
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatus());
+    }
+
+    @Test
+    void anonymousTrackerOpensByKey() {
+        InitiativeTracker tracker = anonymousTracker();
+        when(trackerRepository.findById(tracker.getId())).thenReturn(Optional.of(tracker));
+        when(participantRepository.findAllByTrackerId(tracker.getId())).thenReturn(List.of());
+
+        service.findById(tracker.getId(), tracker.getAccessKey().toString());
+
+        verify(trackerMapper).toDetailedResponse(tracker, List.of());
+    }
+
+    @Test
+    void ownedTrackerDeniedForAnotherUser() {
+        authenticate("intruder");
+        InitiativeTracker tracker = ownedTracker("dungeon-master");
+        when(trackerRepository.findById(tracker.getId())).thenReturn(Optional.of(tracker));
+
+        ApiException exception = assertThrows(ApiException.class,
+                () -> service.findById(tracker.getId(), tracker.getAccessKey().toString()));
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatus());
+    }
+
+    @Test
+    void ownedTrackerDeniedForAnonymousEvenWithKey() {
+        InitiativeTracker tracker = ownedTracker("dungeon-master");
+        when(trackerRepository.findById(tracker.getId())).thenReturn(Optional.of(tracker));
+
+        ApiException exception = assertThrows(ApiException.class,
+                () -> service.findById(tracker.getId(), tracker.getAccessKey().toString()));
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatus());
+    }
+
+    @Test
+    void addPlayerRequiresName() {
+        InitiativeTracker tracker = anonymousTracker();
+        when(trackerRepository.findById(tracker.getId())).thenReturn(Optional.of(tracker));
+
+        ParticipantAddRequest request = new ParticipantAddRequest();
+        request.setType(ParticipantType.PLAYER);
+
+        assertThrows(ApiException.class,
+                () -> service.addParticipants(tracker.getId(), request, tracker.getAccessKey().toString()));
+    }
+
+    @Test
+    void addPlayerFailsOnLimit() {
+        InitiativeTracker tracker = anonymousTracker();
+        when(trackerRepository.findById(tracker.getId())).thenReturn(Optional.of(tracker));
+        when(participantRepository.countByTrackerIdAndType(tracker.getId(), ParticipantType.PLAYER))
+                .thenReturn(50L);
+
+        ParticipantAddRequest request = new ParticipantAddRequest();
+        request.setType(ParticipantType.PLAYER);
+        request.setName("Бард");
+
+        assertThrows(ApiException.class,
+                () -> service.addParticipants(tracker.getId(), request, tracker.getAccessKey().toString()));
+    }
+
+    @Test
+    void addCreaturesFailsWhenBatchExceedsLimit() {
+        InitiativeTracker tracker = anonymousTracker();
+        when(trackerRepository.findById(tracker.getId())).thenReturn(Optional.of(tracker));
+        when(participantRepository.countByTrackerIdAndType(tracker.getId(), ParticipantType.CREATURE))
+                .thenReturn(95L);
+
+        ParticipantAddRequest request = new ParticipantAddRequest();
+        request.setType(ParticipantType.CREATURE);
+        request.setCreatureUrl("goblin");
+        request.setCount(6);
+
+        assertThrows(ApiException.class,
+                () -> service.addParticipants(tracker.getId(), request, tracker.getAccessKey().toString()));
+    }
+
+    @Test
+    void addCreaturesSnapshotsBonusAndNumbersNamesAfterMaxSuffix() {
+        InitiativeTracker tracker = anonymousTracker();
+        when(trackerRepository.findById(tracker.getId())).thenReturn(Optional.of(tracker));
+        when(participantRepository.countByTrackerIdAndType(tracker.getId(), ParticipantType.CREATURE))
+                .thenReturn(0L);
+        // «Гоблин 2» удалён: нумерация должна продолжиться после максимального суффикса, без дублей
+        when(participantRepository.findAllByTrackerId(tracker.getId())).thenReturn(List.of(
+                creatureParticipant("Гоблин 1", "goblin", 5),
+                creatureParticipant("Гоблин 3", "goblin", 7)));
+        when(creatureRepository.findById("goblin")).thenReturn(Optional.of(goblin()));
+
+        ParticipantAddRequest request = new ParticipantAddRequest();
+        request.setType(ParticipantType.CREATURE);
+        request.setCreatureUrl("goblin");
+        request.setCount(2);
+
+        service.addParticipants(tracker.getId(), request, tracker.getAccessKey().toString());
+
+        ArgumentCaptor<List<InitiativeParticipant>> captor = ArgumentCaptor.forClass(List.class);
+        verify(participantRepository).saveAll(captor.capture());
+        List<InitiativeParticipant> saved = captor.getValue();
+        assertEquals(2, saved.size());
+        // ЛОВ 14 (+2), множитель 0 → бонус 2; максимальный суффикс 3 → новые 4 и 5
+        assertEquals("Гоблин 4", saved.getFirst().getName());
+        assertEquals("Гоблин 5", saved.getLast().getName());
+        assertEquals(2, saved.getFirst().getInitiativeBonus());
+        assertEquals("goblin", saved.getFirst().getCreatureUrl());
+        assertEquals(8, saved.getFirst().getSeq());
+        assertEquals(9, saved.getLast().getSeq());
+        // В подготовке инициатива новичкам не бросается
+        assertNull(saved.getFirst().getInitiativeRoll());
+    }
+
+    @Test
+    void addParticipantToActiveCombatRollsInitiative() {
+        InitiativeTracker tracker = anonymousTracker();
+        tracker.setStatus(TrackerStatus.ACTIVE);
+        tracker.setRound(2);
+        when(trackerRepository.findById(tracker.getId())).thenReturn(Optional.of(tracker));
+        when(participantRepository.countByTrackerIdAndType(tracker.getId(), ParticipantType.PLAYER))
+                .thenReturn(0L);
+        when(participantRepository.findMaxSeq(tracker.getId())).thenReturn(0);
+
+        ParticipantAddRequest request = new ParticipantAddRequest();
+        request.setType(ParticipantType.PLAYER);
+        request.setName("Паладин");
+        request.setInitiativeBonus(1);
+
+        service.addParticipants(tracker.getId(), request, tracker.getAccessKey().toString());
+
+        ArgumentCaptor<List<InitiativeParticipant>> captor = ArgumentCaptor.forClass(List.class);
+        verify(participantRepository).saveAll(captor.capture());
+        InitiativeParticipant saved = captor.getValue().getFirst();
+        assertNotNull(saved.getInitiativeRoll());
+        assertEquals(saved.getInitiativeRoll() + 1, saved.getInitiativeTotal());
+    }
+
+    @Test
+    void deleteAnonymousTrackerIsPhysical() {
+        InitiativeTracker tracker = anonymousTracker();
+        when(trackerRepository.findById(tracker.getId())).thenReturn(Optional.of(tracker));
+
+        service.delete(tracker.getId(), tracker.getAccessKey().toString());
+
+        verify(trackerRepository).delete(tracker);
+    }
+
+    @Test
+    void deleteOwnedTrackerIsSoftAndPurgesParticipants() {
+        authenticate("dungeon-master");
+        InitiativeTracker tracker = ownedTracker("dungeon-master");
+        when(trackerRepository.findById(tracker.getId())).thenReturn(Optional.of(tracker));
+        when(trackerRepository.findAllByOwnerUsernameAndDeletedTrueOrderByUpdatedAtDesc("dungeon-master"))
+                .thenReturn(List.of(tracker));
+
+        service.delete(tracker.getId(), null);
+
+        verify(trackerRepository, never()).delete(tracker);
+        assertEquals(true, tracker.isDeleted());
+        // Участники мягко удалённого трекера недоступны — физически чистятся сразу
+        verify(participantRepository).deleteAllByTrackerId(tracker.getId());
+        verify(trackerRepository, never()).deleteAll(any());
+    }
+
+    @Test
+    void deleteOwnedTrackerTrimsHistoryBeyondLimit() {
+        authenticate("dungeon-master");
+        InitiativeTracker tracker = ownedTracker("dungeon-master");
+        when(trackerRepository.findById(tracker.getId())).thenReturn(Optional.of(tracker));
+        List<InitiativeTracker> deletedHistory = new java.util.ArrayList<>();
+        for (int i = 0; i < 31; i++) {
+            deletedHistory.add(ownedTracker("dungeon-master"));
+        }
+        when(trackerRepository.findAllByOwnerUsernameAndDeletedTrueOrderByUpdatedAtDesc("dungeon-master"))
+                .thenReturn(deletedHistory);
+
+        service.delete(tracker.getId(), null);
+
+        // История ограничена 30 удалёнными: самый старый (31-й) удаляется физически
+        ArgumentCaptor<List<InitiativeTracker>> captor = ArgumentCaptor.forClass(List.class);
+        verify(trackerRepository).deleteAll(captor.capture());
+        assertEquals(1, captor.getValue().size());
+        assertEquals(deletedHistory.getLast(), captor.getValue().getFirst());
+    }
+
+    @Test
+    void findMineRequiresAuthorization() {
+        ApiException exception = assertThrows(ApiException.class, () -> service.findMine(false));
+
+        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatus());
+    }
+
+    @Test
+    void updateParticipantMarksDead() {
+        InitiativeTracker tracker = anonymousTracker();
+        InitiativeParticipant participant = creatureParticipant("Гоблин 1", "goblin", 1);
+        when(trackerRepository.findById(tracker.getId())).thenReturn(Optional.of(tracker));
+        when(participantRepository.findByIdAndTrackerId(participant.getId(), tracker.getId()))
+                .thenReturn(Optional.of(participant));
+        when(participantRepository.findAllByTrackerId(tracker.getId())).thenReturn(List.of(participant));
+
+        ParticipantUpdateRequest request = new ParticipantUpdateRequest();
+        request.setDead(true);
+
+        service.updateParticipant(tracker.getId(), participant.getId(), request, tracker.getAccessKey().toString());
+
+        assertTrue(participant.isDead());
+    }
+
+    @Test
+    void updateSettingsTogglesRerollEachRoundWithoutResettingName() {
+        InitiativeTracker tracker = anonymousTracker();
+        when(trackerRepository.findById(tracker.getId())).thenReturn(Optional.of(tracker));
+        when(participantRepository.findAllByTrackerId(tracker.getId())).thenReturn(List.of());
+
+        service.updateSettings(tracker.getId(), new TrackerRequest(null, true), tracker.getAccessKey().toString());
+
+        assertTrue(tracker.isRerollEachRound());
+        // Имя не передано (null) — не должно сброситься в дефолт
+        assertEquals("Трекер", tracker.getName());
+    }
+
+    @Test
+    void rollParticipantRollsSingleWithBonus() {
+        InitiativeTracker tracker = anonymousTracker();
+        InitiativeParticipant participant = creatureParticipant("Гоблин 1", "goblin", 1);
+        participant.setInitiativeBonus(2);
+        when(trackerRepository.findById(tracker.getId())).thenReturn(Optional.of(tracker));
+        when(participantRepository.findByIdAndTrackerId(participant.getId(), tracker.getId()))
+                .thenReturn(Optional.of(participant));
+        when(participantRepository.findAllByTrackerId(tracker.getId())).thenReturn(List.of(participant));
+
+        service.rollParticipant(tracker.getId(), participant.getId(), tracker.getAccessKey().toString());
+
+        assertNotNull(participant.getInitiativeRoll());
+        assertEquals(participant.getInitiativeRoll() + 2, participant.getInitiativeTotal());
+    }
+
+    private static void authenticate(String username) {
+        User user = new User();
+        user.setUsername(username);
+        SecurityContextHolder.getContext()
+                .setAuthentication(new UsernamePasswordAuthenticationToken(user, null, List.of()));
+    }
+
+    private static InitiativeTracker anonymousTracker() {
+        InitiativeTracker tracker = new InitiativeTracker();
+        tracker.setId(UUID.randomUUID());
+        tracker.setName("Трекер");
+        tracker.setAccessKey(UUID.randomUUID());
+        tracker.setStatus(TrackerStatus.PREPARING);
+        return tracker;
+    }
+
+    private static InitiativeTracker ownedTracker(String ownerUsername) {
+        InitiativeTracker tracker = anonymousTracker();
+        tracker.setOwnerUsername(ownerUsername);
+        return tracker;
+    }
+
+    private static InitiativeParticipant creatureParticipant(String name, String creatureUrl, int seq) {
+        InitiativeParticipant participant = new InitiativeParticipant();
+        participant.setId(UUID.randomUUID());
+        participant.setType(ParticipantType.CREATURE);
+        participant.setName(name);
+        participant.setCreatureUrl(creatureUrl);
+        participant.setSeq(seq);
+        return participant;
+    }
+
+    private static Creature goblin() {
+        CreatureAbility dex = new CreatureAbility();
+        dex.setValue((short) 14);
+
+        CreatureAbilities abilities = new CreatureAbilities();
+        abilities.setDexterity(dex);
+
+        CreatureInitiative initiative = new CreatureInitiative();
+        initiative.setMultiplier((byte) 0);
+
+        Creature creature = new Creature();
+        creature.setUrl("goblin");
+        creature.setName("Гоблин");
+        creature.setAbilities(abilities);
+        creature.setInitiative(initiative);
+        creature.setExperience(50L);
+        return creature;
+    }
+}


### PR DESCRIPTION
Данный пулреквест объединяет два крупных функциональных блока:
1. **Расширение модуля статей и новостей**: гибкий жизненный цикл публикаций (черновики, отложенный старт, доступ по ссылке) и автоматическая двусторонняя интеграция (публикация, обновление правок, удаление) с Telegram-каналами, Discord-серверами и стеной сообщества ВКонтакте.
2. **Система трекера инициативы (Initiative Tracker)**: бэкенд для управления боями по правилам D&D 5e с поддержкой игроков, автонумерацией существ из бестиария, детерминированным порядком ходов и обработкой состояния «повержен».

---

## Подробный список изменений по компонентам

### 1. Модуль статей и новостей (Articles & Publication Workflow)
* **Модель публикации и статусы:**
  * Добавлен тип записи (enum `ArticleType`: `NEWS` / `ARTICLE`) и справочник типов.
  * Разделены понятия черновика (`draft`), активности (`active`) и времени публикации (`publishDateTime`). Добавлен вычисляемый статус `ArticleStatus` (`DRAFT`, `SCHEDULED`, `ACTIVE`, `INACTIVE`).
  * Реализован доступ к скрытым из списков записям по прямой ссылке (`accessibleByLink`).
  * Переход идентификации записей с UUID на URL-slug (`/{url}`).
* **Поиск и фильтрация:**
  * Добавлен регистронезависимый поиск по заголовку (`?search=`) с поддержкой фильтрации по типу.
* **Обложки статей:**
  * Загрузка обложек переведена в выделенную папку `articles/` в S3.

---

### 2. Автопубликация в Telegram
* Интегрирован планировщик для периодического опроса и публикации постов в Telegram-канал при наступлении даты публикации.
* Автоматическая синхронизация: правка текста на сайте правит пост на месте; удаление новости удаляет пост из канала.
* Разметка конвертируется в Telegram-HTML через кастомный форматировщик. Неподдерживаемые теги вырезаются, при нарушении структуры отправляется плоский текст во избежание ошибки 400.
* Большие статьи разбиваются на части с учетом лимитов Telegram (подпись к фото ≤1024, сообщения ≤4096 символов). Обложка загружается байтами напрямую из S3.

---

### 3. Автопубликация в Discord
* Реализован транспорт через вебхуки Discord с поддержкой методов `POST` (публикация), `PATCH` (правка) и `DELETE` (удаление сообщения при скрытии статьи).
* Разметка конвертируется в Discord-markdown с маскированием ссылок (`[текст](<url>)`) для предотвращения отображения громоздких карточек-превью.
* Большие статьи бьются на сообщения по лимитам Discord (≤2000 символов), обложка передается в multipart-запросе.

---

### 4. Автопубликация во ВКонтакте
* Постинг на стену сообщества от имени группы через VK API (`wall.post`, `wall.edit`, `wall.delete`) с использованием ключа доступа сообщества.
* Реализована 3-шаговая загрузка обложки в ВК альбом стены (`photos.getWallUploadServer` -> отправка файла -> `photos.saveWallPhoto`) с graceful-фолбэком в текст при отсутствии прав (ошибка 27).
* Все markdown-теги очищаются для вывода плоского текста, внешние ссылки форматируются в виде `метка (url)`.
* **Багфикс:** Исправлена проблема, при которой обложка ВК не заливалась на стену при редактировании статьи, если при первом постинге картинка отсутствовала. Внедрена детальная диагностика этапов загрузки изображения.

---

### 5. Трекер инициативы (Initiative Tracker)
* **Жизненный цикл трекера:**
  * Реализовано создание трекеров боя: для авторизованных пользователей с TTL 30 дней, для анонимов с лимитом на сессию/IP и TTL 1 час (автоматическая очистка неактивных трекеров раз в час).
  * Поддержка добавления игроков (ручной ввод инициативы и бонуса) и пачек существ из бестиария (по идентификаторам с автоматической нумерацией, например: «Гоблин 1», «Гоблин 2»).
* **Логика боя и детерминированность:**
  * Сортировка инициативы учитывает: `Результат броска` ↓ -> `Бонус инициативы` ↓ -> `Случайный tie-break бросок (tieRoll)` ↓ -> `Порядок добавления`. Хранимый `tieRoll` делает сортировку детерминированной и транзитивной (добавление новых участников не ломает существующую очередь).
  * Поддержка перехода хода (`/turn/next`) с пропуском поверженных участников (`dead`), сброса боя (`/reset`) и автоматического ре-ролла инициативы в начале каждого раунда (`rerollEachRound`).

---

## Архитектурные решения и надежность
* **Идемпотентность отправки:** Во избежание дублирования постов из-за сетевых сбоев используется паттерн **claim-before-send** (статус отправки занимает атомарным UPDATE-запросом до выполнения HTTP-вызова).
* **Гонки данных:** Использование аннотации `@DynamicUpdate` для сущности статьи предотвращает затирание служебных полей планировщиков при параллельном редактировании статьи модераторами.
* **Изолированность:** Обновление полей публикации во ВКонтакте переведено на точечные апдейты, не затрагивающие дату последнего изменения статьи (`updatedAt`).

---

## Изменения в БД (Liquibase миграции)
Добавлены наборы изменений для Liquibase:
* **Статьи:** колонки типа, черновика, активности, доступности по ссылке и ограничение удаления (NOT NULL).
* **Интеграции:** поля для хранения состояния отправки, ID сообщений, ссылок на обложки и признаков необходимости синхронизации для Telegram, Discord и VK.
* **Трекер:** таблицы трекера (с индексом по владельцу) и участников (с индексом по трекеру и каскадным удалением).

---

## Тестирование
* Написаны и успешно выполняются модульные и интеграционные тесты для проверки:
  * Детерминированности компаратора инициативы и логики тай-брейков.
  * Обработки мертвых участников боя и опции автоматического ре-ролла раундов.
  * Ограничений скорости создания трекеров для анонимных пользователей.
  * Вычисления бонусов существ на основе статблока.
