### PR TITLE
feat(character-sheet): глубина истории удалённых листов в ответе списка

### DIFF
--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/dto/CharacterSheetListResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/dto/CharacterSheetListResponse.java
@@ -17,6 +17,9 @@ public class CharacterSheetListResponse {
     @Schema(description = "Максимум активных листов у пользователя (в будущем зависит от подписки)")
     private int limit;
 
+    @Schema(description = "Максимум удалённых листов в истории: более старые вытесняются новыми удалениями")
+    private int historyLimit;
+
     @Schema(description = "Текущее число активных (неудалённых) листов")
     private int count;
 

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/service/CharacterSheetService.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/service/CharacterSheetService.java
@@ -64,6 +64,8 @@ public class CharacterSheetService {
     /**
      * Листы текущего пользователя, новые первее, с лимитом и числом активных (для «N из M»
      * на клиенте). {@code includeDeleted=true} — вместе с историей удалённых (без документа).
+     * Глубина истории отдаётся тем же ответом: сколько удалённых листов ещё можно восстановить,
+     * клиенту иначе неоткуда узнать.
      */
     public CharacterSheetListResponse findMine(boolean includeDeleted) {
         User user = SecurityUtils.getUser();
@@ -71,8 +73,8 @@ public class CharacterSheetService {
                 ? sheetRepository.findAllByUserIdOrderByCreatedAtDesc(user.getUuid())
                 : sheetRepository.findAllByUserIdAndDeletedFalseOrderByCreatedAtDesc(user.getUuid());
         long activeCount = sheets.stream().filter(sheet -> !sheet.isDeleted()).count();
-        return new CharacterSheetListResponse(
-                getLimitFor(user), (int) activeCount, sheetMapper.toListItemResponseList(sheets));
+        return new CharacterSheetListResponse(getLimitFor(user), MAX_DELETED_HISTORY_PER_USER,
+                (int) activeCount, sheetMapper.toListItemResponseList(sheets));
     }
 
     public CharacterSheetResponse findById(UUID sheetId) {


### PR DESCRIPTION
Клиент показывает историю удалённых листов счётчиком, но сколько их туда помещается — узнать было неоткуда: глубина истории жила только константой MAX_DELETED_HISTORY_PER_USER в сервисе, и подпись «История листов (10)» ничего не говорила о том, что это уже предел и следующее удаление вытеснит самый старый лист.

В CharacterSheetListResponse добавлено поле historyLimit, findMine отдаёт им ту же константу, которой ограничивает историю trimDeletedHistory. Лимит активных листов клиенту уже отдавался тем же ответом — теперь рядом с ним едет и лимит истории, так что число на клиенте по-прежнему не хардкодится и переживёт смену константы.