### PR TITLE
feat(classes): отдавать флаг улучшения характеристик в ответе класса

### DIFF
--- a/src/main/java/club/ttg/dnd5/domain/character_class/rest/dto/ClassFeatureDto.java
+++ b/src/main/java/club/ttg/dnd5/domain/character_class/rest/dto/ClassFeatureDto.java
@@ -49,6 +49,9 @@ public class ClassFeatureDto {
     @Schema(description = "Скрывать умение в подклассе")
     private boolean hideInSubclasses;
 
+    @Schema(description = "Умение увеличивает характеристики")
+    private boolean abilityImprovement;
+
     @Schema(description = "Умение даёт выбор одной черты категории «Боевой стиль»")
     private boolean fightingStyleChoice;
 
@@ -65,6 +68,7 @@ public class ClassFeatureDto {
         this.description = classFeature.getDescription();
         this.additional = classFeature.getAdditional();
         this.hideInSubclasses = classFeature.isHideInSubclasses();
+        this.abilityImprovement = classFeature.isAbilityImprovement();
         this.fightingStyleChoice = classFeature.isFightingStyleChoice();
         if (filterForSubclassContext) {
             this.scaling = Optional.ofNullable(classFeature.getScaling())

--- a/src/main/java/club/ttg/dnd5/domain/character_class/rest/mapper/ClassMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/character_class/rest/mapper/ClassMapper.java
@@ -300,10 +300,14 @@ public interface ClassMapper
         {
             if (classFeature.isAbilityImprovement())
             {
-                List<Integer> levels = new ArrayList<>(classFeature.getScaling().size() + 1);
+                // Умение может быть без масштабирования (одно повышение за класс),
+                // тогда scaling приходит пустым или вовсе не заполнен.
+                var scaling = Optional.ofNullable(classFeature.getScaling()).orElse(List.of());
+
+                List<Integer> levels = new ArrayList<>(scaling.size() + 1);
                 levels.add(classFeature.getLevel());
 
-                for (var sub : classFeature.getScaling())
+                for (var sub : scaling)
                 {
                     levels.add(sub.getLevel());
                 }

--- a/src/main/resources/db/changelog/2026/07/29-01-backfill-ability-improvement-variants.yaml
+++ b/src/main/resources/db/changelog/2026/07/29-01-backfill-ability-improvement-variants.yaml
@@ -1,0 +1,71 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-29-class-features-backfill-abilityImprovement-variants
+      author: ttg
+      comment: >
+        Прошлый бэкфилл (2026-02-09) сравнивал название умения с «Улучшение
+        характеристик» посимвольно и пропустил два написания: «Улучшение
+        Характеристик» (волшебник) и «Увеличение характеристик» (колдун).
+        Здесь сравнение регистронезависимое и покрывает оба слова.
+      changes:
+        - sql:
+            dbms: postgresql
+            splitStatements: false
+            stripComments: true
+            sql: >
+              SET search_path TO ttg, public;
+
+              UPDATE "class" c
+              SET features =
+              (
+                SELECT jsonb_agg(
+                  CASE
+                    WHEN lower(elem->>'name') IN ('улучшение характеристик', 'увеличение характеристик')
+                         AND COALESCE((elem->>'abilityImprovement')::boolean, false) = false
+                      THEN elem || jsonb_build_object('abilityImprovement', true)
+                    ELSE elem
+                  END
+                  ORDER BY ord
+                )
+                FROM jsonb_array_elements(c.features) WITH ORDINALITY AS t(elem, ord)
+              )
+              WHERE c.features IS NOT NULL
+                AND jsonb_typeof(c.features) = 'array'
+                AND EXISTS (
+                  SELECT 1
+                  FROM jsonb_array_elements(c.features) AS e
+                  WHERE lower(e->>'name') IN ('улучшение характеристик', 'увеличение характеристик')
+                    AND COALESCE((e->>'abilityImprovement')::boolean, false) = false
+                );
+
+      rollback:
+        - sql:
+            dbms: postgresql
+            splitStatements: false
+            stripComments: true
+            sql: >
+              SET search_path TO ttg, public;
+
+              UPDATE "class" c
+              SET features =
+              (
+                SELECT jsonb_agg(
+                  CASE
+                    WHEN lower(elem->>'name') IN ('улучшение характеристик', 'увеличение характеристик')
+                         AND elem->>'name' <> 'Улучшение характеристик'
+                      THEN (elem - 'abilityImprovement')
+                    ELSE elem
+                  END
+                  ORDER BY ord
+                )
+                FROM jsonb_array_elements(c.features) WITH ORDINALITY AS t(elem, ord)
+              )
+              WHERE c.features IS NOT NULL
+                AND jsonb_typeof(c.features) = 'array'
+                AND EXISTS (
+                  SELECT 1
+                  FROM jsonb_array_elements(c.features) AS e
+                  WHERE lower(e->>'name') IN ('улучшение характеристик', 'увеличение характеристик')
+                    AND e->>'name' <> 'Улучшение характеристик'
+                    AND (e->'abilityImprovement') IS NOT NULL
+                );

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -267,3 +267,5 @@ databaseChangeLog:
       file: db/changelog/2026/07/26-01-create-character-sheet-saved-table.yaml
   - include:
       file: db/changelog/2026/07/27-01-add-required-level-to-species-spells.yaml
+  - include:
+      file: db/changelog/2026/07/29-01-backfill-ability-improvement-variants.yaml

--- a/src/test/java/club/ttg/dnd5/domain/character_class/model/ClassFeatureTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/character_class/model/ClassFeatureTest.java
@@ -34,4 +34,26 @@ class ClassFeatureTest {
         assertEquals("Maneuvers", dto.getOptionsName());
         assertTrue(dto.isFightingStyleChoice());
     }
+
+    @Test
+    void requestConstructorCopiesAbilityImprovement() {
+        ClassFeatureRequest request = new ClassFeatureRequest();
+        request.setName("Ability Score Improvement");
+        request.setAbilityImprovement(true);
+
+        ClassFeature feature = new ClassFeature(request);
+
+        assertTrue(feature.isAbilityImprovement());
+    }
+
+    @Test
+    void dtoConstructorCopiesAbilityImprovement() {
+        ClassFeature feature = new ClassFeature();
+        feature.setName("Ability Score Improvement");
+        feature.setAbilityImprovement(true);
+
+        ClassFeatureDto dto = new ClassFeatureDto(feature, false);
+
+        assertTrue(dto.isAbilityImprovement());
+    }
 }


### PR DESCRIPTION
Поле abilityImprovement есть у сущности умения и в запросе редактора, но в ответе класса его не было — листу персонажа приходилось угадывать умение по названию и описанию.

Прошлый бэкфилл (2026-02-09) сравнивал название посимвольно и пропустил два написания: «Улучшение Характеристик» у волшебника и «Увеличение характеристик» у колдуна. Тот changeset уже вышел в релизе, поэтому правки внесены отдельным набором изменений с регистронезависимым сравнением по обоим словам. Порядок умений закреплён через WITH ORDINALITY, чтобы jsonb_agg не переставил их местами.

Заодно getLevels перестал разыменовывать scaling без проверки на null: после бэкфилла флаг стоит у большего числа умений, и умение без масштабирования роняло бы ручку улучшения характеристик.