### PR TITLE
feat(character-sheet): сохранение чужого листа персонажа по ссылке

### DIFF
--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/model/SavedCharacterSheet.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/model/SavedCharacterSheet.java
@@ -1,0 +1,68 @@
+package club.ttg.dnd5.domain.tool.sheet.model;
+
+import club.ttg.dnd5.domain.common.model.Timestamped;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+/**
+ * Чужой лист персонажа, сохранённый пользователем по ссылке «поделиться». Хранится сама ссылка,
+ * а не копия документа: лист остаётся у владельца и виден сохранившему только на чтение.
+ * <p>
+ * Связи с {@link CharacterSheet} через JPA намеренно нет: запись переживает и удаление листа,
+ * и отзыв доступа — пользователь должен увидеть, что лист стал недоступен, а не его молчаливое
+ * исчезновение из списка.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "character_sheet_saved",
+        indexes = {
+                @Index(name = "character_sheet_saved_user_id_index", columnList = "user_id"),
+                @Index(name = "character_sheet_saved_user_sheet_index",
+                        columnList = "user_id, sheet_id", unique = true)
+        })
+public class SavedCharacterSheet extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    /**
+     * Тот, кто сохранил ссылку, — uuid пользователя из JWT (subject).
+     */
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    /**
+     * Идентификатор сохранённого листа. Уникален в паре с владельцем записи: повторное сохранение
+     * того же листа по новой ссылке обновляет токен, а не создаёт вторую запись.
+     */
+    @Column(name = "sheet_id", nullable = false)
+    private UUID sheetId;
+
+    /**
+     * Токен ссылки на момент сохранения. Доступ считается живым, только пока он совпадает с токеном
+     * листа: отзыв доступа владельцем гасит сохранённую ссылку, а новый share выдаёт новый токен —
+     * и требует новой ссылки.
+     */
+    @Column(name = "share_token", nullable = false)
+    private UUID shareToken;
+
+    /**
+     * Название листа на момент сохранения. Нужно недоступным записям: живое название такого листа
+     * взять неоткуда, а карточка без подписи не объясняет, что именно пропало.
+     */
+    @Column(nullable = false)
+    private String name;
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/repository/SavedCharacterSheetRepository.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/repository/SavedCharacterSheetRepository.java
@@ -1,0 +1,26 @@
+package club.ttg.dnd5.domain.tool.sheet.repository;
+
+import club.ttg.dnd5.domain.tool.sheet.model.SavedCharacterSheet;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface SavedCharacterSheetRepository extends JpaRepository<SavedCharacterSheet, UUID> {
+
+    long countByUserId(UUID userId);
+
+    List<SavedCharacterSheet> findAllByUserIdOrderByCreatedAtDesc(UUID userId);
+
+    /**
+     * Уже сохранённый лист: повторное сохранение по новой ссылке обновляет запись.
+     */
+    Optional<SavedCharacterSheet> findByUserIdAndSheetId(UUID userId, UUID sheetId);
+
+    /**
+     * Запись для удаления. Владелец записи в условии, а не в отдельной проверке: чужую
+     * сохранённую ссылку не должно быть видно даже по факту существования.
+     */
+    Optional<SavedCharacterSheet> findByIdAndUserId(UUID id, UUID userId);
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/controller/CharacterSheetSavedController.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/controller/CharacterSheetSavedController.java
@@ -1,0 +1,56 @@
+package club.ttg.dnd5.domain.tool.sheet.rest.controller;
+
+import club.ttg.dnd5.domain.tool.sheet.rest.dto.SavedCharacterSheetListResponse;
+import club.ttg.dnd5.domain.tool.sheet.rest.dto.SavedCharacterSheetRequest;
+import club.ttg.dnd5.domain.tool.sheet.rest.dto.SavedCharacterSheetResponse;
+import club.ttg.dnd5.domain.tool.sheet.service.SavedCharacterSheetService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+/**
+ * Чужие листы персонажей, сохранённые по ссылке. Как и {@link CharacterSheetController}, закрыт
+ * ролью: сохранять ссылки может только тот, у кого есть доступ к самому инструменту. Вынесено в
+ * отдельный контроллер, чтобы литерал {@code /saved} не спорил с {@code /{id}} соседнего.
+ */
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v2/tools/character-sheet/saved")
+@Secured("ADMIN")
+@Tag(name = "Сохранённые листы персонажей",
+        description = "REST API чужих листов, сохранённых по ссылке «поделиться»: только просмотр")
+public class CharacterSheetSavedController {
+
+    private final SavedCharacterSheetService savedSheetService;
+
+    @Operation(summary = "Сохранённые ссылки текущего пользователя с лимитом; "
+            + "у листов, к которым доступ закрыт, data = null и available = false")
+    @GetMapping
+    public SavedCharacterSheetListResponse findMine() {
+        return savedSheetService.findMine();
+    }
+
+    @Operation(summary = "Сохранение чужого листа по токену ссылки: до 4 записей (лимит вернёт 400). "
+            + "Повторное сохранение того же листа обновляет ссылку, свой лист — 400")
+    @PostMapping
+    public SavedCharacterSheetResponse save(@RequestBody @Valid final SavedCharacterSheetRequest request) {
+        return savedSheetService.save(request.getShareToken());
+    }
+
+    @Operation(summary = "Удаление сохранённой ссылки")
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable final UUID id) {
+        savedSheetService.delete(id);
+    }
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/dto/SavedCharacterSheetListResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/dto/SavedCharacterSheetListResponse.java
@@ -1,0 +1,25 @@
+package club.ttg.dnd5.domain.tool.sheet.rest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class SavedCharacterSheetListResponse {
+
+    @Schema(description = "Максимум сохранённых чужих листов у пользователя (в будущем зависит от подписки)")
+    private int limit;
+
+    @Schema(description = "Текущее число сохранённых записей, включая ставшие недоступными")
+    private int count;
+
+    @Schema(description = "Сохранённые листы, новые первее")
+    private List<SavedCharacterSheetResponse> sheets;
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/dto/SavedCharacterSheetRequest.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/dto/SavedCharacterSheetRequest.java
@@ -1,0 +1,19 @@
+package club.ttg.dnd5.domain.tool.sheet.rest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class SavedCharacterSheetRequest {
+
+    @NotBlank
+    @Schema(description = "Токен ссылки «поделиться» — последний сегмент присланного адреса листа")
+    private String shareToken;
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/dto/SavedCharacterSheetResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/dto/SavedCharacterSheetResponse.java
@@ -1,0 +1,46 @@
+package club.ttg.dnd5.domain.tool.sheet.rest.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+/**
+ * Чужой лист, сохранённый по ссылке. Собирается из записи и самого листа, поэтому мапперу
+ * не отдаётся: у недоступного листа половина полей берётся из записи-снимка.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class SavedCharacterSheetResponse {
+
+    @NotNull
+    @Schema(description = "Идентификатор сохранённой записи (им же она и удаляется)")
+    private UUID id;
+
+    @NotNull
+    @Schema(description = "Идентификатор самого листа персонажа")
+    private UUID sheetId;
+
+    @NotNull
+    @Schema(description = "Токен ссылки, по которому лист открывается на чтение")
+    private UUID shareToken;
+
+    @NotNull
+    @Schema(description = "Название листа: живое у доступного, снимок на момент сохранения — у остальных")
+    private String name;
+
+    @Nullable
+    @Schema(description = "Лист персонажа целиком (JSON фронтового формата); null — доступ к листу закрыт")
+    private JsonNode data;
+
+    @Schema(description = "Лист всё ещё открыт по этой ссылке: не удалён и токен не отозван")
+    private boolean available;
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/service/CharacterSheetService.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/service/CharacterSheetService.java
@@ -29,10 +29,16 @@ import java.util.UUID;
 @Service
 public class CharacterSheetService {
 
+    /**
+     * Отказ по ссылке «поделиться». Package-private: тем же текстом отвечает
+     * {@link SavedCharacterSheetService} — сохранение по битой ссылке и просмотр по ней должны
+     * объясняться одинаково.
+     */
+    static final String SHARED_NOT_FOUND_MESSAGE = "Лист персонажа по этой ссылке не найден";
+
     private static final int MAX_ACTIVE_SHEETS = 2;
     private static final int MAX_DELETED_HISTORY_PER_USER = 10;
     private static final String DEFAULT_NAME = "Новый персонаж";
-    private static final String SHARED_NOT_FOUND_MESSAGE = "Лист персонажа по этой ссылке не найден";
 
     private final CharacterSheetRepository sheetRepository;
     private final CharacterSheetMapper sheetMapper;
@@ -156,8 +162,11 @@ public class CharacterSheetService {
     /**
      * Токен разбирается вручную, а не конвертером {@code @PathVariable UUID}: ссылку правят руками
      * и обрезают мессенджеры, а мусор в пути должен давать 404, а не 500 от конвертера.
+     * <p>
+     * Package-private: тем же разбором пользуется {@link SavedCharacterSheetService} — токен
+     * туда приходит из тела запроса, но правят и обрезают его так же.
      */
-    private UUID parseShareToken(String shareToken) {
+    static UUID parseShareToken(String shareToken) {
         if (!StringUtils.hasText(shareToken)) {
             throw new EntityNotFoundException(SHARED_NOT_FOUND_MESSAGE);
         }

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/service/SavedCharacterSheetService.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/service/SavedCharacterSheetService.java
@@ -1,0 +1,138 @@
+package club.ttg.dnd5.domain.tool.sheet.service;
+
+import club.ttg.dnd5.domain.tool.sheet.model.CharacterSheet;
+import club.ttg.dnd5.domain.tool.sheet.model.SavedCharacterSheet;
+import club.ttg.dnd5.domain.tool.sheet.repository.CharacterSheetRepository;
+import club.ttg.dnd5.domain.tool.sheet.repository.SavedCharacterSheetRepository;
+import club.ttg.dnd5.domain.tool.sheet.rest.dto.SavedCharacterSheetListResponse;
+import club.ttg.dnd5.domain.tool.sheet.rest.dto.SavedCharacterSheetResponse;
+import club.ttg.dnd5.domain.user.model.User;
+import club.ttg.dnd5.exception.ApiException;
+import club.ttg.dnd5.exception.EntityNotFoundException;
+import club.ttg.dnd5.security.SecurityUtils;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Чужие листы персонажей, сохранённые по ссылке «поделиться»: список, сохранение и удаление.
+ * Хранится только ссылка — документ остаётся у владельца листа, а сохранивший видит его на чтение
+ * той же публичной ручкой. Своей копией листа заведует {@link CharacterSheetService}.
+ */
+@RequiredArgsConstructor
+@Service
+public class SavedCharacterSheetService {
+
+    private static final int MAX_SAVED_SHEETS = 4;
+    private static final String NOT_FOUND_MESSAGE = "Сохранённый лист персонажа не найден";
+
+    private final SavedCharacterSheetRepository savedRepository;
+    private final CharacterSheetRepository sheetRepository;
+
+    /**
+     * Сохранённые ссылки пользователя, новые первее, с лимитом и числом записей (для «N из M»
+     * на клиенте). Листы догружаются одним запросом: у доступных отдаётся живое название и документ,
+     * у остальных — снимок названия и {@code data = null}.
+     */
+    public SavedCharacterSheetListResponse findMine() {
+        User user = SecurityUtils.getUser();
+        List<SavedCharacterSheet> saved = savedRepository.findAllByUserIdOrderByCreatedAtDesc(user.getUuid());
+        Map<UUID, CharacterSheet> sheets = sheetRepository
+                .findAllById(saved.stream().map(SavedCharacterSheet::getSheetId).toList())
+                .stream()
+                .collect(Collectors.toMap(CharacterSheet::getId, Function.identity()));
+        List<SavedCharacterSheetResponse> responses = saved.stream()
+                .map(savedSheet -> toResponse(savedSheet, sheets.get(savedSheet.getSheetId())))
+                .toList();
+        return new SavedCharacterSheetListResponse(getSavedLimitFor(user), responses.size(), responses);
+    }
+
+    /**
+     * Сохраняет чужой лист по токену ссылки. Неизвестный, отозванный или битый токен — 404, как и
+     * при просмотре по ссылке. Свой лист сохранять незачем: он и так в списке. Повторное сохранение
+     * того же листа не плодит записей — у существующей обновляются токен и название, поэтому
+     * присланная заново ссылка просто «оживляет» карточку.
+     */
+    @Transactional
+    public SavedCharacterSheetResponse save(String shareToken) {
+        User user = SecurityUtils.getUser();
+        UUID token = CharacterSheetService.parseShareToken(shareToken);
+        CharacterSheet sheet = sheetRepository.findByShareTokenAndDeletedFalse(token)
+                .orElseThrow(() -> new EntityNotFoundException(CharacterSheetService.SHARED_NOT_FOUND_MESSAGE));
+        if (sheet.getUserId().equals(user.getUuid())) {
+            throw new ApiException(HttpStatus.BAD_REQUEST,
+                    "Это ваш лист персонажа — он уже есть в списке ваших персонажей");
+        }
+        SavedCharacterSheet savedSheet = savedRepository.findByUserIdAndSheetId(user.getUuid(), sheet.getId())
+                .orElseGet(() -> newSavedSheet(user, sheet));
+        savedSheet.setShareToken(token);
+        savedSheet.setName(sheet.getName());
+        // Флаш сразу: id новой записи генерируется при INSERT, без него в ответе был бы null,
+        // а клиент по нему сразу убирает запись из списка.
+        return toResponse(savedRepository.saveAndFlush(savedSheet), sheet);
+    }
+
+    /**
+     * Убирает сохранённую ссылку. Чужая запись, как и несуществующая, — 404.
+     */
+    @Transactional
+    public void delete(UUID savedId) {
+        User user = SecurityUtils.getUser();
+        SavedCharacterSheet savedSheet = savedRepository.findByIdAndUserId(savedId, user.getUuid())
+                .orElseThrow(() -> new EntityNotFoundException(NOT_FOUND_MESSAGE));
+        savedRepository.delete(savedSheet);
+    }
+
+    /**
+     * Лимит сохранённых чужих листов. Пока константа; с появлением подписок здесь появится
+     * расчёт по уровню подписки пользователя — как и у лимита своих листов.
+     */
+    private int getSavedLimitFor(User user) {
+        return MAX_SAVED_SHEETS;
+    }
+
+    private void validateLimit(User user) {
+        int limit = getSavedLimitFor(user);
+        if (savedRepository.countByUserId(user.getUuid()) >= limit) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, String.format(
+                    "Достигнут лимит сохранённых листов: %d. Уберите один из сохранённых", limit));
+        }
+    }
+
+    /**
+     * Заготовка новой записи. Лимит проверяется здесь, а не в начале сохранения: освежить уже
+     * сохранённый лист новой ссылкой можно и при исчерпанном лимите — записей от этого не прибавится.
+     */
+    private SavedCharacterSheet newSavedSheet(User user, CharacterSheet sheet) {
+        validateLimit(user);
+        SavedCharacterSheet savedSheet = new SavedCharacterSheet();
+        savedSheet.setUserId(user.getUuid());
+        savedSheet.setSheetId(sheet.getId());
+        return savedSheet;
+    }
+
+    /**
+     * Доступность записи: лист есть, не удалён и открыт по тому же токену. Совпадение токена
+     * обязательно — отзыв доступа владельцем должен гасить сохранённую ссылку, иначе выпущенная
+     * позже ссылка для кого-то другого молча вернула бы доступ прежнему зрителю.
+     */
+    private SavedCharacterSheetResponse toResponse(SavedCharacterSheet savedSheet, CharacterSheet sheet) {
+        boolean available = sheet != null
+                && !sheet.isDeleted()
+                && savedSheet.getShareToken().equals(sheet.getShareToken());
+        return new SavedCharacterSheetResponse(
+                savedSheet.getId(),
+                savedSheet.getSheetId(),
+                savedSheet.getShareToken(),
+                available ? sheet.getName() : savedSheet.getName(),
+                available ? sheet.getData() : null,
+                available);
+    }
+}

--- a/src/main/resources/db/changelog/2026/07/26-01-create-character-sheet-saved-table.yaml
+++ b/src/main/resources/db/changelog/2026/07/26-01-create-character-sheet-saved-table.yaml
@@ -1,0 +1,72 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-26-01-create-character-sheet-saved-table
+      author: Peterko
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            tableName: character_sheet_saved
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_character_sheet_saved
+                  name: id
+                  type: UUID
+              - column:
+                  name: user_id
+                  type: UUID
+                  constraints:
+                    nullable: false
+              - column:
+                  name: sheet_id
+                  type: UUID
+                  constraints:
+                    nullable: false
+              - column:
+                  name: share_token
+                  type: UUID
+                  constraints:
+                    nullable: false
+              # Снимок названия на момент сохранения: им подписывается карточка
+              # листа, к которому доступ уже закрыт — живое название взять неоткуда.
+              - column:
+                  name: name
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME
+              - column:
+                  name: updated_at
+                  type: DATETIME
+              - column:
+                  name: username
+                  type: VARCHAR(255)
+              - column:
+                  name: last_username
+                  type: VARCHAR(255)
+  - changeSet:
+      id: 2026-07-26-01-create-character-sheet-saved-user-index
+      author: Peterko
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createIndex:
+            columns:
+              - column:
+                  name: user_id
+            indexName: character_sheet_saved_user_id_index
+            tableName: character_sheet_saved
+        # Один лист сохраняется пользователем один раз: повторное сохранение
+        # (новая ссылка на тот же лист) обновляет запись, а не плодит дубли.
+        - createIndex:
+            columns:
+              - column:
+                  name: user_id
+              - column:
+                  name: sheet_id
+            indexName: character_sheet_saved_user_sheet_index
+            tableName: character_sheet_saved
+            unique: true

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -263,3 +263,5 @@ databaseChangeLog:
       file: db/changelog/2026/07/24-01-create-character-sheet-table.yaml
   - include:
       file: db/changelog/2026/07/25-01-add-share-token-to-character-sheet.yaml
+  - include:
+      file: db/changelog/2026/07/26-01-create-character-sheet-saved-table.yaml

--- a/src/test/java/club/ttg/dnd5/domain/tool/sheet/service/SavedCharacterSheetServiceTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/tool/sheet/service/SavedCharacterSheetServiceTest.java
@@ -1,0 +1,194 @@
+package club.ttg.dnd5.domain.tool.sheet.service;
+
+import club.ttg.dnd5.domain.tool.sheet.model.CharacterSheet;
+import club.ttg.dnd5.domain.tool.sheet.model.SavedCharacterSheet;
+import club.ttg.dnd5.domain.tool.sheet.repository.CharacterSheetRepository;
+import club.ttg.dnd5.domain.tool.sheet.repository.SavedCharacterSheetRepository;
+import club.ttg.dnd5.domain.tool.sheet.rest.dto.SavedCharacterSheetListResponse;
+import club.ttg.dnd5.domain.tool.sheet.rest.dto.SavedCharacterSheetResponse;
+import club.ttg.dnd5.domain.user.model.User;
+import club.ttg.dnd5.exception.ApiException;
+import club.ttg.dnd5.exception.EntityNotFoundException;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Сохранение чужих листов по ссылке: лимит, свой лист, повторное сохранение и потеря доступа.
+ */
+class SavedCharacterSheetServiceTest {
+
+    private final SavedCharacterSheetRepository savedRepository = mock(SavedCharacterSheetRepository.class);
+    private final CharacterSheetRepository sheetRepository = mock(CharacterSheetRepository.class);
+    private final SavedCharacterSheetService service =
+            new SavedCharacterSheetService(savedRepository, sheetRepository);
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void saveStoresForeignSheetByShareToken() {
+        UUID viewer = authenticate();
+        CharacterSheet sheet = sharedSheet();
+        when(sheetRepository.findByShareTokenAndDeletedFalse(sheet.getShareToken()))
+                .thenReturn(Optional.of(sheet));
+        when(savedRepository.findByUserIdAndSheetId(viewer, sheet.getId())).thenReturn(Optional.empty());
+        when(savedRepository.countByUserId(viewer)).thenReturn(0L);
+        when(savedRepository.saveAndFlush(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        SavedCharacterSheetResponse response = service.save(sheet.getShareToken().toString());
+
+        assertEquals(sheet.getId(), response.getSheetId());
+        assertEquals(sheet.getShareToken(), response.getShareToken());
+        assertEquals(sheet.getName(), response.getName());
+        assertTrue(response.isAvailable());
+    }
+
+    @Test
+    void saveOfOwnSheetIsRejected() {
+        UUID owner = authenticate();
+        CharacterSheet sheet = sharedSheet();
+        sheet.setUserId(owner);
+        when(sheetRepository.findByShareTokenAndDeletedFalse(sheet.getShareToken()))
+                .thenReturn(Optional.of(sheet));
+
+        ApiException exception = assertThrows(ApiException.class,
+                () -> service.save(sheet.getShareToken().toString()));
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatus());
+        verify(savedRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void saveOfAlreadySavedSheetRefreshesTokenInsteadOfDuplicating() {
+        UUID viewer = authenticate();
+        CharacterSheet sheet = sharedSheet();
+        SavedCharacterSheet existing = new SavedCharacterSheet();
+        existing.setId(UUID.randomUUID());
+        existing.setUserId(viewer);
+        existing.setSheetId(sheet.getId());
+        existing.setShareToken(UUID.randomUUID());
+        existing.setName("Старое имя");
+        when(sheetRepository.findByShareTokenAndDeletedFalse(sheet.getShareToken()))
+                .thenReturn(Optional.of(sheet));
+        when(savedRepository.findByUserIdAndSheetId(viewer, sheet.getId())).thenReturn(Optional.of(existing));
+        when(savedRepository.saveAndFlush(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        SavedCharacterSheetResponse response = service.save(sheet.getShareToken().toString());
+
+        assertEquals(existing.getId(), response.getId());
+        assertEquals(sheet.getShareToken(), existing.getShareToken());
+        assertEquals(sheet.getName(), existing.getName());
+        // Лимит проверяется только для новых записей: освежить уже сохранённый лист можно всегда
+        verify(savedRepository, never()).countByUserId(any());
+    }
+
+    @Test
+    void saveOverLimitIsRejected() {
+        UUID viewer = authenticate();
+        CharacterSheet sheet = sharedSheet();
+        when(sheetRepository.findByShareTokenAndDeletedFalse(sheet.getShareToken()))
+                .thenReturn(Optional.of(sheet));
+        when(savedRepository.findByUserIdAndSheetId(viewer, sheet.getId())).thenReturn(Optional.empty());
+        when(savedRepository.countByUserId(viewer)).thenReturn(4L);
+
+        ApiException exception = assertThrows(ApiException.class,
+                () -> service.save(sheet.getShareToken().toString()));
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatus());
+        verify(savedRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void saveWithMalformedTokenIsNotFoundInsteadOfServerError() {
+        authenticate();
+
+        assertThrows(EntityNotFoundException.class, () -> service.save("не-похоже-на-uuid"));
+
+        verify(sheetRepository, never()).findByShareTokenAndDeletedFalse(any());
+    }
+
+    @Test
+    void findMineMarksRevokedAndDeletedSheetsUnavailable() {
+        UUID viewer = authenticate();
+        CharacterSheet revoked = sharedSheet();
+        SavedCharacterSheet savedRevoked = savedRecord(viewer, revoked);
+        // Владелец отозвал доступ: токен листа обнулился, а сохранённый остался
+        revoked.setShareToken(null);
+        CharacterSheet alive = sharedSheet();
+        SavedCharacterSheet savedAlive = savedRecord(viewer, alive);
+        when(savedRepository.findAllByUserIdOrderByCreatedAtDesc(viewer))
+                .thenReturn(List.of(savedRevoked, savedAlive));
+        when(sheetRepository.findAllById(any())).thenReturn(List.of(revoked, alive));
+
+        SavedCharacterSheetListResponse response = service.findMine();
+
+        assertEquals(4, response.getLimit());
+        assertEquals(2, response.getCount());
+        SavedCharacterSheetResponse first = response.getSheets().getFirst();
+        assertFalse(first.isAvailable());
+        assertNull(first.getData());
+        // Название недоступного листа берётся из снимка — живое взять неоткуда
+        assertEquals(savedRevoked.getName(), first.getName());
+        assertTrue(response.getSheets().get(1).isAvailable());
+    }
+
+    @Test
+    void deleteOfForeignRecordIsNotFound() {
+        UUID viewer = authenticate();
+        UUID savedId = UUID.randomUUID();
+        when(savedRepository.findByIdAndUserId(savedId, viewer)).thenReturn(Optional.empty());
+
+        assertThrows(EntityNotFoundException.class, () -> service.delete(savedId));
+
+        verify(savedRepository, never()).delete(any());
+    }
+
+    private static CharacterSheet sharedSheet() {
+        CharacterSheet sheet = new CharacterSheet();
+        sheet.setId(UUID.randomUUID());
+        sheet.setUserId(UUID.randomUUID());
+        sheet.setName("Гимли");
+        sheet.setData(JsonNodeFactory.instance.objectNode());
+        sheet.setShareToken(UUID.randomUUID());
+        return sheet;
+    }
+
+    private static SavedCharacterSheet savedRecord(UUID userId, CharacterSheet sheet) {
+        SavedCharacterSheet saved = new SavedCharacterSheet();
+        saved.setId(UUID.randomUUID());
+        saved.setUserId(userId);
+        saved.setSheetId(sheet.getId());
+        saved.setShareToken(sheet.getShareToken());
+        saved.setName(sheet.getName());
+        return saved;
+    }
+
+    private static UUID authenticate() {
+        User user = new User();
+        user.setUuid(UUID.randomUUID());
+        SecurityContextHolder.getContext()
+                .setAuthentication(new UsernamePasswordAuthenticationToken(user, null, List.of()));
+        return user.getUuid();
+    }
+}


### PR DESCRIPTION
Получателю ссылки «поделиться» раньше нечего было с ней делать — ссылку приходилось хранить где-то на стороне. Теперь чужой лист можно сохранить к себе: серверная часть хранит саму ссылку, документ остаётся у владельца, а сохранивший видит лист только на чтение той же публичной ручкой.

Новая таблица character_sheet_saved (миграция 2026/07/26-01): владелец записи, идентификатор листа, токен ссылки и снимок названия на момент сохранения. Индексы: по user_id и уникальный по (user_id, sheet_id) — один лист сохраняется пользователем один раз, присланная заново ссылка на него обновляет запись, а не плодит дубли. Связи с character_sheet через JPA намеренно нет: запись переживает и удаление листа, и отзыв доступа, чтобы пользователь увидел причину пропажи, а не молчаливое исчезновение из списка.

Эндпоинты /api/v2/tools/character-sheet/saved, закрыты @Secured("ADMIN") — как и сам инструмент; вынесены в отдельный контроллер, чтобы литерал /saved не спорил с /{id} соседнего:
- GET — сохранённые ссылки, новые первее, с лимитом и числом записей для «N из M» на клиенте; листы догружаются одним запросом, у доступных отдаётся живое название и документ, у остальных — снимок названия и data = null;
- POST — сохранение по токену ссылки: лимит 4 записи (задел под подписки в getSavedLimitFor, как у лимита своих листов), свой лист и неизвестный либо битый токен отклоняются, повторное сохранение того же листа обновляет токен и название и лимитом не ограничивается — записей от него не прибавляется;
- DELETE /{id} — удаление своей записи; чужая, как и несуществующая, даёт 404.

Ключевое решение по доступу: запись считается живой, только пока токен листа совпадает с сохранённым, а не просто «доступ по ссылке включён». Отзыв доступа владельцем гасит сохранённую ссылку навсегда — иначе выпущенная позже ссылка для кого-то другого молча вернула бы доступ прежнему зрителю. Из-за этого и хранится снимок названия: у недоступного листа живое название взять неоткуда.

Разбор токена ссылки (parseShareToken) и текст отказа по ней переведены в package-private доступ CharacterSheetService и переиспользуются: сохранение по битой ссылке и просмотр по ней должны объясняться одинаково, а мусор в токене — давать 404, а не 500 от конвертера.

Тесты SavedCharacterSheetServiceTest: сохранение чужого листа, отказ на своём, обновление записи вместо дубля, отказ по лимиту, 404 на битом токене и на чужой записи, недоступность после отзыва доступа.