### PR TITLE
feat(user): отображаемое имя пользователя (смена имени, скрытие логина)

### DIFF
--- a/src/main/java/club/ttg/dnd5/domain/user/model/UserDisplayName.java
+++ b/src/main/java/club/ttg/dnd5/domain/user/model/UserDisplayName.java
@@ -1,0 +1,46 @@
+package club.ttg.dnd5.domain.user.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Отображаемое имя пользователя — то, что показывается на сайте вместо логина
+ * (в профиле, комментариях, рейтинге охотников за багами).
+ *
+ * Владелец данных — core-api (сайтовый бэкенд). Ключ {@code userId} совпадает с
+ * {@code sub} JWT (он же {@code authorId} в сервисе комментариев), поэтому смену
+ * имени можно синхронно пробросить в другие сервисы. {@code username} хранится,
+ * чтобы резолвить «логин → имя» там, где известен только логин (таблица охотников).
+ *
+ * Строка создаётся лениво при первом обращении: core-api сам пользователей не
+ * заводит, поэтому запись появляется при первом чтении/смене имени.
+ */
+@Getter
+@Setter
+@Entity
+@Table(name = "user_display_name")
+public class UserDisplayName {
+    /** UUID пользователя из токена ({@code sub}). Присваивается вручную, не генерируется. */
+    @Id
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "username", nullable = false)
+    private String username;
+
+    @Column(name = "display_name", nullable = false, length = 50)
+    private String displayName;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/src/main/java/club/ttg/dnd5/domain/user/repository/UserDisplayNameRepository.java
+++ b/src/main/java/club/ttg/dnd5/domain/user/repository/UserDisplayNameRepository.java
@@ -1,0 +1,20 @@
+package club.ttg.dnd5.domain.user.repository;
+
+import club.ttg.dnd5.domain.user.model.UserDisplayName;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface UserDisplayNameRepository extends JpaRepository<UserDisplayName, UUID> {
+
+    /** Занято ли имя (регистронезависимо) кем угодно — для генерации уникального дефолта. */
+    boolean existsByDisplayNameIgnoreCase(String displayName);
+
+    /** Занято ли имя (регистронезависимо) другим пользователем — для проверки при смене. */
+    boolean existsByDisplayNameIgnoreCaseAndUserIdNot(String displayName, UUID userId);
+
+    /** Является ли имя логином другого пользователя (регистронезависимо) — против подмены. */
+    boolean existsByUsernameIgnoreCaseAndUserIdNot(String username, UUID userId);
+}

--- a/src/main/java/club/ttg/dnd5/domain/user/rest/controller/UserController.java
+++ b/src/main/java/club/ttg/dnd5/domain/user/rest/controller/UserController.java
@@ -3,12 +3,16 @@ package club.ttg.dnd5.domain.user.rest.controller;
 import club.ttg.dnd5.domain.source.rest.dto.filter.SourceSavedFilterRequest;
 import club.ttg.dnd5.domain.source.rest.dto.filter.SourceSavedFilterResponse;
 import club.ttg.dnd5.domain.source.service.SourceSavedFilterService;
+import club.ttg.dnd5.domain.user.rest.dto.DisplayNameResponse;
+import club.ttg.dnd5.domain.user.rest.dto.UpdateDisplayNameRequest;
 import club.ttg.dnd5.domain.user.rest.dto.UserDto;
 import club.ttg.dnd5.domain.user.rest.dto.UserProfileShortResponse;
+import club.ttg.dnd5.domain.user.service.DisplayNameService;
 import club.ttg.dnd5.domain.user.service.UserService;
 import club.ttg.dnd5.security.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.*;
