### PR TITLE
feat(statistics): количество листов персонажей для админ-панели

### DIFF
--- a/src/main/java/club/ttg/dnd5/domain/statistics/rest/controller/StatisticsController.java
+++ b/src/main/java/club/ttg/dnd5/domain/statistics/rest/controller/StatisticsController.java
@@ -1,5 +1,6 @@
 package club.ttg.dnd5.domain.statistics.rest.controller;
 
+import club.ttg.dnd5.domain.statistics.rest.dto.CharacterSheetStatisticsResponse;
 import club.ttg.dnd5.domain.statistics.service.StatisticsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -8,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,5 +37,17 @@ public class StatisticsController {
     )
     public Long countAllMaterials() {
         return statisticsService.countAllMaterials();
+    }
+
+    /**
+     * Только для админ-панели: числа по всем пользователям сразу.
+     * Классовой аннотации у контроллера нет, поэтому публичный {@code /count-all}
+     * ограничение не затрагивает.
+     */
+    @Operation(summary = "Количество листов персонажей: всего (с историей удалённых) и активных")
+    @GetMapping("/character-sheets")
+    @Secured("ADMIN")
+    public CharacterSheetStatisticsResponse countCharacterSheets() {
+        return statisticsService.countCharacterSheets();
     }
 }

--- a/src/main/java/club/ttg/dnd5/domain/statistics/rest/dto/CharacterSheetStatisticsResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/statistics/rest/dto/CharacterSheetStatisticsResponse.java
@@ -1,0 +1,20 @@
+package club.ttg.dnd5.domain.statistics.rest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class CharacterSheetStatisticsResponse {
+
+    @Schema(description = "Все листы персонажей сайта: активные и лежащие в истории удалённых")
+    private long total;
+
+    @Schema(description = "Активные (неудалённые) листы персонажей")
+    private long active;
+}

--- a/src/main/java/club/ttg/dnd5/domain/statistics/service/StatisticsService.java
+++ b/src/main/java/club/ttg/dnd5/domain/statistics/service/StatisticsService.java
@@ -9,6 +9,8 @@ import club.ttg.dnd5.domain.item.model.Item;
 import club.ttg.dnd5.domain.magic.model.MagicItem;
 import club.ttg.dnd5.domain.species.model.Species;
 import club.ttg.dnd5.domain.spell.model.Spell;
+import club.ttg.dnd5.domain.statistics.rest.dto.CharacterSheetStatisticsResponse;
+import club.ttg.dnd5.domain.tool.sheet.repository.CharacterSheetRepository;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Table;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class StatisticsService {
     private final EntityManager entityManager;
+    private final CharacterSheetRepository characterSheetRepository;
     private final List<Class<?>> COUNTED_ENTITIES = List.of(
             Spell.class,
             Species.class,
@@ -47,6 +50,23 @@ public class StatisticsService {
                                 .getSingleResult())
                 .mapToLong(e -> (Long)e)
                 .sum();
+    }
+
+    /**
+     * Листы персонажей всех пользователей: сколько сейчас активных и сколько всего строк.
+     * <p>
+     * {@code total} — это активные плюс лежащие в истории удалённых, а не «созданные
+     * когда-либо»: история обрезается до последних удалений пользователя
+     * ({@code CharacterSheetService.trimDeletedHistory}), вытесненные листы удаляются
+     * из базы физически.
+     * <p>
+     * Без кэша: число меняется постоянно, а кэши сбрасываются только вручную
+     * через {@code /api/v2/cache/evict-all}.
+     */
+    public CharacterSheetStatisticsResponse countCharacterSheets() {
+        return new CharacterSheetStatisticsResponse(
+                characterSheetRepository.count(),
+                characterSheetRepository.countByDeletedFalse());
     }
 }
 

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/repository/CharacterSheetRepository.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/repository/CharacterSheetRepository.java
@@ -11,6 +11,11 @@ public interface CharacterSheetRepository extends JpaRepository<CharacterSheet, 
 
     long countByUserIdAndDeletedFalse(UUID userId);
 
+    /**
+     * Число активных (неудалённых) листов на сайте — для статистики админ-панели.
+     */
+    long countByDeletedFalse();
+
     List<CharacterSheet> findAllByUserIdOrderByCreatedAtDesc(UUID userId);
 
     List<CharacterSheet> findAllByUserIdAndDeletedFalseOrderByCreatedAtDesc(UUID userId);


### PR DESCRIPTION
Добавлена ручка GET /api/v2/statistics/character-sheets: отдаёт числа по листам персонажей всех пользователей — total (все строки: активные вместе с историей удалённых) и active (только неудалённые).

- CharacterSheetRepository: countByDeletedFalse() — подсчёт активных листов;
- CharacterSheetStatisticsResponse: DTO ответа с описанием полей для Swagger;
- StatisticsService.countCharacterSheets(): без @Cacheable, в отличие от countAllMaterials — число меняется постоянно, а кэши сбрасываются только вручную через /api/v2/cache/evict-all;
- StatisticsController: метод под @Secured("ADMIN"); классовой аннотации у контроллера нет, поэтому публичный /count-all ограничение не затрагивает.

Смысл total: активные плюс сохранённая история удалённых, а не «созданные когда-либо» — история обрезается до последних удалений пользователя, вытесненные листы удаляются из базы физически.