### PR TITLE
feat(tracker): откат хода назад — POST /turn/prev, симметрично /turn/next

### DIFF
--- a/src/main/java/club/ttg/dnd5/domain/tool/tracker/rest/controller/InitiativeTrackerController.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/tracker/rest/controller/InitiativeTrackerController.java
@@ -161,6 +161,16 @@ public class InitiativeTrackerController {
         return trackerService.nextTurn(id, trackerKey);
     }
 
+    @Operation(summary = "Откат хода на шаг назад; с первого участника раунда — к последнему живому "
+            + "предыдущего раунда (round - 1). На первом ходу первого раунда не откатывает — возвращает "
+            + "текущее состояние. Броски инициативы не восстанавливаются (актуально при rerollEachRound)")
+    @PostMapping("/{id}/turn/prev")
+    public TrackerDetailedResponse prevTurn(
+            @PathVariable final UUID id,
+            @RequestHeader(value = TRACKER_KEY_HEADER, required = false) final String trackerKey) {
+        return trackerService.prevTurn(id, trackerKey);
+    }
+
     @Operation(summary = "Завершить бой: броски очищаются, состав участников сохраняется, "
             + "трекер возвращается в подготовку")
     @PostMapping("/{id}/reset")

--- a/src/main/java/club/ttg/dnd5/domain/tool/tracker/service/InitiativeCombatService.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/tracker/service/InitiativeCombatService.java
@@ -99,7 +99,7 @@ public class InitiativeCombatService {
             throw new ApiException(HttpStatus.BAD_REQUEST, "В трекере нет участников");
         }
         int currentIndex = indexOf(order, tracker.getCurrentParticipantId());
-        NextTurn result = nextAlive(order, currentIndex, null);
+        TurnStep result = nextAlive(order, currentIndex, null);
         if (result.participant() == null) {
             tracker.setCurrentParticipantId(null);
             return;
@@ -116,6 +116,39 @@ public class InitiativeCombatService {
     }
 
     /**
+     * Откатывает ход на шаг назад: к предыдущему живому по порядку, пропуская повержённых;
+     * с первого живого участника раунда — к последнему живому предыдущего раунда
+     * ({@code round - 1}). На первом ходу первого раунда отката нет — состояние не меняется.
+     * Живых нет или текущий ход не назначен — no-op. Броски инициативы не трогаются: при
+     * включённом {@code rerollEachRound} значения прошлого раунда не хранятся и не
+     * восстанавливаются.
+     */
+    public void prevTurn(InitiativeTracker tracker, List<InitiativeParticipant> participants) {
+        if (tracker.getStatus() != TrackerStatus.ACTIVE) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "Бой не начат — сначала прокиньте инициативу");
+        }
+        List<InitiativeParticipant> order = sort(participants);
+        if (order.isEmpty()) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "В трекере нет участников");
+        }
+        int currentIndex = indexOf(order, tracker.getCurrentParticipantId());
+        if (currentIndex < 0) {
+            return;
+        }
+        TurnStep result = prevAlive(order, currentIndex);
+        if (result.participant() == null) {
+            return;
+        }
+        if (result.wrapped()) {
+            if (tracker.getRound() <= 1) {
+                return;
+            }
+            tracker.setRound(tracker.getRound() - 1);
+        }
+        tracker.setCurrentParticipantId(result.participant().getId());
+    }
+
+    /**
      * Переносит ход с удаляемого участника на следующего живого (вызывается ДО удаления).
      * Удаляемый ходил последним в раунде — ход первому живому и новый раунд; живых больше
      * не остаётся — текущего хода нет.
@@ -128,7 +161,7 @@ public class InitiativeCombatService {
         }
         List<InitiativeParticipant> order = sort(participants);
         int removedIndex = indexOf(order, removed.getId());
-        NextTurn result = nextAlive(order, removedIndex, removed.getId());
+        TurnStep result = nextAlive(order, removedIndex, removed.getId());
         if (result.participant() == null) {
             tracker.setCurrentParticipantId(null);
             return;
@@ -181,7 +214,7 @@ public class InitiativeCombatService {
      * и {@code excludedId} (удаляемого). {@code wrapped} — был ли переход через конец списка
      * (значит начался новый раунд). {@code participant == null} — живых не осталось.
      */
