### PR TITLE
feat(class): структурное стартовое снаряжение классов

### DIFF
--- a/src/main/java/club/ttg/dnd5/domain/character_class/model/CharacterClass.java
+++ b/src/main/java/club/ttg/dnd5/domain/character_class/model/CharacterClass.java
@@ -109,6 +109,13 @@ public class CharacterClass extends NamedEntity {
     private String equipment;
 
     /**
+     * Стартовое снаряжение вариантами выбора: «А» — предметы, «Б» — монеты и т.д.
+     */
+    @Type(JsonType.class)
+    @Column(columnDefinition = "jsonb", name = "starting_equipment")
+    private List<ClassEquipmentOption> startingEquipment;
+
+    /**
      * Тип заклинателя
      */
     @Enumerated(EnumType.STRING)

--- a/src/main/java/club/ttg/dnd5/domain/character_class/model/ClassEquipmentItem.java
+++ b/src/main/java/club/ttg/dnd5/domain/character_class/model/ClassEquipmentItem.java
@@ -1,0 +1,30 @@
+package club.ttg.dnd5.domain.character_class.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Предмет в варианте стартового снаряжения класса.
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+@Getter
+@Setter
+public class ClassEquipmentItem {
+    @Schema(description = "URL предмета", example = "dagger")
+    private String url;
+
+    @Schema(description = "Название предмета на момент сохранения", example = "Кинжал")
+    private String name;
+
+    @Schema(description = "Количество предметов", example = "2")
+    private Integer quantity;
+
+    @Schema(description = "Уточнение к предмету", example = "по вашему выбору")
+    private String description;
+}

--- a/src/main/java/club/ttg/dnd5/domain/character_class/model/ClassEquipmentOption.java
+++ b/src/main/java/club/ttg/dnd5/domain/character_class/model/ClassEquipmentOption.java
@@ -1,0 +1,32 @@
+package club.ttg.dnd5.domain.character_class.model;
+
+import club.ttg.dnd5.domain.common.dictionary.Coin;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * Вариант стартового снаряжения класса — подблок «А», «Б» и т.д.
+ * Состоит из списка предметов с количеством и суммы монет.
+ * Метка варианта не хранится: она выводится из порядка при отдаче ответа.
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+@Getter
+@Setter
+public class ClassEquipmentOption {
+    @Schema(description = "Предметы варианта")
+    private List<ClassEquipmentItem> items;
+
+    @Schema(description = "Количество монет", example = "15")
+    private Integer coins;
+
+    @Schema(description = "Тип монет")
+    private Coin coin = Coin.GC;
+}

--- a/src/main/java/club/ttg/dnd5/domain/character_class/rest/dto/ClassDetailedResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/character_class/rest/dto/ClassDetailedResponse.java
@@ -33,6 +33,9 @@ public class ClassDetailedResponse extends BaseResponse {
     @Schema(description = "Снаряжение класса в формате Markdown")
     private String equipment;
 
+    @Schema(description = "Стартовое снаряжение вариантами выбора")
+    private List<ClassEquipmentOptionDto> startingEquipment;
+
     @Schema(description = "Спасброски класса")
     private String savingThrows;
 

--- a/src/main/java/club/ttg/dnd5/domain/character_class/rest/dto/ClassEquipmentItemDto.java
+++ b/src/main/java/club/ttg/dnd5/domain/character_class/rest/dto/ClassEquipmentItemDto.java
@@ -1,0 +1,25 @@
+package club.ttg.dnd5.domain.character_class.rest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClassEquipmentItemDto {
+    @Schema(description = "URL предмета", example = "dagger")
+    private String url;
+
+    @Schema(description = "Название предмета", example = "Кинжал")
+    private String name;
+
+    @Schema(description = "Количество предметов", example = "2")
+    private Integer quantity;
+
+    @Schema(description = "Уточнение к предмету", example = "по вашему выбору")
+    private String description;
+}

--- a/src/main/java/club/ttg/dnd5/domain/character_class/rest/dto/ClassEquipmentOptionDto.java
+++ b/src/main/java/club/ttg/dnd5/domain/character_class/rest/dto/ClassEquipmentOptionDto.java
@@ -1,0 +1,27 @@
+package club.ttg.dnd5.domain.character_class.rest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClassEquipmentOptionDto {
+    @Schema(description = "Метка варианта", example = "А")
+    private String label;
+
+    @Schema(description = "Предметы варианта")
+    private List<ClassEquipmentItemDto> items;
+
+    @Schema(description = "Количество монет", example = "15")
+    private Integer coins;
+
+    @Schema(description = "Сокращённое название монет", example = "зм")
+    private String coin;
+}

--- a/src/main/java/club/ttg/dnd5/domain/character_class/rest/dto/ClassRequest.java
+++ b/src/main/java/club/ttg/dnd5/domain/character_class/rest/dto/ClassRequest.java
@@ -1,6 +1,7 @@
 package club.ttg.dnd5.domain.character_class.rest.dto;
 
 import club.ttg.dnd5.domain.character_class.model.CasterType;
+import club.ttg.dnd5.domain.character_class.model.ClassEquipmentOption;
 import club.ttg.dnd5.domain.character_class.model.ClassTableColumn;
 import club.ttg.dnd5.domain.character_class.model.MulticlassProficiency;
 import club.ttg.dnd5.domain.common.dictionary.Ability;
@@ -46,6 +47,9 @@ public class ClassRequest extends BaseRequest {
     @JsonSerialize(using = FormattedMarkupDescriptionSerializer.class)
     @Schema(description = "Снаряжение класса в формате Markdown")
     private String equipment;
+
+    @Schema(description = "Стартовое снаряжение вариантами выбора: предметы с количеством и монеты")
+    private List<ClassEquipmentOption> startingEquipment;
 
     @Schema(description = "Особенности класса")
     private List<ClassFeatureRequest> features;

--- a/src/main/java/club/ttg/dnd5/domain/character_class/rest/mapper/ClassMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/character_class/rest/mapper/ClassMapper.java
@@ -4,6 +4,7 @@ import club.ttg.dnd5.domain.source.model.Source;
 import club.ttg.dnd5.domain.character_class.model.*;
 import club.ttg.dnd5.domain.character_class.rest.dto.*;
 import club.ttg.dnd5.domain.common.dictionary.Ability;
+import club.ttg.dnd5.domain.common.dictionary.Coin;
 import club.ttg.dnd5.domain.common.dictionary.Delimiter;
 import club.ttg.dnd5.domain.common.dictionary.Dice;
 import club.ttg.dnd5.domain.common.dictionary.WeaponCategory;
@@ -58,6 +59,7 @@ public interface ClassMapper
     @Mapping(target = "hasSubclasses", source = "subclasses", qualifiedByName = "hasSubclasses")
     @Mapping(target = "parent", source = "parent", qualifiedByName = "toShortResponse")
     @Mapping(target = "imageUrl", source = ".", qualifiedByName = "toImageUrl")
+    @Mapping(target = "startingEquipment", source = "startingEquipment", qualifiedByName = "toEquipmentOptionDtos")
     ClassDetailedResponse toDetailedResponse(CharacterClass characterClass);
 
     @BaseMapping.BaseEntityNameMapping
@@ -90,6 +92,7 @@ public interface ClassMapper
     @Mapping(target = "multiclassProficiency", source = "multiclassProficiency")
     @Mapping(target = "primaryCharacteristics.values", source = "primaryCharacteristics")
     @Mapping(target = "primaryCharacteristics.delimiter", source = "delimiterPrimary")
+    @Mapping(target = "startingEquipment", source = "startingEquipment", qualifiedByName = "toEquipmentForm")
     ClassRequest toRequest(CharacterClass entity);
 
     @Mapping(target = "url", source = "request.url")
@@ -107,6 +110,7 @@ public interface ClassMapper
     @Mapping(target = "toolProficiency", source = "request.proficiency.tool")
     @Mapping(target = "skillProficiency", source = "request.proficiency.skill")
     @Mapping(target = "equipment", source = "request.equipment")
+    @Mapping(target = "startingEquipment", source = "request.startingEquipment", qualifiedByName = "toEquipmentEntities")
     @Mapping(target = "casterType", source = "request.casterType")
     @Mapping(target = "primaryCharacteristics", source = "request.primaryCharacteristics.values")
     @Mapping(target = "delimiterPrimary", source = "request.primaryCharacteristics.delimiter")
@@ -274,6 +278,117 @@ public interface ClassMapper
                 .flatMap(List::stream)
                 .sorted(Comparator.comparing(ClassFeatureDto::getLevel))
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Метки вариантов снаряжения — выводятся из порядка вариантов, в базе не хранятся.
+     */
+    String EQUIPMENT_LABELS = "АБВГДЕЖЗИКЛМНОПРСТУФХЦЧШЩЭЮЯ";
+
+    /**
+     * Количество вариантов снаряжения, которые редактор показывает у класса без снаряжения.
+     */
+    int DEFAULT_EQUIPMENT_OPTIONS = 2;
+
+    /**
+     * Варианты снаряжения для формы редактора: если у класса их нет,
+     * отдаём пустые подблоки «А» и «Б», чтобы редактору было что показать.
+     */
+    @Named("toEquipmentForm")
+    default List<ClassEquipmentOption> toEquipmentForm(List<ClassEquipmentOption> options)
+    {
+        if (!CollectionUtils.isEmpty(options))
+        {
+            return options;
+        }
+
+        List<ClassEquipmentOption> defaults = new ArrayList<>(DEFAULT_EQUIPMENT_OPTIONS);
+        for (int index = 0; index < DEFAULT_EQUIPMENT_OPTIONS; index++)
+        {
+            ClassEquipmentOption option = new ClassEquipmentOption();
+            option.setItems(new ArrayList<>());
+            defaults.add(option);
+        }
+
+        return defaults;
+    }
+
+    /**
+     * Варианты снаряжения для сохранения: пустые предметы и пустые подблоки отбрасываются,
+     * чтобы дефолтные подблоки редактора не попадали в базу.
+     */
+    @Named("toEquipmentEntities")
+    default List<ClassEquipmentOption> toEquipmentEntities(List<ClassEquipmentOption> options)
+    {
+        if (CollectionUtils.isEmpty(options))
+        {
+            return null;
+        }
+
+        List<ClassEquipmentOption> cleaned = new ArrayList<>(options.size());
+        for (ClassEquipmentOption option : options)
+        {
+            if (option == null)
+            {
+                continue;
+            }
+
+            option.setItems(cleanEquipmentItems(option.getItems()));
+
+            if (!option.getItems().isEmpty() || option.getCoins() != null)
+            {
+                cleaned.add(option);
+            }
+        }
+
+        return cleaned.isEmpty() ? null : cleaned;
+    }
+
+    private List<ClassEquipmentItem> cleanEquipmentItems(List<ClassEquipmentItem> items)
+    {
+        if (CollectionUtils.isEmpty(items))
+        {
+            return Collections.emptyList();
+        }
+
+        return items.stream()
+                .filter(Objects::nonNull)
+                .filter(item -> StringUtils.hasText(item.getUrl()) || StringUtils.hasText(item.getDescription()))
+                .toList();
+    }
+
+    @Named("toEquipmentOptionDtos")
+    default List<ClassEquipmentOptionDto> toEquipmentOptionDtos(List<ClassEquipmentOption> options)
+    {
+        if (CollectionUtils.isEmpty(options))
+        {
+            return Collections.emptyList();
+        }
+
+        List<ClassEquipmentOptionDto> dtos = new ArrayList<>(options.size());
+        for (int index = 0; index < options.size(); index++)
+        {
+            ClassEquipmentOption option = options.get(index);
+            Coin coin = option.getCoin() == null ? Coin.GC : option.getCoin();
+
+            dtos.add(new ClassEquipmentOptionDto(
+                    equipmentLabel(index),
+                    toEquipmentItemDtos(option.getItems()),
+                    option.getCoins(),
+                    coin.getShortName()
+            ));
+        }
+
+        return dtos;
+    }
+
+    List<ClassEquipmentItemDto> toEquipmentItemDtos(List<ClassEquipmentItem> items);
+
+    default String equipmentLabel(int index)
+    {
+        return index < EQUIPMENT_LABELS.length()
+                ? String.valueOf(EQUIPMENT_LABELS.charAt(index))
+                : String.valueOf(index + 1);
     }
 
     @Named("hasSubclasses")

--- a/src/main/java/club/ttg/dnd5/domain/character_class/service/ClassService.java
+++ b/src/main/java/club/ttg/dnd5/domain/character_class/service/ClassService.java
@@ -10,6 +10,8 @@ import club.ttg.dnd5.domain.character_class.model.CasterType;
 import club.ttg.dnd5.domain.character_class.model.CharacterClass;
 import club.ttg.dnd5.domain.character_class.repository.ClassRepository;
 import club.ttg.dnd5.domain.character_class.rest.dto.ClassDetailedResponse;
+import club.ttg.dnd5.domain.character_class.rest.dto.ClassEquipmentItemDto;
+import club.ttg.dnd5.domain.character_class.rest.dto.ClassEquipmentOptionDto;
 import club.ttg.dnd5.domain.character_class.rest.dto.ClassRequest;
 import club.ttg.dnd5.domain.character_class.rest.dto.ClassShortResponse;
 import club.ttg.dnd5.domain.character_class.rest.mapper.ClassMapper;
@@ -17,6 +19,8 @@ import club.ttg.dnd5.domain.common.model.Gallery;
 import club.ttg.dnd5.domain.common.model.SectionType;
 import club.ttg.dnd5.domain.common.repository.GalleryRepository;
 import club.ttg.dnd5.domain.common.rest.dto.SourceRequest;
+import club.ttg.dnd5.domain.item.repository.ItemNameRef;
+import club.ttg.dnd5.domain.item.repository.ItemRepository;
 import club.ttg.dnd5.domain.revision.model.RevisionOperation;
 import club.ttg.dnd5.domain.revision.service.EntityRevisionService;
 import club.ttg.dnd5.exception.EntityExistException;
@@ -32,6 +36,8 @@ import org.springframework.util.StringUtils;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -49,6 +55,7 @@ public class ClassService {
     private final GalleryRepository galleryRepository;
     private final SourceSavedFilterService sourceSavedFilterService;
     private final EntityRevisionService revisionService;
+    private final ItemRepository itemRepository;
 
     public List<ClassShortResponse> search(ClassQueryRequest request) {
         var predicate = ClassPredicateBuilder.build(request);
@@ -101,7 +108,9 @@ public class ClassService {
         CharacterClass saved = classRepository.save(toSave);
         revisionService.record(REVISION_ENTITY_TYPE, saved.getUrl(), RevisionOperation.CREATE,
                 findFormByUrl(saved.getUrl()));
-        return classMapper.toDetailedResponse(saved);
+        ClassDetailedResponse response = classMapper.toDetailedResponse(saved);
+        resolveEquipmentNames(response.getStartingEquipment());
+        return response;
     }
 
     @Transactional
@@ -175,6 +184,7 @@ public class ClassService {
         var charClass = findByUrl(url);
         var response = classMapper.toDetailedResponse(charClass);
         fillResponseFieldsFromParentClass(charClass, response);
+        resolveEquipmentNames(response.getStartingEquipment());
         response.setGallery(galleryRepository.findAllByUrlAndType(url, SectionType.CLASS)
                 .stream()
                 .map(Gallery::getImage)
@@ -189,6 +199,37 @@ public class ClassService {
                 .map(Gallery::getImage)
                 .toList());
         return request;
+    }
+
+    /**
+     * Подставляет актуальные названия предметов из справочника: в снаряжении класса хранится
+     * ссылка на предмет и название на момент сохранения, и снимок мог устареть после переименования.
+     * Название из снимка остаётся запасным — для предметов, которых уже нет в справочнике.
+     */
+    private void resolveEquipmentNames(List<ClassEquipmentOptionDto> options) {
+        if (CollectionUtils.isEmpty(options)) {
+            return;
+        }
+
+        List<ClassEquipmentItemDto> items = options.stream()
+                .map(ClassEquipmentOptionDto::getItems)
+                .filter(Objects::nonNull)
+                .flatMap(List::stream)
+                .filter(item -> StringUtils.hasText(item.getUrl()))
+                .toList();
+
+        if (items.isEmpty()) {
+            return;
+        }
+
+        Set<String> urls = items.stream()
+                .map(ClassEquipmentItemDto::getUrl)
+                .collect(Collectors.toSet());
+
+        Map<String, String> names = itemRepository.findNamesByUrls(urls).stream()
+                .collect(Collectors.toMap(ItemNameRef::getUrl, ItemNameRef::getName));
+
+        items.forEach(item -> item.setName(names.getOrDefault(item.getUrl(), item.getName())));
     }
 
     private void fillResponseFieldsFromParentClass(CharacterClass characterClass, ClassDetailedResponse response) {
@@ -211,6 +252,10 @@ public class ClassService {
 
         if (!StringUtils.hasText(response.getEquipment())) {
             response.setEquipment(parent.getEquipment());
+        }
+
+        if (CollectionUtils.isEmpty(response.getStartingEquipment())) {
+            response.setStartingEquipment(classMapper.toEquipmentOptionDtos(parent.getStartingEquipment()));
         }
 
         if (response.getTable() == null) {
@@ -250,6 +295,7 @@ public class ClassService {
         var entity = classMapper.toEntity(request, source);
         entity.setParent(parent);
         var response = classMapper.toDetailedResponse(entity);
+        resolveEquipmentNames(response.getStartingEquipment());
         response.setGallery(galleryRepository.findAllByUrlAndType(response.getUrl(), SectionType.CLASS)
                 .stream()
                 .map(Gallery::getImage)

--- a/src/main/java/club/ttg/dnd5/domain/item/repository/ItemNameRef.java
+++ b/src/main/java/club/ttg/dnd5/domain/item/repository/ItemNameRef.java
@@ -1,0 +1,11 @@
+package club.ttg.dnd5.domain.item.repository;
+
+/**
+ * Лёгкая проекция предмета: только url и название, без гидрации jsonb-полей.
+ * Используется, чтобы подставить актуальные названия предметов в стартовое снаряжение класса.
+ */
+public interface ItemNameRef {
+    String getUrl();
+
+    String getName();
+}

--- a/src/main/java/club/ttg/dnd5/domain/item/repository/ItemRepository.java
+++ b/src/main/java/club/ttg/dnd5/domain/item/repository/ItemRepository.java
@@ -37,6 +37,10 @@ public interface ItemRepository extends JpaRepository<Item, String>,
         """, nativeQuery = true)
     List<String> findAllUsedSourceCodes();
 
+    /** Названия предметов по набору url — для подстановки в стартовое снаряжение классов. */
+    @Query("select i.url as url, i.name as name from Item i where i.url in :urls")
+    List<ItemNameRef> findNamesByUrls(@Param("urls") Collection<String> urls);
+
     @Query(value = """
         select distinct i.srd_version
         from item i

--- a/src/main/resources/db/changelog/2026/07/29-01-add-class-starting-equipment.yaml
+++ b/src/main/resources/db/changelog/2026/07/29-01-add-class-starting-equipment.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: 29-01-add-class-starting-equipment
+      author: Magistrus
+      changes:
+        - addColumn:
+            tableName: class
+            columns:
+              - column:
+                  name: starting_equipment
+                  type: jsonb

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -267,3 +267,5 @@ databaseChangeLog:
       file: db/changelog/2026/07/26-01-create-character-sheet-saved-table.yaml
   - include:
       file: db/changelog/2026/07/27-01-add-required-level-to-species-spells.yaml
+  - include:
+      file: db/changelog/2026/07/29-01-add-class-starting-equipment.yaml

--- a/src/test/java/club/ttg/dnd5/domain/character_class/rest/mapper/ClassMapperTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/character_class/rest/mapper/ClassMapperTest.java
@@ -1,0 +1,110 @@
+package club.ttg.dnd5.domain.character_class.rest.mapper;
+
+import club.ttg.dnd5.domain.character_class.model.ClassEquipmentItem;
+import club.ttg.dnd5.domain.character_class.model.ClassEquipmentOption;
+import club.ttg.dnd5.dto.base.mapping.BaseMapping;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+class ClassMapperTest
+{
+    @Mock
+    private BaseMapping baseMapping;
+
+    @InjectMocks
+    private ClassMapperImpl mapper;
+
+    @Test
+    void formGetsTwoEmptyOptionsWhenClassHasNoEquipment()
+    {
+        var options = mapper.toEquipmentForm(null);
+
+        assertEquals(2, options.size());
+        assertTrue(options.get(0).getItems().isEmpty());
+        assertNull(options.get(0).getCoins());
+    }
+
+    @Test
+    void formKeepsSavedOptionsAsIs()
+    {
+        List<ClassEquipmentOption> saved = List.of(coins(75));
+
+        assertEquals(saved, mapper.toEquipmentForm(saved));
+    }
+
+    @Test
+    void emptyOptionsAndItemsAreNotSaved()
+    {
+        ClassEquipmentOption filled = new ClassEquipmentOption();
+        filled.setItems(new ArrayList<>(List.of(item("dagger", 2, null), item(null, null, null))));
+
+        var options = mapper.toEquipmentEntities(new ArrayList<>(List.of(filled, new ClassEquipmentOption())));
+
+        assertEquals(1, options.size());
+        assertEquals(1, options.getFirst().getItems().size());
+        assertEquals("dagger", options.getFirst().getItems().getFirst().getUrl());
+    }
+
+    @Test
+    void itemWithOnlyDescriptionIsSaved()
+    {
+        ClassEquipmentOption option = new ClassEquipmentOption();
+        option.setItems(new ArrayList<>(List.of(item(null, null, "музыкальный инструмент по вашему выбору"))));
+
+        var options = mapper.toEquipmentEntities(new ArrayList<>(List.of(option)));
+
+        assertEquals(1, options.size());
+        assertEquals(1, options.getFirst().getItems().size());
+    }
+
+    @Test
+    void formDefaultsAreNotSaved()
+    {
+        assertNull(mapper.toEquipmentEntities(mapper.toEquipmentForm(null)));
+    }
+
+    @Test
+    void responseDerivesLabelsFromOrderAndCoinName()
+    {
+        ClassEquipmentOption gear = new ClassEquipmentOption();
+        gear.setItems(List.of(item("musical-instrument", 1, "по вашему выбору")));
+        gear.setCoins(19);
+
+        var response = mapper.toEquipmentOptionDtos(List.of(gear, coins(75)));
+
+        assertEquals("А", response.get(0).getLabel());
+        assertEquals("Б", response.get(1).getLabel());
+        assertEquals("зм", response.get(0).getCoin());
+        assertEquals(19, response.get(0).getCoins());
+        assertEquals("по вашему выбору", response.get(0).getItems().getFirst().getDescription());
+        assertEquals(1, response.get(0).getItems().getFirst().getQuantity());
+        assertEquals(75, response.get(1).getCoins());
+    }
+
+    private ClassEquipmentOption coins(int amount)
+    {
+        ClassEquipmentOption option = new ClassEquipmentOption();
+        option.setCoins(amount);
+        return option;
+    }
+
+    private ClassEquipmentItem item(String url, Integer quantity, String description)
+    {
+        ClassEquipmentItem item = new ClassEquipmentItem();
+        item.setUrl(url);
+        item.setQuantity(quantity);
+        item.setDescription(description);
+        return item;
+    }
+}

--- a/src/test/java/club/ttg/dnd5/domain/character_class/service/ClassServiceTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/character_class/service/ClassServiceTest.java
@@ -2,17 +2,25 @@ package club.ttg.dnd5.domain.character_class.service;
 
 import club.ttg.dnd5.domain.character_class.model.CharacterClass;
 import club.ttg.dnd5.domain.character_class.repository.ClassRepository;
+import club.ttg.dnd5.domain.character_class.rest.dto.ClassDetailedResponse;
+import club.ttg.dnd5.domain.character_class.rest.dto.ClassEquipmentItemDto;
+import club.ttg.dnd5.domain.character_class.rest.dto.ClassEquipmentOptionDto;
 import club.ttg.dnd5.domain.character_class.rest.dto.ClassRequest;
 import club.ttg.dnd5.domain.character_class.rest.mapper.ClassMapper;
 import club.ttg.dnd5.domain.common.repository.GalleryRepository;
+import club.ttg.dnd5.domain.item.repository.ItemNameRef;
+import club.ttg.dnd5.domain.item.repository.ItemRepository;
 import club.ttg.dnd5.domain.revision.service.EntityRevisionService;
 import club.ttg.dnd5.domain.source.service.SourceSavedFilterService;
 import club.ttg.dnd5.domain.source.service.SourceService;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -28,6 +36,7 @@ class ClassServiceTest {
     private final GalleryRepository galleryRepository = mock(GalleryRepository.class);
     private final SourceSavedFilterService sourceSavedFilterService = mock(SourceSavedFilterService.class);
     private final EntityRevisionService revisionService = mock(EntityRevisionService.class);
+    private final ItemRepository itemRepository = mock(ItemRepository.class);
     private final ClassService service = new ClassService(
             classRepository,
             classMapper,
@@ -35,7 +44,8 @@ class ClassServiceTest {
             sourceService,
             galleryRepository,
             sourceSavedFilterService,
-            revisionService
+            revisionService,
+            itemRepository
     );
 
     @Test
@@ -61,5 +71,37 @@ class ClassServiceTest {
         verify(classRepository).save(captor.capture());
         verify(classRepository, never()).getReferenceById(any());
         assertNull(captor.getValue().getParent());
+    }
+
+    @Test
+    void detailedResponseUsesActualItemNames() {
+        CharacterClass characterClass = new CharacterClass();
+        characterClass.setUrl("bard");
+
+        var renamed = new ClassEquipmentItemDto("dagger", "Название на момент сохранения", 2, null);
+        var missing = new ClassEquipmentItemDto("lost-item", "Снимок", 1, null);
+        ClassDetailedResponse response = new ClassDetailedResponse();
+        response.setStartingEquipment(List.of(
+                new ClassEquipmentOptionDto("А", List.of(renamed, missing), 15, "зм")
+        ));
+
+        List<ItemNameRef> found = List.of(itemName("dagger", "Кинжал"));
+
+        when(classRepository.findById("bard")).thenReturn(Optional.of(characterClass));
+        when(classMapper.toDetailedResponse(characterClass)).thenReturn(response);
+        when(itemRepository.findNamesByUrls(Set.of("dagger", "lost-item"))).thenReturn(found);
+
+        var items = service.findDetailedByUrl("bard").getStartingEquipment().getFirst().getItems();
+
+        assertEquals("Кинжал", items.getFirst().getName());
+        // Предмета уже нет в справочнике — остаётся название из снимка.
+        assertEquals("Снимок", items.get(1).getName());
+    }
+
+    private ItemNameRef itemName(String url, String name) {
+        ItemNameRef ref = mock(ItemNameRef.class);
+        when(ref.getUrl()).thenReturn(url);
+        when(ref.getName()).thenReturn(name);
+        return ref;
     }
 }


### PR DESCRIPTION
Снаряжение класса теперь задаётся вариантами выбора: каждый вариант — список предметов с количеством и текстовым уточнением плюс сумма монет. Хранится в jsonb-колонке class.starting_equipment рядом с прежним markdown-описанием, которое осталось без изменений.

Метка варианта («А», «Б», …) выводится из порядка и в базе не хранится. Названия предметов подставляются из справочника при отдаче ответа, сохранённый снимок названия остаётся запасным для удалённых предметов. Форма редактора получает два пустых варианта, если снаряжение ещё не заполнено; пустые варианты и предметы при сохранении отбрасываются. Подкласс без своего снаряжения наследует его от родителя.