### PR TITLE
feat(character-sheet): хранение листов персонажей одним JSON-документом

### DIFF
--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/model/CharacterSheet.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/model/CharacterSheet.java
@@ -1,0 +1,65 @@
+package club.ttg.dnd5.domain.tool.sheet.model;
+
+import club.ttg.dnd5.domain.common.model.Timestamped;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.hypersistence.utils.hibernate.type.json.JsonType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.Type;
+
+import java.util.UUID;
+
+/**
+ * Лист персонажа (инструмент): сохранённый лист пользователя одним JSON-документом.
+ * Структуру документа сервер не разбирает — форматом владеет фронтенд.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "character_sheet",
+        indexes = {
+                @Index(name = "character_sheet_user_id_index", columnList = "user_id")
+        })
+public class CharacterSheet extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    /**
+     * Владелец — uuid пользователя из JWT (subject). Лист доступен только владельцу.
+     */
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    /**
+     * Название листа. Дублируется клиентом из JSON-документа, чтобы список (включая историю
+     * удалённых, где документ не отдаётся) не требовал разбора jsonb на сервере.
+     */
+    @Column(nullable = false)
+    private String name;
+
+    /**
+     * Весь лист персонажа как есть (фронтовый формат Character). Сохраняется при мягком
+     * удалении — восстановление возвращает лист без потерь.
+     */
+    @Type(JsonType.class)
+    @Column(columnDefinition = "jsonb", nullable = false)
+    private JsonNode data;
+
+    /**
+     * Мягкое удаление: лист скрыт из активных, остаётся в истории и может быть восстановлен,
+     * пока не вытеснен из неё более свежими удалениями.
+     */
+    @Column(nullable = false)
+    private boolean deleted;
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/repository/CharacterSheetRepository.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/repository/CharacterSheetRepository.java
@@ -1,0 +1,18 @@
+package club.ttg.dnd5.domain.tool.sheet.repository;
+
+import club.ttg.dnd5.domain.tool.sheet.model.CharacterSheet;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface CharacterSheetRepository extends JpaRepository<CharacterSheet, UUID> {
+
+    long countByUserIdAndDeletedFalse(UUID userId);
+
+    List<CharacterSheet> findAllByUserIdOrderByCreatedAtDesc(UUID userId);
+
+    List<CharacterSheet> findAllByUserIdAndDeletedFalseOrderByCreatedAtDesc(UUID userId);
+
+    List<CharacterSheet> findAllByUserIdAndDeletedTrueOrderByUpdatedAtDesc(UUID userId);
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/controller/CharacterSheetController.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/controller/CharacterSheetController.java
@@ -1,0 +1,85 @@
+package club.ttg.dnd5.domain.tool.sheet.rest.controller;
+
+import club.ttg.dnd5.domain.tool.sheet.rest.dto.CharacterSheetListResponse;
+import club.ttg.dnd5.domain.tool.sheet.rest.dto.CharacterSheetRequest;
+import club.ttg.dnd5.domain.tool.sheet.rest.dto.CharacterSheetResponse;
+import club.ttg.dnd5.domain.tool.sheet.service.CharacterSheetService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+/**
+ * Доступ: лист виден и редактируем только владельцу (uuid из JWT). Пока фича закрыта —
+ * {@code @Secured("ADMIN")} на классе (снять при открытии всем): {@code /api/v2/**} на уровне
+ * фильтров — permitAll, авторизацию обеспечивают только аннотации методов.
+ */
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v2/tools/character-sheet")
+@Secured("ADMIN")
+@Tag(name = "Лист персонажа",
+        description = "REST API листов персонажей: сохранение листа одним JSON-документом, "
+                + "список с лимитом, мягкое удаление и восстановление")
+public class CharacterSheetController {
+
+    private final CharacterSheetService sheetService;
+
+    @Operation(summary = "Создание листа: до 2 активных на пользователя (лимит вернёт 400); "
+            + "data — лист целиком, обязателен")
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    public CharacterSheetResponse create(@RequestBody @Valid final CharacterSheetRequest request) {
+        return sheetService.create(request);
+    }
+
+    @Operation(summary = "Листы текущего пользователя с лимитом и числом активных; "
+            + "includeDeleted=true — вместе с историей удалённых (у них data = null)")
+    @GetMapping
+    public CharacterSheetListResponse findMine(
+            @RequestParam(required = false, defaultValue = "false")
+            @Schema(description = "Включить удалённые листы (история с восстановлением)") final boolean includeDeleted) {
+        return sheetService.findMine(includeDeleted);
+    }
+
+    @Operation(summary = "Лист целиком по идентификатору")
+    @GetMapping("/{id}")
+    public CharacterSheetResponse findById(@PathVariable final UUID id) {
+        return sheetService.findById(id);
+    }
+
+    @Operation(summary = "Обновление листа: название и/или документ. Применяются только переданные поля")
+    @PutMapping("/{id}")
+    public CharacterSheetResponse update(@PathVariable final UUID id,
+                                         @RequestBody @Valid final CharacterSheetRequest request) {
+        return sheetService.update(id, request);
+    }
+
+    @Operation(summary = "Мягкое удаление: лист уходит в историю (хранятся последние 10 удалённых) "
+            + "и может быть восстановлен")
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable final UUID id) {
+        sheetService.delete(id);
+    }
+
+    @Operation(summary = "Восстановление удалённого листа; при заполненном лимите активных — 400")
+    @PostMapping("/{id}/restore")
+    public CharacterSheetResponse restore(@PathVariable final UUID id) {
+        return sheetService.restore(id);
+    }
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/dto/CharacterSheetListResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/dto/CharacterSheetListResponse.java
@@ -1,0 +1,25 @@
+package club.ttg.dnd5.domain.tool.sheet.rest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class CharacterSheetListResponse {
+
+    @Schema(description = "Максимум активных листов у пользователя (в будущем зависит от подписки)")
+    private int limit;
+
+    @Schema(description = "Текущее число активных (неудалённых) листов")
+    private int count;
+
+    @Schema(description = "Листы пользователя, новые первее; у удалённых data = null")
+    private List<CharacterSheetResponse> sheets;
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/dto/CharacterSheetRequest.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/dto/CharacterSheetRequest.java
@@ -1,0 +1,27 @@
+package club.ttg.dnd5.domain.tool.sheet.rest.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class CharacterSheetRequest {
+
+    @Nullable
+    @Size(max = 100)
+    @Schema(description = "Название листа (по умолчанию — «Новый персонаж»). При обновлении null — не менять")
+    private String name;
+
+    @Nullable
+    @Schema(description = "Лист персонажа целиком (JSON фронтового формата). Обязателен при создании; "
+            + "при обновлении null — не менять")
+    private JsonNode data;
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/dto/CharacterSheetResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/dto/CharacterSheetResponse.java
@@ -1,0 +1,43 @@
+package club.ttg.dnd5.domain.tool.sheet.rest.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class CharacterSheetResponse {
+
+    @NotNull
+    @Schema(description = "Идентификатор листа")
+    private UUID id;
+
+    @NotNull
+    @Schema(description = "Название листа")
+    private String name;
+
+    @Schema(description = "Лист удалён (виден только в истории при includeDeleted=true)")
+    private boolean deleted;
+
+    @Nullable
+    @Schema(description = "Лист персонажа целиком (JSON фронтового формата); в списке у удалённых листов — null")
+    private JsonNode data;
+
+    @Nullable
+    @Schema(description = "Дата создания")
+    private Instant createdAt;
+
+    @Nullable
+    @Schema(description = "Дата последнего изменения")
+    private Instant updatedAt;
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/mapper/CharacterSheetMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/mapper/CharacterSheetMapper.java
@@ -1,0 +1,29 @@
+package club.ttg.dnd5.domain.tool.sheet.rest.mapper;
+
+import club.ttg.dnd5.domain.tool.sheet.model.CharacterSheet;
+import club.ttg.dnd5.domain.tool.sheet.rest.dto.CharacterSheetResponse;
+import org.mapstruct.IterableMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.mapstruct.ReportingPolicy;
+
+import java.util.Collection;
+import java.util.List;
+
+@Mapper(unmappedTargetPolicy = ReportingPolicy.ERROR, componentModel = "spring")
+public interface CharacterSheetMapper {
+
+    CharacterSheetResponse toResponse(CharacterSheet sheet);
+
+    /**
+     * Элемент списка: у удалённых листов документ не отдаётся (история показывает только
+     * название и даты, а полный JSON вернётся после восстановления).
+     */
+    @Named("listItem")
+    @Mapping(target = "data", expression = "java(sheet.isDeleted() ? null : sheet.getData())")
+    CharacterSheetResponse toListItemResponse(CharacterSheet sheet);
+
+    @IterableMapping(qualifiedByName = "listItem")
+    List<CharacterSheetResponse> toListItemResponseList(Collection<CharacterSheet> sheets);
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/service/CharacterSheetService.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/service/CharacterSheetService.java
@@ -1,0 +1,161 @@
+package club.ttg.dnd5.domain.tool.sheet.service;
+
+import club.ttg.dnd5.domain.tool.sheet.model.CharacterSheet;
+import club.ttg.dnd5.domain.tool.sheet.repository.CharacterSheetRepository;
+import club.ttg.dnd5.domain.tool.sheet.rest.dto.CharacterSheetListResponse;
+import club.ttg.dnd5.domain.tool.sheet.rest.dto.CharacterSheetRequest;
+import club.ttg.dnd5.domain.tool.sheet.rest.dto.CharacterSheetResponse;
+import club.ttg.dnd5.domain.tool.sheet.rest.mapper.CharacterSheetMapper;
+import club.ttg.dnd5.domain.user.model.User;
+import club.ttg.dnd5.exception.ApiException;
+import club.ttg.dnd5.exception.EntityNotFoundException;
+import club.ttg.dnd5.security.SecurityUtils;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Листы персонажей: CRUD с владением по uuid пользователя из JWT, лимитом активных листов
+ * и мягким удалением с восстановлением. Содержимое листа — непрозрачный для сервера JSON.
+ */
+@RequiredArgsConstructor
+@Service
+public class CharacterSheetService {
+
+    private static final int MAX_ACTIVE_SHEETS = 2;
+    private static final int MAX_DELETED_HISTORY_PER_USER = 10;
+    private static final String DEFAULT_NAME = "Новый персонаж";
+
+    private final CharacterSheetRepository sheetRepository;
+    private final CharacterSheetMapper sheetMapper;
+
+    /**
+     * Создаёт лист. Лимит — {@link #getLimitFor(User)} активных листов; документ обязателен.
+     */
+    @Transactional
+    public CharacterSheetResponse create(CharacterSheetRequest request) {
+        User user = SecurityUtils.getUser();
+        validateLimit(user);
+        if (request == null || request.getData() == null || request.getData().isNull()) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "Не переданы данные листа персонажа (data)");
+        }
+        CharacterSheet sheet = new CharacterSheet();
+        sheet.setUserId(user.getUuid());
+        sheet.setName(nameOrDefault(request));
+        sheet.setData(request.getData());
+        // Флаш сразу: createdAt/updatedAt генерирует БД при INSERT, без него в ответе были бы null.
+        return sheetMapper.toResponse(sheetRepository.saveAndFlush(sheet));
+    }
+
+    /**
+     * Листы текущего пользователя, новые первее, с лимитом и числом активных (для «N из M»
+     * на клиенте). {@code includeDeleted=true} — вместе с историей удалённых (без документа).
+     */
+    public CharacterSheetListResponse findMine(boolean includeDeleted) {
+        User user = SecurityUtils.getUser();
+        List<CharacterSheet> sheets = includeDeleted
+                ? sheetRepository.findAllByUserIdOrderByCreatedAtDesc(user.getUuid())
+                : sheetRepository.findAllByUserIdAndDeletedFalseOrderByCreatedAtDesc(user.getUuid());
+        long activeCount = sheets.stream().filter(sheet -> !sheet.isDeleted()).count();
+        return new CharacterSheetListResponse(
+                getLimitFor(user), (int) activeCount, sheetMapper.toListItemResponseList(sheets));
+    }
+
+    public CharacterSheetResponse findById(UUID sheetId) {
+        return sheetMapper.toResponse(getOwnedActive(sheetId));
+    }
+
+    /**
+     * Обновление листа: применяются только заполненные поля (название, документ), null — «не менять».
+     */
+    @Transactional
+    public CharacterSheetResponse update(UUID sheetId, CharacterSheetRequest request) {
+        CharacterSheet sheet = getOwnedActive(sheetId);
+        if (StringUtils.hasText(request.getName())) {
+            sheet.setName(request.getName().trim());
+        }
+        if (request.getData() != null && !request.getData().isNull()) {
+            sheet.setData(request.getData());
+        }
+        return sheetMapper.toResponse(sheet);
+    }
+
+    /**
+     * Мягкое удаление: лист скрыт из активных, документ сохраняется — восстановление без потерь.
+     * История ограничивается последними {@value MAX_DELETED_HISTORY_PER_USER} удалёнными листами —
+     * иначе цикл «создать → удалить» рос бы в БД без ограничений: лимит активных удалённые не считает.
+     */
+    @Transactional
+    public void delete(UUID sheetId) {
+        CharacterSheet sheet = getOwnedActive(sheetId);
+        sheet.setDeleted(true);
+        trimDeletedHistory(sheet.getUserId());
+    }
+
+    /**
+     * Восстановление из истории удалённых. Проверяет лимит активных — вернуть лист сверх
+     * лимита нельзя.
+     */
+    @Transactional
+    public CharacterSheetResponse restore(UUID sheetId) {
+        User user = SecurityUtils.getUser();
+        CharacterSheet sheet = sheetRepository.findById(sheetId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        String.format("Лист персонажа с id %s не существует", sheetId)));
+        requireOwner(sheet, user);
+        if (!sheet.isDeleted()) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "Лист персонажа не удалён");
+        }
+        validateLimit(user);
+        sheet.setDeleted(false);
+        return sheetMapper.toResponse(sheet);
+    }
+
+    /**
+     * Лимит активных листов пользователя. Пока константа; с появлением подписок здесь появится
+     * расчёт по уровню подписки пользователя.
+     */
+    private int getLimitFor(User user) {
+        return MAX_ACTIVE_SHEETS;
+    }
+
+    private void validateLimit(User user) {
+        int limit = getLimitFor(user);
+        if (sheetRepository.countByUserIdAndDeletedFalse(user.getUuid()) >= limit) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, String.format(
+                    "Достигнут лимит листов персонажей: %d. Удалите один из существующих", limit));
+        }
+    }
+
+    private void trimDeletedHistory(UUID userId) {
+        List<CharacterSheet> deleted = sheetRepository.findAllByUserIdAndDeletedTrueOrderByUpdatedAtDesc(userId);
+        if (deleted.size() > MAX_DELETED_HISTORY_PER_USER) {
+            sheetRepository.deleteAll(deleted.subList(MAX_DELETED_HISTORY_PER_USER, deleted.size()));
+        }
+    }
+
+    private CharacterSheet getOwnedActive(UUID sheetId) {
+        User user = SecurityUtils.getUser();
+        CharacterSheet sheet = sheetRepository.findById(sheetId)
+                .filter(found -> !found.isDeleted())
+                .orElseThrow(() -> new EntityNotFoundException(
+                        String.format("Лист персонажа с id %s не существует", sheetId)));
+        requireOwner(sheet, user);
+        return sheet;
+    }
+
+    private void requireOwner(CharacterSheet sheet, User user) {
+        if (!sheet.getUserId().equals(user.getUuid())) {
+            throw new ApiException(HttpStatus.FORBIDDEN, "Доступ к листу персонажа запрещен");
+        }
+    }
+
+    private String nameOrDefault(CharacterSheetRequest request) {
+        return StringUtils.hasText(request.getName()) ? request.getName().trim() : DEFAULT_NAME;
+    }
+}