@@ -22,12 +26,27 @@ import java.util.List;
 public class UserController {
     private final UserService userService;
     private final SourceSavedFilterService sourceSavedFilterService;
+    private final DisplayNameService displayNameService;
 
     @Secured("USER")
     @Operation(summary = "Получение профиля пользователя")
     @GetMapping("/profile")
     public UserDto getUser() {
         return SecurityUtils.getUserDto();
+    }
+
+    @Secured("USER")
+    @Operation(summary = "Отображаемое имя текущего пользователя (создаётся лениво)")
+    @GetMapping("/profile/display-name")
+    public DisplayNameResponse getDisplayName() {
+        return displayNameService.getOrCreateForCurrentUser();
+    }
+
+    @Secured("USER")
+    @Operation(summary = "Смена отображаемого имени")
+    @PatchMapping("/profile/display-name")
+    public DisplayNameResponse updateDisplayName(@Valid @RequestBody UpdateDisplayNameRequest request) {
+        return displayNameService.updateForCurrentUser(request.displayName());
     }
 
     @Secured("USER")

--- a/src/main/java/club/ttg/dnd5/domain/user/rest/dto/DisplayNameResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/user/rest/dto/DisplayNameResponse.java
@@ -1,0 +1,7 @@
+package club.ttg.dnd5.domain.user.rest.dto;
+
+/**
+ * Ответ с текущим отображаемым именем пользователя.
+ */
+public record DisplayNameResponse(String displayName) {
+}

--- a/src/main/java/club/ttg/dnd5/domain/user/rest/dto/UpdateDisplayNameRequest.java
+++ b/src/main/java/club/ttg/dnd5/domain/user/rest/dto/UpdateDisplayNameRequest.java
@@ -1,0 +1,19 @@
+package club.ttg.dnd5.domain.user.rest.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Запрос на смену отображаемого имени. Формат дублирует клиентскую схему:
+ * буквы (в т.ч. кириллица), цифры, пробелы, дефисы и подчёркивания, 2–50 символов.
+ * Остальные проверки (уникальность, зарезервированные слова, чужой логин) — в сервисе.
+ */
+public record UpdateDisplayNameRequest(
+        @NotBlank(message = "Имя не может быть пустым")
+        @Size(min = 2, max = 24, message = "Имя должно быть от 2 до 24 символов")
+        @Pattern(
+                regexp = "^[\\p{L}\\p{N}_\\s-]+$",
+                message = "Только буквы, цифры, пробелы, дефисы и подчёркивания")
+        String displayName) {
+}

--- a/src/main/java/club/ttg/dnd5/domain/user/service/DisplayNameGenerator.java
+++ b/src/main/java/club/ttg/dnd5/domain/user/service/DisplayNameGenerator.java
@@ -1,0 +1,49 @@
+package club.ttg.dnd5.domain.user.service;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Генератор случайного отображаемого имени в тематике D&D («Отважный Странник»).
+ * Используется как дефолт при первом появлении пользователя, чтобы поле не было
+ * пустым и человек пошёл менять его на своё.
+ */
+@Component
+public class DisplayNameGenerator {
+    private static final List<String> ADJECTIVES = List.of(
+            "Отважный", "Хмурый", "Мудрый", "Тихий", "Дерзкий", "Странствующий",
+            "Забытый", "Пламенный", "Ледяной", "Теневой", "Лунный", "Грозовой",
+            "Безымянный", "Вечный", "Хитрый", "Стальной", "Древний", "Багряный",
+            "Северный", "Одинокий");
+
+    private static final List<String> NOUNS = List.of(
+            "Странник", "Голем", "Гоблин", "Дракон", "Маг", "Рыцарь", "Бард",
+            "Друид", "Плут", "Следопыт", "Варвар", "Паладин", "Чародей", "Жрец",
+            "Искатель", "Хранитель", "Пилигрим", "Наёмник", "Алхимик", "Скиталец");
+
+    /**
+     * Возвращает случайное имя вида «Прилагательное Существительное»
+     * (максимум ~23 символа — укладывается в лимит имени).
+     */
+    public String nextBaseName() {
+        String adjective = ADJECTIVES.get(ThreadLocalRandom.current().nextInt(ADJECTIVES.size()));
+        return adjective + " " + nextNoun();
+    }
+
+    /**
+     * Возвращает случайное существительное — короткая основа для развода коллизий
+     * с числовым суффиксом (укладывается в лимит длины).
+     */
+    public String nextNoun() {
+        return NOUNS.get(ThreadLocalRandom.current().nextInt(NOUNS.size()));
+    }
+
+    /**
+     * Возвращает случайный числовой суффикс для развода коллизий имён (например «734»).
+     */
+    public int nextSuffix() {
+        return ThreadLocalRandom.current().nextInt(1, 10_000);
+    }
+}

--- a/src/main/java/club/ttg/dnd5/domain/user/service/DisplayNameService.java
+++ b/src/main/java/club/ttg/dnd5/domain/user/service/DisplayNameService.java
@@ -1,0 +1,187 @@
+package club.ttg.dnd5.domain.user.service;
+
+import club.ttg.dnd5.domain.user.model.User;
+import club.ttg.dnd5.domain.user.model.UserDisplayName;
+import club.ttg.dnd5.domain.user.repository.UserDisplayNameRepository;
+import club.ttg.dnd5.domain.user.repository.UserRepository;
+import club.ttg.dnd5.domain.user.rest.dto.DisplayNameResponse;
+import club.ttg.dnd5.exception.ApiException;
+import club.ttg.dnd5.security.SecurityUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+/**
+ * Отображаемое имя пользователя. core-api — владелец данных (сайтовый бэкенд);
+ * auth-service и JWT не участвуют.
+ *
+ * Методы намеренно НЕ помечены {@code @Transactional}: каждый вызов репозитория
+ * идёт своей транзакцией, поэтому нарушение уникального индекса не переводит
+ * окружающую транзакцию в rollback-only и не ломает последующие чтения. Гонки
+ * на уникальном имени ловятся через {@link DataIntegrityViolationException},
+ * а {@code save()} по назначенному id работает как upsert (merge).
+ */
+@Service
+@RequiredArgsConstructor
+public class DisplayNameService {
+    private static final Pattern NAME_PATTERN = Pattern.compile("^[\\p{L}\\p{N}_\\s-]+$");
+    private static final int MIN_LENGTH = 2;
+    private static final int MAX_LENGTH = 24;
+    private static final int GENERATION_ATTEMPTS = 10;
+
+    /**
+     * Подстроки, запрещённые в имени (регистронезависимо, без учёта пробелов) —
+     * против выдачи себя за администрацию сайта.
+     */
+    private static final Set<String> RESERVED_SUBSTRINGS = Set.of(
+            "admin", "админ", "administrator", "администратор",
+            "moderator", "модератор", "модер",
+            "support", "поддержк", "owner", "овнер",
+            "root", "superuser", "суперюзер", "ttgclub", "ттгклаб");
+
+    private final UserDisplayNameRepository repository;
+    private final UserRepository userRepository;
+    private final DisplayNameGenerator generator;
+
+    /**
+     * Возвращает отображаемое имя текущего пользователя, лениво создавая запись
+     * со случайным дефолтом при первом обращении.
+     */
+    public DisplayNameResponse getOrCreateForCurrentUser() {
+        User user = SecurityUtils.getUser();
+        UUID userId = user.getUuid();
+
+        return new DisplayNameResponse(
+                repository.findById(userId)
+                        .map(UserDisplayName::getDisplayName)
+                        .orElseGet(() -> createDefault(userId, user.getUsername())));
+    }
+
+    /**
+     * Меняет отображаемое имя текущего пользователя после проверок формата,
+     * зарезервированных слов, чужого логина и уникальности.
+     */
+    public DisplayNameResponse updateForCurrentUser(String requested) {
+        User user = SecurityUtils.getUser();
+        UUID userId = user.getUuid();
+        String username = user.getUsername();
+        String name = normalize(requested);
+
+        validate(name, userId, username);
+
+        UserDisplayName entity = repository.findById(userId).orElseGet(() -> {
+            UserDisplayName created = new UserDisplayName();
+            created.setUserId(userId);
+            created.setCreatedAt(Instant.now());
+            return created;
+        });
+        entity.setUsername(username);
+        entity.setDisplayName(name);
+        entity.setUpdatedAt(Instant.now());
+
+        try {
+            repository.saveAndFlush(entity);
+        } catch (DataIntegrityViolationException ex) {
+            // Гонка по уникальному индексу: имя заняли между проверкой и сохранением.
+            throw new ApiException(HttpStatus.CONFLICT, "Это имя уже занято");
+        }
+
+        return new DisplayNameResponse(name);
+    }
+
+    /**
+     * Создаёт запись со случайным уникальным именем. Гонку по первичному ключу
+     * (два первых запроса одного пользователя) гасит повторным чтением.
+     */
+    private String createDefault(UUID userId, String username) {
+        String name = generateUniqueDefault();
+
+        UserDisplayName entity = new UserDisplayName();
+        entity.setUserId(userId);
+        entity.setUsername(username);
+        entity.setDisplayName(name);
+        Instant now = Instant.now();
+        entity.setCreatedAt(now);
+        entity.setUpdatedAt(now);
+
+        try {
+            repository.saveAndFlush(entity);
+            return name;
+        } catch (DataIntegrityViolationException ex) {
+            return repository.findById(userId)
+                    .map(UserDisplayName::getDisplayName)
+                    .orElseGet(() -> createDefault(userId, username));
+        }
+    }
+
+    /**
+     * Подбирает свободное случайное имя: базовое «Прилагательное Существительное»,
+     * при коллизии — с числовым суффиксом.
+     */
+    private String generateUniqueDefault() {
+        String base = generator.nextBaseName();
+        if (base.length() <= MAX_LENGTH && !repository.existsByDisplayNameIgnoreCase(base)) {
+            return base;
+        }
+        // При коллизии — короткая основа «Существительное Число», гарантированно ≤ 24.
+        for (int attempt = 0; attempt < GENERATION_ATTEMPTS; attempt++) {
+            String candidate = generator.nextNoun() + " " + generator.nextSuffix();
+            if (candidate.length() <= MAX_LENGTH && !repository.existsByDisplayNameIgnoreCase(candidate)) {
+                return candidate;
+            }
+        }
+        return generator.nextNoun() + generator.nextSuffix();
+    }
+
+    private void validate(String name, UUID userId, String username) {
+        if (name.length() < MIN_LENGTH || name.length() > MAX_LENGTH) {
+            throw new ApiException(HttpStatus.UNPROCESSABLE_ENTITY, "Имя должно быть от 2 до 24 символов");
+        }
+        if (!NAME_PATTERN.matcher(name).matches()) {
+            throw new ApiException(HttpStatus.UNPROCESSABLE_ENTITY,
+                    "Только буквы, цифры, пробелы, дефисы и подчёркивания");
+        }
+        if (isReserved(name)) {
+            throw new ApiException(HttpStatus.UNPROCESSABLE_ENTITY, "Это имя зарезервировано");
+        }
+        if (isForeignLogin(name, userId, username)) {
+            throw new ApiException(HttpStatus.UNPROCESSABLE_ENTITY,
+                    "Это имя совпадает с логином другого пользователя");
+        }
+        if (repository.existsByDisplayNameIgnoreCaseAndUserIdNot(name, userId)) {
+            throw new ApiException(HttpStatus.CONFLICT, "Это имя уже занято");
+        }
+    }
+
+    /**
+     * Приводит имя к каноничному виду: без крайних пробелов, внутренние пробелы схлопнуты.
+     */
+    private String normalize(String value) {
+        return value == null ? "" : value.trim().replaceAll("\\s+", " ");
+    }
+
+    private boolean isReserved(String name) {
+        String collapsed = name.toLowerCase(Locale.ROOT).replaceAll("\\s+", "");
+        return RESERVED_SUBSTRINGS.stream().anyMatch(collapsed::contains);
+    }
+
+    /**
+     * Совпадает ли имя с логином ДРУГОГО пользователя. Свой логин ставить можно.
+     * Источники логинов — таблица {@code users} (мог быть заполнен не полностью)
+     * и собственная таблица имён; покрытие растёт по мере входа пользователей.
+     */
+    private boolean isForeignLogin(String name, UUID userId, String username) {
+        if (name.equalsIgnoreCase(username)) {
+            return false;
+        }
+        return userRepository.existsByUsernameIgnoreCase(name)
+                || repository.existsByUsernameIgnoreCaseAndUserIdNot(name, userId);
+    }
+}

--- a/src/main/resources/db/changelog/2026/07/21-01-create-user-display-name-table.yaml
+++ b/src/main/resources/db/changelog/2026/07/21-01-create-user-display-name-table.yaml
@@ -1,0 +1,46 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-21-01-create-user-display-name-table
+      author: claude
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            tableName: user_display_name
+            columns:
+              - column:
+                  name: user_id
+                  type: UUID
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_user_display_name
+              - column:
+                  name: username
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: display_name
+                  type: VARCHAR(50)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME
+                  constraints:
+                    nullable: false
+        # Регистронезависимая уникальность отображаемого имени: два пользователя
+        # не могут занять одно и то же имя вне зависимости от регистра.
+        - sql:
+            dbms: postgresql
+            sql: create unique index uk_user_display_name_lower on user_display_name (lower(display_name));
+        # Индекс под резолв «логин → отображаемое имя» (таблица охотников за багами)
+        # и под проверку «имя не совпадает с логином другого пользователя».
+        - sql:
+            dbms: postgresql
+            sql: create index idx_user_display_name_username_lower on user_display_name (lower(username));

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -257,3 +257,5 @@ databaseChangeLog:
       file: db/changelog/2026/07/12-01-add-telegram-tail-message-ids-to-article.yaml
   - include:
       file: db/changelog/2026/07/13-01-update-full-name-search-view-add-article.yaml
+  - include:
+      file: db/changelog/2026/07/21-01-create-user-display-name-table.yaml


### PR DESCRIPTION
- новая таблица user_display_name (ключ = sub токена, регистронезависимая уникальность имени) + миграция и регистрация в master-changelog
- сущность UserDisplayName, репозиторий, DTO и DisplayNameService: ленивое создание случайного имени при первом обращении; смена имени с валидацией формата, уникальности, зарезервированных слов и совпадения с чужим логином; лимит 24 символа
- генератор случайных имён в тематике D&D
- эндпоинты GET/PATCH /api/user/profile/display-name (роль USER)