-    private static NextTurn nextAlive(List<InitiativeParticipant> order, int fromIndex, UUID excludedId) {
+    private static TurnStep nextAlive(List<InitiativeParticipant> order, int fromIndex, UUID excludedId) {
         int size = order.size();
         boolean wrapped = false;
         for (int step = 1; step <= size; step++) {
@@ -196,9 +229,31 @@ public class InitiativeCombatService {
             if (candidate.isDead()) {
                 continue;
             }
-            return new NextTurn(candidate, wrapped);
+            return new TurnStep(candidate, wrapped);
         }
-        return new NextTurn(null, wrapped);
+        return new TurnStep(null, wrapped);
+    }
+
+    /**
+     * Предыдущий живой участник перед позицией {@code fromIndex} (по кругу), пропуская
+     * повержённых. {@code wrapped} — был ли переход через начало списка (значит откат в
+     * предыдущий раунд). {@code participant == null} — живых не осталось.
+     */
+    private static TurnStep prevAlive(List<InitiativeParticipant> order, int fromIndex) {
+        int size = order.size();
+        boolean wrapped = false;
+        for (int step = 1; step <= size; step++) {
+            int raw = fromIndex - step;
+            if (raw < 0) {
+                wrapped = true;
+            }
+            InitiativeParticipant candidate = order.get(((raw % size) + size) % size);
+            if (candidate.isDead()) {
+                continue;
+            }
+            return new TurnStep(candidate, wrapped);
+        }
+        return new TurnStep(null, wrapped);
     }
 
     private static int compareTurnOrder(InitiativeParticipant left, InitiativeParticipant right) {
@@ -261,6 +316,6 @@ public class InitiativeCombatService {
         return -1;
     }
 
-    private record NextTurn(InitiativeParticipant participant, boolean wrapped) {
+    private record TurnStep(InitiativeParticipant participant, boolean wrapped) {
     }
 }

--- a/src/main/java/club/ttg/dnd5/domain/tool/tracker/service/InitiativeTrackerService.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/tracker/service/InitiativeTrackerService.java
@@ -243,6 +243,13 @@ public class InitiativeTrackerService {
         return toDetailedResponse(tracker);
     }
 
+    @Transactional
+    public TrackerDetailedResponse prevTurn(UUID trackerId, String trackerKey) {
+        InitiativeTracker tracker = getWithAccess(trackerId, trackerKey);
+        combatService.prevTurn(tracker, participantRepository.findAllByTrackerId(trackerId));
+        return toDetailedResponse(tracker);
+    }
+
     /** Завершает бой: броски очищаются, состав сохраняется, трекер снова в подготовке. */
     @Transactional
     public TrackerDetailedResponse reset(UUID trackerId, String trackerKey) {

--- a/src/test/java/club/ttg/dnd5/domain/tool/tracker/service/InitiativeCombatServiceTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/tool/tracker/service/InitiativeCombatServiceTest.java
@@ -142,6 +142,125 @@ class InitiativeCombatServiceTest {
     }
 
     @Test
+    void prevTurnMovesToPreviousParticipant() {
+        InitiativeParticipant first = participant(1, 20, 0, 1);
+        InitiativeParticipant second = participant(2, 10, 0, 1);
+        InitiativeTracker tracker = activeTracker(second.getId());
+
+        service.prevTurn(tracker, List.of(first, second));
+
+        assertEquals(first.getId(), tracker.getCurrentParticipantId());
+        assertEquals(1, tracker.getRound());
+    }
+
+    @Test
+    void prevTurnFromFirstParticipantReturnsToPreviousRound() {
+        InitiativeParticipant first = participant(1, 20, 0, 1);
+        InitiativeParticipant last = participant(2, 10, 0, 1);
+        InitiativeTracker tracker = activeTracker(first.getId());
+        tracker.setRound(3);
+
+        service.prevTurn(tracker, List.of(first, last));
+
+        assertEquals(last.getId(), tracker.getCurrentParticipantId());
+        assertEquals(2, tracker.getRound());
+    }
+
+    @Test
+    void prevTurnOnFirstTurnOfFirstRoundKeepsState() {
+        InitiativeParticipant first = participant(1, 20, 0, 1);
+        InitiativeParticipant last = participant(2, 10, 0, 1);
+        InitiativeTracker tracker = activeTracker(first.getId());
+
+        service.prevTurn(tracker, List.of(first, last));
+
+        assertEquals(first.getId(), tracker.getCurrentParticipantId());
+        assertEquals(1, tracker.getRound());
+    }
+
+    @Test
+    void prevTurnSkipsDeadParticipants() {
+        InitiativeParticipant first = participant(1, 20, 0, 1);
+        InitiativeParticipant deadMiddle = participant(2, 15, 0, 1);
+        deadMiddle.setDead(true);
+        InitiativeParticipant last = participant(3, 10, 0, 1);
+        InitiativeTracker tracker = activeTracker(last.getId());
+
+        service.prevTurn(tracker, List.of(first, deadMiddle, last));
+
+        // Мёртвый в середине порядка пропущен — откат сразу к первому
+        assertEquals(first.getId(), tracker.getCurrentParticipantId());
+        assertEquals(1, tracker.getRound());
+    }
+
+    @Test
+    void prevTurnFromFirstAliveOfFirstRoundKeepsStateEvenWithDeadBefore() {
+        // Текущий — первый ЖИВОЙ первого раунда (выше по порядку только повержённый):
+        // отката нет, круг назад через конец списка означал бы раунд 0
+        InitiativeParticipant deadFirst = participant(1, 20, 0, 1);
+        deadFirst.setDead(true);
+        InitiativeParticipant current = participant(2, 15, 0, 1);
+        InitiativeParticipant last = participant(3, 10, 0, 1);
+        InitiativeTracker tracker = activeTracker(current.getId());
+
+        service.prevTurn(tracker, List.of(deadFirst, current, last));
+
+        assertEquals(current.getId(), tracker.getCurrentParticipantId());
+        assertEquals(1, tracker.getRound());
+    }
+
+    @Test
+    void prevTurnWithSingleAliveDecrementsRoundKeepingTurn() {
+        InitiativeParticipant only = participant(1, 20, 0, 1);
+        InitiativeParticipant dead = participant(2, 10, 0, 1);
+        dead.setDead(true);
+        InitiativeTracker tracker = activeTracker(only.getId());
+        tracker.setRound(2);
+
+        service.prevTurn(tracker, List.of(only, dead));
+
+        // Единственный живой: откат по кругу возвращается к нему же, но раундом раньше
+        assertEquals(only.getId(), tracker.getCurrentParticipantId());
+        assertEquals(1, tracker.getRound());
+    }
+
+    @Test
+    void prevTurnWhenEveryoneDeadIsNoOp() {
+        InitiativeParticipant a = participant(1, 20, 0, 1);
+        a.setDead(true);
+        InitiativeParticipant b = participant(2, 10, 0, 1);
+        b.setDead(true);
+        InitiativeTracker tracker = activeTracker(a.getId());
+        tracker.setRound(2);
+
+        service.prevTurn(tracker, List.of(a, b));
+
+        assertEquals(a.getId(), tracker.getCurrentParticipantId());
+        assertEquals(2, tracker.getRound());
+    }
+
+    @Test
+    void prevTurnWithoutCurrentIsNoOp() {
+        InitiativeTracker tracker = activeTracker(null);
+        tracker.setRound(2);
+
+        service.prevTurn(tracker, List.of(participant(1, 10, 0, 1)));
+
+        assertNull(tracker.getCurrentParticipantId());
+        assertEquals(2, tracker.getRound());
+    }
+
+    @Test
+    void prevTurnRequiresActiveCombat() {
+        assertThrows(ApiException.class, () -> service.prevTurn(tracker(), List.of(participant(1, 10, 0, 1))));
+    }
+
+    @Test
+    void prevTurnWithoutParticipantsThrows() {
+        assertThrows(ApiException.class, () -> service.prevTurn(activeTracker(null), List.of()));
+    }
+
+    @Test
     void removalOfCurrentParticipantPassesTurnToNext() {
         InitiativeParticipant current = participant(1, 20, 0, 1);
         InitiativeParticipant next = participant(2, 10, 0, 1);


### PR DESCRIPTION
Указатель хода переходит к предыдущему живому по порядку инициативы, повержённые пропускаются. С первого живого участника раунда — к последнему живому предыдущего раунда с round - 1. На первом ходу первого раунда, без живых или без текущего хода — no-op (текущее состояние без изменений). Броски при откате не восстанавливаются (при rerollEachRound прошлые значения не хранятся). Авторизация как у /turn/next: Bearer или X-Tracker-Key.