--- a/src/main/resources/db/changelog/2026/07/24-01-create-character-sheet-table.yaml
+++ b/src/main/resources/db/changelog/2026/07/24-01-create-character-sheet-table.yaml
@@ -1,0 +1,60 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-24-01-create-character-sheet-table
+      author: Peterko
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            tableName: character_sheet
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_character_sheet
+                  name: id
+                  type: UUID
+              - column:
+                  name: user_id
+                  type: UUID
+                  constraints:
+                    nullable: false
+              - column:
+                  name: name
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: data
+                  type: jsonb
+                  constraints:
+                    nullable: false
+              - column:
+                  name: deleted
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME
+              - column:
+                  name: updated_at
+                  type: DATETIME
+              - column:
+                  name: username
+                  type: VARCHAR(255)
+              - column:
+                  name: last_username
+                  type: VARCHAR(255)
+  - changeSet:
+      id: 2026-07-24-01-create-character-sheet-index
+      author: Peterko
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createIndex:
+            columns:
+              - column:
+                  name: user_id
+            indexName: character_sheet_user_id_index
+            tableName: character_sheet

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -259,3 +259,5 @@ databaseChangeLog:
       file: db/changelog/2026/07/13-01-update-full-name-search-view-add-article.yaml
   - include:
       file: db/changelog/2026/07/21-01-create-user-display-name-table.yaml
