### PR TITLE
feat: Добавить выбор боевого стиля для классовых умений

### DIFF
--- a/src/main/java/club/ttg/dnd5/domain/character_class/model/ClassFeature.java
+++ b/src/main/java/club/ttg/dnd5/domain/character_class/model/ClassFeature.java
@@ -52,6 +52,9 @@ public class ClassFeature {
     @Schema(description = "Умение увеличивает характеристики")
     private boolean abilityImprovement;
 
+    @Schema(description = "Умение даёт выбор одной черты категории «Боевой стиль»")
+    private boolean fightingStyleChoice;
+
     @Schema(description = "Скрывать умение в подклассе")
     private boolean hideInSubclasses;
 
@@ -74,6 +77,7 @@ public class ClassFeature {
         this.key = SlugifyUtil.getSlug(this.name);
         this.hideInSubclasses = classFeatureRequest.isHideInSubclasses();
         this.abilityImprovement = classFeatureRequest.isAbilityImprovement();
+        this.fightingStyleChoice = classFeatureRequest.isFightingStyleChoice();
         this.abilityBonus = classFeatureRequest.getAbilityBonus();
     }
 }

--- a/src/main/java/club/ttg/dnd5/domain/character_class/rest/dto/ClassFeatureDto.java
+++ b/src/main/java/club/ttg/dnd5/domain/character_class/rest/dto/ClassFeatureDto.java
@@ -49,6 +49,9 @@ public class ClassFeatureDto {
     @Schema(description = "Скрывать умение в подклассе")
     private boolean hideInSubclasses;
 
+    @Schema(description = "Умение даёт выбор одной черты категории «Боевой стиль»")
+    private boolean fightingStyleChoice;
+
     public ClassFeatureDto(ClassFeature classFeature, boolean isSubclass) {
         this(classFeature, isSubclass, isSubclass);
     }
@@ -62,6 +65,7 @@ public class ClassFeatureDto {
         this.description = classFeature.getDescription();
         this.additional = classFeature.getAdditional();
         this.hideInSubclasses = classFeature.isHideInSubclasses();
+        this.fightingStyleChoice = classFeature.isFightingStyleChoice();
         if (filterForSubclassContext) {
             this.scaling = Optional.ofNullable(classFeature.getScaling())
                     .orElse(List.of())

--- a/src/main/java/club/ttg/dnd5/domain/character_class/rest/dto/ClassFeatureRequest.java
+++ b/src/main/java/club/ttg/dnd5/domain/character_class/rest/dto/ClassFeatureRequest.java
@@ -49,6 +49,9 @@ public class ClassFeatureRequest {
     @Schema(description = "Умение увеличивает характеристики")
     private boolean abilityImprovement;
 
+    @Schema(description = "Умение даёт выбор одной черты категории «Боевой стиль»")
+    private boolean fightingStyleChoice;
+
     @Schema(description = "Бонус к увеличивает характеристик")
     private AbilityBonus abilityBonus;
 

--- a/src/main/java/club/ttg/dnd5/domain/character_class/service/MulticlassService.java
+++ b/src/main/java/club/ttg/dnd5/domain/character_class/service/MulticlassService.java
@@ -517,6 +517,7 @@ public class MulticlassService {
                 .map(ClassFeatureOption::new)
                 .toList());
         copy.setAbilityImprovement(classFeature.isAbilityImprovement());
+        copy.setFightingStyleChoice(classFeature.isFightingStyleChoice());
         copy.setHideInSubclasses(classFeature.isHideInSubclasses());
         copy.setAbilityBonus(classFeature.getAbilityBonus());
         return copy;

--- a/src/test/java/club/ttg/dnd5/domain/character_class/model/ClassFeatureTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/character_class/model/ClassFeatureTest.java
@@ -5,6 +5,7 @@ import club.ttg.dnd5.domain.character_class.rest.dto.ClassFeatureRequest;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ClassFeatureTest {
 
@@ -13,10 +14,12 @@ class ClassFeatureTest {
         ClassFeatureRequest request = new ClassFeatureRequest();
         request.setName("Combat Superiority");
         request.setOptionsName("Maneuvers");
+        request.setFightingStyleChoice(true);
 
         ClassFeature feature = new ClassFeature(request);
 
         assertEquals("Maneuvers", feature.getOptionsName());
+        assertTrue(feature.isFightingStyleChoice());
     }
 
     @Test
@@ -24,9 +27,11 @@ class ClassFeatureTest {
         ClassFeature feature = new ClassFeature();
         feature.setName("Combat Superiority");
         feature.setOptionsName("Maneuvers");
+        feature.setFightingStyleChoice(true);
 
         ClassFeatureDto dto = new ClassFeatureDto(feature, false);
 
         assertEquals("Maneuvers", dto.getOptionsName());
+        assertTrue(dto.isFightingStyleChoice());
     }
 }


### PR DESCRIPTION
## Что сделано

- добавлен независимый признак `fightingStyleChoice` для классового умения;
- признак проходит через запросы, DTO и сохраняется в JSONB-модели класса;
- признак сохраняется при формировании данных мультикласса;
- добавлены проверки преобразования запроса и ответа.

## Зачем

Лист персонажа должен определять право выбора боевого стиля по явному признаку умения, а не по его названию.

## Проверка

- `ClassFeatureTest`: 2 теста успешно;
- сборка и тесты выполнены на Java 21;
- `git diff --check` успешно.