### PR TITLE
feat(character-sheet): доступ к листу персонажа по ссылке

### DIFF
--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/model/CharacterSheet.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/model/CharacterSheet.java
@@ -27,7 +27,8 @@ import java.util.UUID;
 @Entity
 @Table(name = "character_sheet",
         indexes = {
-                @Index(name = "character_sheet_user_id_index", columnList = "user_id")
+                @Index(name = "character_sheet_user_id_index", columnList = "user_id"),
+                @Index(name = "character_sheet_share_token_index", columnList = "share_token", unique = true)
         })
 public class CharacterSheet extends Timestamped {
 
@@ -62,4 +63,12 @@ public class CharacterSheet extends Timestamped {
      */
     @Column(nullable = false)
     private boolean deleted;
+
+    /**
+     * Секрет ссылки «поделиться листом»: {@code null} — доступа по ссылке нет. По токену лист
+     * отдаётся кому угодно, но только на чтение. Токен, а не сам id, чтобы ссылка не раскрывала
+     * идентификатор листа и отзывалась независимо от него.
+     */
+    @Column(name = "share_token")
+    private UUID shareToken;
 }

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/repository/CharacterSheetRepository.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/repository/CharacterSheetRepository.java
@@ -4,6 +4,7 @@ import club.ttg.dnd5.domain.tool.sheet.model.CharacterSheet;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface CharacterSheetRepository extends JpaRepository<CharacterSheet, UUID> {
@@ -15,4 +16,10 @@ public interface CharacterSheetRepository extends JpaRepository<CharacterSheet, 
     List<CharacterSheet> findAllByUserIdAndDeletedFalseOrderByCreatedAtDesc(UUID userId);
 
     List<CharacterSheet> findAllByUserIdAndDeletedTrueOrderByUpdatedAtDesc(UUID userId);
+
+    /**
+     * Лист по ссылке «поделиться». Удалённые не отдаются: доступ по ссылке пропадает
+     * вместе с листом и возвращается при восстановлении.
+     */
+    Optional<CharacterSheet> findByShareTokenAndDeletedFalse(UUID shareToken);
 }

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/controller/CharacterSheetController.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/controller/CharacterSheetController.java
@@ -3,6 +3,7 @@ package club.ttg.dnd5.domain.tool.sheet.rest.controller;
 import club.ttg.dnd5.domain.tool.sheet.rest.dto.CharacterSheetListResponse;
 import club.ttg.dnd5.domain.tool.sheet.rest.dto.CharacterSheetRequest;
 import club.ttg.dnd5.domain.tool.sheet.rest.dto.CharacterSheetResponse;
+import club.ttg.dnd5.domain.tool.sheet.rest.dto.CharacterSheetShareResponse;
 import club.ttg.dnd5.domain.tool.sheet.service.CharacterSheetService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -81,5 +82,18 @@ public class CharacterSheetController {
     @PostMapping("/{id}/restore")
     public CharacterSheetResponse restore(@PathVariable final UUID id) {
         return sheetService.restore(id);
+    }
+
+    @Operation(summary = "Включение доступа по ссылке: возвращает токен ссылки. "
+            + "Повторный вызов идемпотентен — токен у расшаренного листа не меняется")
+    @PostMapping("/{id}/share")
+    public CharacterSheetShareResponse share(@PathVariable final UUID id) {
+        return sheetService.share(id);
+    }
+
+    @Operation(summary = "Отзыв доступа по ссылке: выданная ранее ссылка перестаёт открываться")
+    @DeleteMapping("/{id}/share")
+    public void revokeShare(@PathVariable final UUID id) {
+        sheetService.revokeShare(id);
     }
 }

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/controller/CharacterSheetShareController.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/controller/CharacterSheetShareController.java
@@ -1,0 +1,36 @@
+package club.ttg.dnd5.domain.tool.sheet.rest.controller;
+
+import club.ttg.dnd5.domain.tool.sheet.rest.dto.CharacterSheetPublicResponse;
+import club.ttg.dnd5.domain.tool.sheet.service.CharacterSheetService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Просмотр листа персонажа по ссылке «поделиться»: без авторизации и без роли.
+ * <p>
+ * Вынесено в отдельный контроллер, потому что {@link CharacterSheetController} закрыт
+ * {@code @Secured("ADMIN")} на уровне класса — аннотация распространилась бы и на эту ручку,
+ * а ссылка должна открываться кем угодно, включая анонима. Ручек записи по токену здесь нет:
+ * режим «только просмотр» обеспечен их отсутствием на сервере, а не блокировками на клиенте.
+ */
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v2/tools/character-sheet/shared")
+@Tag(name = "Лист персонажа по ссылке",
+        description = "Публичное чтение листа персонажа по токену ссылки «поделиться»")
+public class CharacterSheetShareController {
+
+    private final CharacterSheetService sheetService;
+
+    @Operation(summary = "Лист по ссылке: только чтение, без авторизации. "
+            + "Неизвестный, отозванный или битый токен — 404")
+    @GetMapping("/{token}")
+    public CharacterSheetPublicResponse findShared(@PathVariable final String token) {
+        return sheetService.findShared(token);
+    }
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/dto/CharacterSheetPublicResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/dto/CharacterSheetPublicResponse.java
@@ -1,0 +1,34 @@
+package club.ttg.dnd5.domain.tool.sheet.rest.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+/**
+ * Лист, открытый по ссылке. Отдельный DTO, а не {@link CharacterSheetResponse}: наружу уходит
+ * только то, что нужно для отображения — без токена ссылки, флага удаления и служебных дат.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class CharacterSheetPublicResponse {
+
+    @NotNull
+    @Schema(description = "Идентификатор листа")
+    private UUID id;
+
+    @NotNull
+    @Schema(description = "Название листа")
+    private String name;
+
+    @NotNull
+    @Schema(description = "Лист персонажа целиком (JSON фронтового формата)")
+    private JsonNode data;
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/dto/CharacterSheetResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/dto/CharacterSheetResponse.java
@@ -34,6 +34,11 @@ public class CharacterSheetResponse {
     private JsonNode data;
 
     @Nullable
+    @Schema(description = "Токен ссылки «поделиться»; null — доступ по ссылке выключен. "
+            + "Отдаётся только владельцу листа")
+    private UUID shareToken;
+
+    @Nullable
     @Schema(description = "Дата создания")
     private Instant createdAt;
 

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/dto/CharacterSheetShareResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/dto/CharacterSheetShareResponse.java
@@ -1,0 +1,25 @@
+package club.ttg.dnd5.domain.tool.sheet.rest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+/**
+ * Ответ на включение доступа по ссылке. Ссылку собирает клиент — сервер не знает
+ * ни домена фронтенда, ни его маршрутов.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class CharacterSheetShareResponse {
+
+    @NotNull
+    @Schema(description = "Токен ссылки: по нему лист открывается на чтение без авторизации")
+    private UUID shareToken;
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/mapper/CharacterSheetMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/mapper/CharacterSheetMapper.java
@@ -1,6 +1,7 @@
 package club.ttg.dnd5.domain.tool.sheet.rest.mapper;
 
 import club.ttg.dnd5.domain.tool.sheet.model.CharacterSheet;
+import club.ttg.dnd5.domain.tool.sheet.rest.dto.CharacterSheetPublicResponse;
 import club.ttg.dnd5.domain.tool.sheet.rest.dto.CharacterSheetResponse;
 import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
@@ -26,4 +27,9 @@ public interface CharacterSheetMapper {
 
     @IterableMapping(qualifiedByName = "listItem")
     List<CharacterSheetResponse> toListItemResponseList(Collection<CharacterSheet> sheets);
+
+    /**
+     * Лист для просмотра по ссылке: владелец и токен ссылки наружу не уходят.
+     */
+    CharacterSheetPublicResponse toPublicResponse(CharacterSheet sheet);
 }

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/service/CharacterSheetService.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/service/CharacterSheetService.java
@@ -3,8 +3,10 @@ package club.ttg.dnd5.domain.tool.sheet.service;
 import club.ttg.dnd5.domain.tool.sheet.model.CharacterSheet;
 import club.ttg.dnd5.domain.tool.sheet.repository.CharacterSheetRepository;
 import club.ttg.dnd5.domain.tool.sheet.rest.dto.CharacterSheetListResponse;
+import club.ttg.dnd5.domain.tool.sheet.rest.dto.CharacterSheetPublicResponse;
 import club.ttg.dnd5.domain.tool.sheet.rest.dto.CharacterSheetRequest;
 import club.ttg.dnd5.domain.tool.sheet.rest.dto.CharacterSheetResponse;
+import club.ttg.dnd5.domain.tool.sheet.rest.dto.CharacterSheetShareResponse;
 import club.ttg.dnd5.domain.tool.sheet.rest.mapper.CharacterSheetMapper;
 import club.ttg.dnd5.domain.user.model.User;
 import club.ttg.dnd5.exception.ApiException;
@@ -30,6 +32,7 @@ public class CharacterSheetService {
     private static final int MAX_ACTIVE_SHEETS = 2;
     private static final int MAX_DELETED_HISTORY_PER_USER = 10;
     private static final String DEFAULT_NAME = "Новый персонаж";
+    private static final String SHARED_NOT_FOUND_MESSAGE = "Лист персонажа по этой ссылке не найден";
 
     private final CharacterSheetRepository sheetRepository;
     private final CharacterSheetMapper sheetMapper;
@@ -114,6 +117,55 @@ public class CharacterSheetService {
         validateLimit(user);
         sheet.setDeleted(false);
         return sheetMapper.toResponse(sheet);
+    }
+
+    /**
+     * Включает доступ по ссылке и возвращает её токен. Идемпотентно: у уже расшаренного листа
+     * токен не перевыпускается, иначе разосланные ранее ссылки молча перестали бы открываться.
+     */
+    @Transactional
+    public CharacterSheetShareResponse share(UUID sheetId) {
+        CharacterSheet sheet = getOwnedActive(sheetId);
+        if (sheet.getShareToken() == null) {
+            sheet.setShareToken(UUID.randomUUID());
+        }
+        return new CharacterSheetShareResponse(sheet.getShareToken());
+    }
+
+    /**
+     * Отзывает доступ по ссылке: выданная ранее ссылка перестаёт открываться немедленно
+     * и навсегда — повторное «поделиться» выдаст новый токен. Повторный отзыв безопасен.
+     */
+    @Transactional
+    public void revokeShare(UUID sheetId) {
+        getOwnedActive(sheetId).setShareToken(null);
+    }
+
+    /**
+     * Лист по ссылке: чтение без авторизации и без владения. Неизвестный, отозванный или битый
+     * токен, как и удалённый лист, — одинаковый 404: наружу не подтверждается даже существование
+     * листа. Ручек записи по токену нет — просмотр «только чтение» обеспечен их отсутствием,
+     * а не поведением клиента.
+     */
+    public CharacterSheetPublicResponse findShared(String shareToken) {
+        CharacterSheet sheet = sheetRepository.findByShareTokenAndDeletedFalse(parseShareToken(shareToken))
+                .orElseThrow(() -> new EntityNotFoundException(SHARED_NOT_FOUND_MESSAGE));
+        return sheetMapper.toPublicResponse(sheet);
+    }
+
+    /**
+     * Токен разбирается вручную, а не конвертером {@code @PathVariable UUID}: ссылку правят руками
+     * и обрезают мессенджеры, а мусор в пути должен давать 404, а не 500 от конвертера.
+     */
+    private UUID parseShareToken(String shareToken) {
+        if (!StringUtils.hasText(shareToken)) {
+            throw new EntityNotFoundException(SHARED_NOT_FOUND_MESSAGE);
+        }
+        try {
+            return UUID.fromString(shareToken.trim());
+        } catch (IllegalArgumentException e) {
+            throw new EntityNotFoundException(SHARED_NOT_FOUND_MESSAGE);
+        }
     }
 
     /**

--- a/src/main/resources/db/changelog/2026/07/25-01-add-share-token-to-character-sheet.yaml
+++ b/src/main/resources/db/changelog/2026/07/25-01-add-share-token-to-character-sheet.yaml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-25-01-add-share-token-to-character-sheet
+      author: Peterko
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addColumn:
+            tableName: character_sheet
+            columns:
+              - column:
+                  name: share_token
+                  type: UUID
+        # Уникальный индекс: токен — единственный ключ поиска листа по ссылке.
+        # Колонка nullable (нерасшаренные листы), в Postgres несколько NULL уникальности не нарушают.
+        - createIndex:
+            columns:
+              - column:
+                  name: share_token
+            indexName: character_sheet_share_token_index
+            tableName: character_sheet
+            unique: true

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -261,3 +261,5 @@ databaseChangeLog:
       file: db/changelog/2026/07/21-01-create-user-display-name-table.yaml
   - include:
       file: db/changelog/2026/07/24-01-create-character-sheet-table.yaml
+  - include:
+      file: db/changelog/2026/07/25-01-add-share-token-to-character-sheet.yaml

--- a/src/test/java/club/ttg/dnd5/domain/tool/sheet/service/CharacterSheetServiceTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/tool/sheet/service/CharacterSheetServiceTest.java
@@ -1,0 +1,133 @@
+package club.ttg.dnd5.domain.tool.sheet.service;
+
+import club.ttg.dnd5.domain.tool.sheet.model.CharacterSheet;
+import club.ttg.dnd5.domain.tool.sheet.repository.CharacterSheetRepository;
+import club.ttg.dnd5.domain.tool.sheet.rest.dto.CharacterSheetPublicResponse;
+import club.ttg.dnd5.domain.tool.sheet.rest.dto.CharacterSheetShareResponse;
+import club.ttg.dnd5.domain.tool.sheet.rest.mapper.CharacterSheetMapper;
+import club.ttg.dnd5.domain.user.model.User;
+import club.ttg.dnd5.exception.ApiException;
+import club.ttg.dnd5.exception.EntityNotFoundException;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Доступ к листу по ссылке: выпуск и отзыв токена владельцем и анонимный просмотр.
+ */
+class CharacterSheetServiceTest {
+
+    private final CharacterSheetRepository sheetRepository = mock(CharacterSheetRepository.class);
+    private final CharacterSheetMapper sheetMapper = mock(CharacterSheetMapper.class);
+    private final CharacterSheetService service = new CharacterSheetService(sheetRepository, sheetMapper);
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void shareIssuesTokenAndKeepsItOnRepeatedCalls() {
+        UUID owner = authenticate();
+        CharacterSheet sheet = sheet(owner);
+        when(sheetRepository.findById(sheet.getId())).thenReturn(Optional.of(sheet));
+
+        CharacterSheetShareResponse first = service.share(sheet.getId());
+        CharacterSheetShareResponse second = service.share(sheet.getId());
+
+        assertNotNull(first.getShareToken());
+        // Идемпотентность: перевыпуск токена сломал бы уже разосланные ссылки
+        assertEquals(first.getShareToken(), second.getShareToken());
+        assertEquals(first.getShareToken(), sheet.getShareToken());
+    }
+
+    @Test
+    void shareOnForeignSheetIsForbidden() {
+        authenticate();
+        CharacterSheet foreign = sheet(UUID.randomUUID());
+        when(sheetRepository.findById(foreign.getId())).thenReturn(Optional.of(foreign));
+
+        ApiException exception = assertThrows(ApiException.class, () -> service.share(foreign.getId()));
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatus());
+        assertNull(foreign.getShareToken());
+    }
+
+    @Test
+    void revokeShareClearsToken() {
+        UUID owner = authenticate();
+        CharacterSheet sheet = sheet(owner);
+        sheet.setShareToken(UUID.randomUUID());
+        when(sheetRepository.findById(sheet.getId())).thenReturn(Optional.of(sheet));
+
+        service.revokeShare(sheet.getId());
+
+        assertNull(sheet.getShareToken());
+    }
+
+    @Test
+    void findSharedReturnsSheetToAnonymousViewer() {
+        CharacterSheet sheet = sheet(UUID.randomUUID());
+        UUID token = UUID.randomUUID();
+        sheet.setShareToken(token);
+        CharacterSheetPublicResponse expected = new CharacterSheetPublicResponse();
+        when(sheetRepository.findByShareTokenAndDeletedFalse(token)).thenReturn(Optional.of(sheet));
+        when(sheetMapper.toPublicResponse(sheet)).thenReturn(expected);
+
+        // Контекст безопасности пуст — ручка публичная
+        CharacterSheetPublicResponse actual = service.findShared(token.toString());
+
+        assertSame(expected, actual);
+    }
+
+    @Test
+    void findSharedWithUnknownTokenIsNotFound() {
+        UUID token = UUID.randomUUID();
+        when(sheetRepository.findByShareTokenAndDeletedFalse(token)).thenReturn(Optional.empty());
+
+        assertThrows(EntityNotFoundException.class, () -> service.findShared(token.toString()));
+    }
+
+    @Test
+    void findSharedWithMalformedTokenIsNotFoundInsteadOfServerError() {
+        assertThrows(EntityNotFoundException.class, () -> service.findShared("не-похоже-на-uuid"));
+        assertThrows(EntityNotFoundException.class, () -> service.findShared("  "));
+
+        verify(sheetRepository, never()).findByShareTokenAndDeletedFalse(any());
+    }
+
+    private static CharacterSheet sheet(UUID ownerId) {
+        CharacterSheet sheet = new CharacterSheet();
+        sheet.setId(UUID.randomUUID());
+        sheet.setUserId(ownerId);
+        sheet.setName("Гимли");
+        sheet.setData(JsonNodeFactory.instance.objectNode());
+        return sheet;
+    }
+
+    private static UUID authenticate() {
+        User user = new User();
+        user.setUuid(UUID.randomUUID());
+        SecurityContextHolder.getContext()
+                .setAuthentication(new UsernamePasswordAuthenticationToken(user, null, List.of()));
+        return user.getUuid();
+    }
+}


### PR DESCRIPTION
Владелец выдаёт ссылку на свой лист, по которой лист открывается на чтение кем угодно, включая анонимных пользователей. Доступ решает секретный токен, а не идентификатор листа: ссылка не раскрывает id и отзывается независимо от него.

REST дополнен тремя ручками:
- POST /{id}/share — выдача токена, идемпотентна: у уже расшаренного листа токен не перевыпускается, иначе разосланные ранее ссылки молча перестали бы открываться
- DELETE /{id}/share — отзыв доступа, повторный вызов безопасен
- GET /shared/{token} — публичное чтение

Публичная ручка вынесена в отдельный CharacterSheetShareController: на CharacterSheetController висит классовый @Secured("ADMIN"), который распространился бы и на неё, а @PreAuthorize его не переопределяет. Режим «только просмотр» обеспечен отсутствием ручек записи по токену, а не поведением клиента.

Наружу уходит отдельный CharacterSheetPublicResponse (id, name, data) — без токена ссылки, флага удаления и служебных дат. Токен разбирается вручную, а не конвертером @PathVariable UUID: правленая или обрезанная мессенджером ссылка даёт 404, а не 500. Неизвестный, отозванный и битый токен, как и удалённый лист, неотличимы — наружу не подтверждается даже существование листа. Владельцу shareToken приходит в CharacterSheetResponse, чтобы клиент знал состояние доступа без лишнего запроса.

Миграция Liquibase 2026/07/25-01: колонка share_token с уникальным индексом (nullable — у нерасшаренных листов), подключена в master-чейнджлог.

Тесты сервиса: выдача и идемпотентность токена, отзыв, 403 при попытке поделиться чужим листом, 404 на неизвестном и на битом токене.