+  - include:
+      file: db/changelog/2026/07/24-01-create-character-sheet-table.yaml


### PR DESCRIPTION
Новый домен tool/sheet: лист пользователя сохраняется одной строкой character_sheet (user_id из JWT, name, data jsonb, deleted) с аудитом Timestamped. Содержимое документа сервер не разбирает — форматом владеет фронтенд; name дублируется клиентом в отдельную колонку, чтобы списку и истории удалённых не требовался разбор jsonb.

REST /api/v2/tools/character-sheet (пока @Secured("ADMIN") на классе — /api/v2/** на уровне фильтров permitAll, авторизацию дают аннотации):
- GET /?includeDeleted — листы пользователя с лимитом и числом активных ({limit, count, sheets[]}); у удалённых в списке data = null
- POST / — создание (201), документ обязателен, имя по умолчанию
- GET /{id}, PUT /{id} — чтение и обновление (применяются только переданные поля, null = не менять)
- DELETE /{id} — мягкое удаление, в истории хранятся последние 10
- POST /{id}/restore — восстановление с повторной проверкой лимита

Лимит активных листов — 2 на пользователя, вынесен в getLimitFor(user) под будущую зависимость от подписки; превышение — 400 с текстом. Чужой лист — 403, отсутствующий или удалённый — 404.

Миграция Liquibase 2026/07/24-01: таблица character_sheet + индекс по user_id, подключена в master-чейнджлог.