### PR TITLE
Добавить уровни врождённых заклинаний видов

### DIFF
--- a/src/main/java/club/ttg/dnd5/domain/species/repository/SpeciesInnateSpellView.java
+++ b/src/main/java/club/ttg/dnd5/domain/species/repository/SpeciesInnateSpellView.java
@@ -1,0 +1,8 @@
+package club.ttg.dnd5.domain.species.repository;
+
+public interface SpeciesInnateSpellView
+{
+    String getSpellUrl();
+
+    Integer getRequiredLevel();
+}

--- a/src/main/java/club/ttg/dnd5/domain/species/repository/SpeciesRepository.java
+++ b/src/main/java/club/ttg/dnd5/domain/species/repository/SpeciesRepository.java
@@ -5,6 +5,7 @@ import club.ttg.dnd5.domain.vttg.repository.VttgEntityRef;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
@@ -15,6 +16,44 @@ import java.util.List;
 @Repository
 public interface SpeciesRepository extends JpaRepository<Species, String> {
     Collection<Species> findByParent(Species parent);
+
+    @Query(value = """
+            select spell_url as "spellUrl", required_level as "requiredLevel"
+            from spell_species_affiliation
+            where species_affiliation_url = :speciesUrl
+            union all
+            select spell_url as "spellUrl", required_level as "requiredLevel"
+            from spell_lineages_affiliation
+            where lineages_affiliation_url = :speciesUrl
+            order by "requiredLevel", "spellUrl"
+            """, nativeQuery = true)
+    List<SpeciesInnateSpellView> findInnateSpells(@Param("speciesUrl") String speciesUrl);
+
+    @Modifying
+    @Query(value = "delete from spell_species_affiliation where species_affiliation_url = :speciesUrl", nativeQuery = true)
+    void deleteSpeciesInnateSpells(@Param("speciesUrl") String speciesUrl);
+
+    @Modifying
+    @Query(value = "delete from spell_lineages_affiliation where lineages_affiliation_url = :speciesUrl", nativeQuery = true)
+    void deleteLineageInnateSpells(@Param("speciesUrl") String speciesUrl);
+
+    @Modifying
+    @Query(value = """
+            insert into spell_species_affiliation (spell_url, species_affiliation_url, required_level)
+            values (:spellUrl, :speciesUrl, :requiredLevel)
+            """, nativeQuery = true)
+    void addSpeciesInnateSpell(@Param("speciesUrl") String speciesUrl,
+                               @Param("spellUrl") String spellUrl,
+                               @Param("requiredLevel") Integer requiredLevel);
+
+    @Modifying
+    @Query(value = """
+            insert into spell_lineages_affiliation (spell_url, lineages_affiliation_url, required_level)
+            values (:spellUrl, :speciesUrl, :requiredLevel)
+            """, nativeQuery = true)
+    void addLineageInnateSpell(@Param("speciesUrl") String speciesUrl,
+                               @Param("spellUrl") String spellUrl,
+                               @Param("requiredLevel") Integer requiredLevel);
 
     @Query(value = """
         select s from Species s

--- a/src/main/java/club/ttg/dnd5/domain/species/rest/dto/SpeciesDetailResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/species/rest/dto/SpeciesDetailResponse.java
@@ -22,6 +22,9 @@ public class SpeciesDetailResponse extends BaseResponse {
 
     @Schema(description = "Умения")
     private Collection<SpeciesFeatureResponse> features;
+
+    @Schema(description = "Врождённые заклинания и уровни их доступности")
+    private Collection<SpeciesInnateSpellResponse> innateSpells;
     @Schema(description = "Ссылки на изображения")
     private boolean hasLineages;
 }

--- a/src/main/java/club/ttg/dnd5/domain/species/rest/dto/SpeciesInnateSpellRequest.java
+++ b/src/main/java/club/ttg/dnd5/domain/species/rest/dto/SpeciesInnateSpellRequest.java
@@ -1,0 +1,16 @@
+package club.ttg.dnd5.domain.species.rest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SpeciesInnateSpellRequest
+{
+    @Schema(description = "URL заклинания")
+    private String spell;
+
+    @Schema(description = "Уровень персонажа, с которого доступно заклинание")
+    private Integer requiredLevel;
+}

--- a/src/main/java/club/ttg/dnd5/domain/species/rest/dto/SpeciesInnateSpellResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/species/rest/dto/SpeciesInnateSpellResponse.java
@@ -1,0 +1,13 @@
+package club.ttg.dnd5.domain.species.rest.dto;
+
+import club.ttg.dnd5.domain.spell.rest.dto.SpellShortResponse;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SpeciesInnateSpellResponse
+{
+    private SpellShortResponse spell;
+    private Integer requiredLevel;
+}

--- a/src/main/java/club/ttg/dnd5/domain/species/rest/dto/SpeciesRequest.java
+++ b/src/main/java/club/ttg/dnd5/domain/species/rest/dto/SpeciesRequest.java
@@ -16,6 +16,9 @@ public class SpeciesRequest extends BaseRequest {
 
     @Schema(description = "Умения")
     private Collection<FeatureRequest> features;
+
+    @Schema(description = "Врождённые заклинания и уровни их доступности")
+    private Collection<SpeciesInnateSpellRequest> innateSpells;
     @Schema(description = "URL на вид", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String parent;
 

--- a/src/main/java/club/ttg/dnd5/domain/species/service/SpeciesService.java
+++ b/src/main/java/club/ttg/dnd5/domain/species/service/SpeciesService.java
@@ -6,13 +6,19 @@ import club.ttg.dnd5.domain.species.model.SpeciesFeature;
 import club.ttg.dnd5.domain.species.rest.dto.SpeciesQueryRequest;
 import club.ttg.dnd5.domain.species.model.Species;
 import club.ttg.dnd5.domain.species.repository.SpeciesRepository;
+import club.ttg.dnd5.domain.species.repository.SpeciesInnateSpellView;
 import club.ttg.dnd5.domain.species.rest.dto.SpeciesDetailResponse;
 import club.ttg.dnd5.domain.species.rest.dto.SpeciesRequest;
 import club.ttg.dnd5.domain.species.rest.dto.SpeciesShortResponse;
+import club.ttg.dnd5.domain.species.rest.dto.SpeciesInnateSpellRequest;
+import club.ttg.dnd5.domain.species.rest.dto.SpeciesInnateSpellResponse;
 import club.ttg.dnd5.domain.species.rest.mapper.SpeciesFeatureMapper;
 import club.ttg.dnd5.domain.species.rest.mapper.SpeciesMapper;
 import club.ttg.dnd5.domain.revision.model.RevisionOperation;
 import club.ttg.dnd5.domain.revision.service.EntityRevisionService;
+import club.ttg.dnd5.domain.spell.model.Spell;
+import club.ttg.dnd5.domain.spell.repository.SpellRepository;
+import club.ttg.dnd5.domain.spell.rest.mapper.SpellMapper;
 import club.ttg.dnd5.exception.ApiException;
 import club.ttg.dnd5.exception.EntityExistException;
 import club.ttg.dnd5.exception.EntityNotFoundException;
@@ -26,6 +32,8 @@ import org.springframework.util.StringUtils;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -42,6 +50,8 @@ public class SpeciesService {
     private final SpeciesFeatureMapper speciesFeatureMapper;
     private final SourceSavedFilterService sourceSavedFilterService;
     private final EntityRevisionService revisionService;
+    private final SpellRepository spellRepository;
+    private final SpellMapper spellMapper;
 
     public boolean exists(String url) {
         return speciesRepository.existsById(url);
@@ -52,12 +62,17 @@ public class SpeciesService {
         var species = speciesRepository.findById(url)
                 .orElseThrow(() -> new EntityNotFoundException(url));
         var response = speciesMapper.toDetail(species);
+        response.setInnateSpells(loadInnateSpells(species.getUrl()));
 
         if (species.getParent() != null) {
             var features = new ArrayList<SpeciesFeature>();
             Optional.ofNullable(species.getFeatures()).ifPresent(features::addAll);
             Optional.ofNullable(species.getParent().getFeatures()).ifPresent(features::addAll);
             response.setFeatures(speciesFeatureMapper.toResponses(features));
+            response.setInnateSpells(mergeInnateSpells(
+                    loadInnateSpells(species.getParent().getUrl()),
+                    response.getInnateSpells()
+            ));
         }
 
         return response;
@@ -95,13 +110,14 @@ public class SpeciesService {
         return url;
     }
 
+    @Transactional(readOnly = true)
     public List<SpeciesDetailResponse> getLineages(String parentUrl) {
         return speciesRepository.findById(parentUrl)
                 .filter(species -> !species.isHiddenEntity())
                 .map(speciesRepository::findByParent)
                 .orElseThrow(() -> new EntityNotFoundException("Вид не найден для URL: " + parentUrl))
                 .stream()
-                .map(speciesMapper::toDetail)
+                .map(this::toDetailWithInnateSpells)
                 .toList();
     }
 
@@ -162,6 +178,7 @@ public class SpeciesService {
             }
             existing.setSource(sourceService.findByUrl(request.getSource().getUrl()));
             String url = speciesRepository.save(existing).getUrl();
+            syncInnateSpells(url, existing.getParent() != null, request.getInnateSpells());
             revisionService.record(REVISION_ENTITY_TYPE, url, RevisionOperation.UPDATE, findFormByUrl(url));
             return url;
         }
@@ -169,6 +186,8 @@ public class SpeciesService {
         if (speciesRepository.existsById(request.getUrl())) {
             throw new EntityExistException("Р’РёРґ СѓР¶Рµ СЃСѓС‰РµСЃС‚РІСѓРµС‚ СЃ URL: " + request.getUrl());
         }
+        speciesRepository.deleteSpeciesInnateSpells(oldUrl);
+        speciesRepository.deleteLineageInnateSpells(oldUrl);
         speciesRepository.deleteById(oldUrl);
         speciesRepository.flush();
         String url = saveSpecies(request).getUrl();
@@ -191,8 +210,12 @@ public class SpeciesService {
         return speciesMapper.toDetail(speciesRepository.save(species));
     }
 
+    @Transactional(readOnly = true)
     public SpeciesRequest findFormByUrl(final String url) {
-        return speciesMapper.toRequest(findByUrl(url));
+        Species species = findByUrl(url);
+        SpeciesRequest request = speciesMapper.toRequest(species);
+        request.setInnateSpells(loadInnateSpellRequests(url));
+        return request;
     }
 
     // Private methods
@@ -212,6 +235,7 @@ public class SpeciesService {
         species.setSource(source);
 
         Species save = speciesRepository.save(species);
+        syncInnateSpells(save.getUrl(), save.getParent() != null, request.getInnateSpells());
         return speciesMapper.toDetail(save);
     }
 
@@ -219,6 +243,122 @@ public class SpeciesService {
         var source = sourceService.findByUrl(request.getSource().getUrl());
         var species = speciesMapper.toEntity(request);
         species.setSource(source);
-        return speciesMapper.toDetail(species);
+        SpeciesDetailResponse response = speciesMapper.toDetail(species);
+        response.setInnateSpells(resolveInnateSpells(request.getInnateSpells()));
+        return response;
+    }
+
+    private SpeciesDetailResponse toDetailWithInnateSpells(Species species)
+    {
+        SpeciesDetailResponse response = speciesMapper.toDetail(species);
+        response.setInnateSpells(loadInnateSpells(species.getUrl()));
+        return response;
+    }
+
+    private List<SpeciesInnateSpellResponse> loadInnateSpells(String speciesUrl)
+    {
+        return resolveInnateSpells(loadInnateSpellRequests(speciesUrl));
+    }
+
+    private List<SpeciesInnateSpellRequest> loadInnateSpellRequests(String speciesUrl)
+    {
+        return speciesRepository.findInnateSpells(speciesUrl).stream()
+                .map(this::toInnateSpellRequest)
+                .toList();
+    }
+
+    private SpeciesInnateSpellRequest toInnateSpellRequest(SpeciesInnateSpellView view)
+    {
+        SpeciesInnateSpellRequest request = new SpeciesInnateSpellRequest();
+        request.setSpell(view.getSpellUrl());
+        request.setRequiredLevel(view.getRequiredLevel());
+        return request;
+    }
+
+    private List<SpeciesInnateSpellResponse> resolveInnateSpells(Collection<SpeciesInnateSpellRequest> requests)
+    {
+        if (requests == null || requests.isEmpty())
+        {
+            return List.of();
+        }
+
+        Map<String, Spell> spellsByUrl = spellRepository.findAllShortByUrlIn(
+                        requests.stream().map(SpeciesInnateSpellRequest::getSpell).toList())
+                .stream()
+                .collect(Collectors.toMap(Spell::getUrl, spell -> spell));
+
+        return requests.stream()
+                .map(request -> {
+                    Spell spell = Optional.ofNullable(spellsByUrl.get(request.getSpell()))
+                            .orElseThrow(() -> new EntityNotFoundException("Spell not found with URL: " + request.getSpell()));
+                    SpeciesInnateSpellResponse response = new SpeciesInnateSpellResponse();
+                    response.setSpell(spellMapper.toShort(spell));
+                    response.setRequiredLevel(validateRequiredLevel(request.getRequiredLevel()));
+                    return response;
+                })
+                .toList();
+    }
+
+    private List<SpeciesInnateSpellResponse> mergeInnateSpells(
+            Collection<SpeciesInnateSpellResponse> parentSpells,
+            Collection<SpeciesInnateSpellResponse> lineageSpells)
+    {
+        Map<String, SpeciesInnateSpellResponse> spellsByUrl = new LinkedHashMap<>();
+        parentSpells.forEach(spell -> spellsByUrl.put(spell.getSpell().getUrl(), spell));
+        lineageSpells.forEach(spell -> spellsByUrl.merge(
+                spell.getSpell().getUrl(),
+                spell,
+                (parentSpell, lineageSpell) -> lineageSpell.getRequiredLevel() <= parentSpell.getRequiredLevel()
+                        ? lineageSpell
+                        : parentSpell
+        ));
+        return List.copyOf(spellsByUrl.values());
+    }
+
+    private void syncInnateSpells(
+            String speciesUrl,
+            boolean lineage,
+            Collection<SpeciesInnateSpellRequest> requests)
+    {
+        speciesRepository.deleteSpeciesInnateSpells(speciesUrl);
+        speciesRepository.deleteLineageInnateSpells(speciesUrl);
+
+        if (requests == null || requests.isEmpty())
+        {
+            return;
+        }
+
+        Set<String> spellUrls = requests.stream()
+                .map(SpeciesInnateSpellRequest::getSpell)
+                .collect(Collectors.toSet());
+        if (spellUrls.size() != requests.size())
+        {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "Врождённое заклинание указано несколько раз");
+        }
+        if (spellRepository.countByUrlIn(spellUrls) != spellUrls.size())
+        {
+            throw new EntityNotFoundException("Одно или несколько врождённых заклинаний не найдены");
+        }
+
+        requests.forEach(request -> {
+            Integer requiredLevel = validateRequiredLevel(request.getRequiredLevel());
+            if (lineage)
+            {
+                speciesRepository.addLineageInnateSpell(speciesUrl, request.getSpell(), requiredLevel);
+            }
+            else
+            {
+                speciesRepository.addSpeciesInnateSpell(speciesUrl, request.getSpell(), requiredLevel);
+            }
+        });
+    }
+
+    private Integer validateRequiredLevel(Integer requiredLevel)
+    {
+        if (requiredLevel == null || requiredLevel < 1 || requiredLevel > 20)
+        {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "Уровень врождённого заклинания должен быть от 1 до 20");
+        }
+        return requiredLevel;
     }
 }

--- a/src/main/java/club/ttg/dnd5/domain/spell/repository/SpellRepository.java
+++ b/src/main/java/club/ttg/dnd5/domain/spell/repository/SpellRepository.java
@@ -15,6 +15,11 @@ import java.util.Optional;
 import java.util.Set;
 
 public interface SpellRepository extends JpaRepository<Spell, String> {
+    long countByUrlIn(Collection<String> urls);
+
+    @EntityGraph(attributePaths = {"source", "classAffiliation"})
+    @Query("select distinct s from Spell s where s.url in :urls")
+    List<Spell> findAllShortByUrlIn(@Param("urls") Collection<String> urls);
     @EntityGraph(attributePaths = {
             "source",
             "classAffiliation", "classAffiliation.source",

--- a/src/main/resources/db/changelog/2026/07/27-01-add-required-level-to-species-spells.yaml
+++ b/src/main/resources/db/changelog/2026/07/27-01-add-required-level-to-species-spells.yaml
@@ -1,0 +1,27 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-27-add-required-level-to-species-spells
+      author: dev
+      changes:
+        - addColumn:
+            tableName: spell_species_affiliation
+            columns:
+              - column:
+                  name: required_level
+                  type: integer
+                  defaultValueNumeric: 1
+                  constraints:
+                    nullable: false
+        - addColumn:
+            tableName: spell_lineages_affiliation
+            columns:
+              - column:
+                  name: required_level
+                  type: integer
+                  defaultValueNumeric: 1
+                  constraints:
+                    nullable: false
+        - sql:
+            sql: alter table spell_species_affiliation add constraint chk_spell_species_required_level check (required_level between 1 and 20)
+        - sql:
+            sql: alter table spell_lineages_affiliation add constraint chk_spell_lineages_required_level check (required_level between 1 and 20)

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -265,3 +265,5 @@ databaseChangeLog:
       file: db/changelog/2026/07/25-01-add-share-token-to-character-sheet.yaml
   - include:
       file: db/changelog/2026/07/26-01-create-character-sheet-saved-table.yaml
+  - include:
+      file: db/changelog/2026/07/27-01-add-required-level-to-species-spells.yaml

--- a/src/test/java/club/ttg/dnd5/domain/species/service/SpeciesServiceTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/species/service/SpeciesServiceTest.java
@@ -1,0 +1,86 @@
+package club.ttg.dnd5.domain.species.service;
+
+import club.ttg.dnd5.domain.common.rest.dto.SourceRequest;
+import club.ttg.dnd5.domain.revision.service.EntityRevisionService;
+import club.ttg.dnd5.domain.source.service.SourceSavedFilterService;
+import club.ttg.dnd5.domain.source.service.SourceService;
+import club.ttg.dnd5.domain.species.model.Species;
+import club.ttg.dnd5.domain.species.repository.SpeciesRepository;
+import club.ttg.dnd5.domain.species.rest.dto.SpeciesInnateSpellRequest;
+import club.ttg.dnd5.domain.species.rest.dto.SpeciesRequest;
+import club.ttg.dnd5.domain.species.rest.mapper.SpeciesFeatureMapper;
+import club.ttg.dnd5.domain.species.rest.mapper.SpeciesMapper;
+import club.ttg.dnd5.domain.spell.repository.SpellRepository;
+import club.ttg.dnd5.domain.spell.rest.mapper.SpellMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SpeciesServiceTest
+{
+    private final SpeciesRepository speciesRepository = mock(SpeciesRepository.class);
+    private final SourceService sourceService = mock(SourceService.class);
+    private final SpeciesQueryDslSearchService searchService = mock(SpeciesQueryDslSearchService.class);
+    private final SpeciesMapper speciesMapper = mock(SpeciesMapper.class);
+    private final SpeciesFeatureMapper featureMapper = mock(SpeciesFeatureMapper.class);
+    private final SourceSavedFilterService sourceSavedFilterService = mock(SourceSavedFilterService.class);
+    private final EntityRevisionService revisionService = mock(EntityRevisionService.class);
+    private final SpellRepository spellRepository = mock(SpellRepository.class);
+    private final SpellMapper spellMapper = mock(SpellMapper.class);
+    private final SpeciesService service = new SpeciesService(
+            speciesRepository,
+            sourceService,
+            searchService,
+            speciesMapper,
+            featureMapper,
+            sourceSavedFilterService,
+            revisionService,
+            spellRepository,
+            spellMapper
+    );
+
+    @Test
+    void updateLineageStoresInnateSpellInExistingLineageAffiliation()
+    {
+        Species parent = new Species();
+        Species lineage = new Species();
+        lineage.setUrl("forest-gnome");
+        lineage.setParent(parent);
+
+        SpeciesInnateSpellRequest innateSpell = new SpeciesInnateSpellRequest();
+        innateSpell.setSpell("minor-illusion");
+        innateSpell.setRequiredLevel(3);
+
+        SourceRequest source = new SourceRequest();
+        source.setUrl("phb");
+
+        SpeciesRequest request = new SpeciesRequest();
+        request.setUrl(lineage.getUrl());
+        request.setParent("gnome");
+        request.setSource(source);
+        request.setInnateSpells(List.of(innateSpell));
+
+        when(speciesRepository.findById(lineage.getUrl())).thenReturn(Optional.of(lineage));
+        when(speciesRepository.findById("gnome")).thenReturn(Optional.of(parent));
+        when(speciesRepository.save(lineage)).thenReturn(lineage);
+        when(speciesRepository.findInnateSpells(lineage.getUrl())).thenReturn(List.of());
+        when(speciesMapper.toRequest(lineage)).thenReturn(new SpeciesRequest());
+        when(spellRepository.countByUrlIn(Set.of("minor-illusion"))).thenReturn(1L);
+
+        service.update(lineage.getUrl(), request);
+
+        verify(speciesRepository).deleteSpeciesInnateSpells(lineage.getUrl());
+        verify(speciesRepository).deleteLineageInnateSpells(lineage.getUrl());
+        verify(speciesRepository).addLineageInnateSpell(
+                lineage.getUrl(),
+                "minor-illusion",
+                3
+        );
+    }
+}


### PR DESCRIPTION
## Что сделано

- Использованы существующие связи заклинаний с видами и происхождениями.
- Для каждой связи добавлен уровень персонажа, с которого доступно заклинание.
- API редактора возвращает и сохраняет врождённые заклинания; происхождение наследует заклинания родительского вида.
- Добавлена проверка уровня от 1 до 20 и защита от дубликатов.

## Проверки

- `SpeciesServiceTest`: 1 тест, без ошибок и падений.
- `git diff --check`.