### PR TITLE
feat(character-sheet): расширенные лимиты листов по действующей подписке

### DIFF
--- a/src/main/java/club/ttg/dnd5/domain/subscription/client/SubscriptionStatusClient.java
+++ b/src/main/java/club/ttg/dnd5/domain/subscription/client/SubscriptionStatusClient.java
@@ -1,0 +1,86 @@
+package club.ttg.dnd5.domain.subscription.client;
+
+import club.ttg.dnd5.config.properties.InternalServiceProperties;
+import club.ttg.dnd5.security.InternalServiceTokenFilter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * Статус подписки пользователя из subscriber-service: домен подписок вынесен туда целиком,
+ * в core-api своей таблицы подписок нет.
+ * <p>
+ * Проверять подписку нужно именно здесь, а не по роли {@code SUBSCRIBER} из токена: роль
+ * кэшируется в JWT и живёт до перелогина, поэтому истёкшая подписка продолжала бы открывать
+ * платные возможности.
+ * <p>
+ * Недоступность сервиса (таймаут, не-2xx, пустое тело) — это {@code Optional.empty()}, а не
+ * «подписки нет»: вызывающий сам решает, чем обернуть неизвестный статус. Для выдачи платных
+ * возможностей это отказ (fail-closed), а для необратимых операций вроде вытеснения истории —
+ * повод считать пользователя подписчиком, чтобы чужой сбой не стоил ему данных.
+ */
+@Slf4j
+@Component
+public class SubscriptionStatusClient {
+
+    private final InternalServiceProperties internalProperties;
+    private final RestClient restClient;
+
+    public SubscriptionStatusClient(InternalServiceProperties internalProperties,
+                                    RestClient subscriberServiceRestClient) {
+        this.internalProperties = internalProperties;
+        this.restClient = subscriberServiceRestClient;
+    }
+
+    /**
+     * Реал-тайм статус подписки. Идентификатор пользователя в subscriber-service — его username.
+     *
+     * @return статус или {@code Optional.empty()}, если subscriber-service не ответил
+     */
+    public Optional<SubscriptionStatus> status(String username) {
+        if (!StringUtils.hasText(username)) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.ofNullable(restClient.get()
+                    .uri("/api/internal/subscriptions/{username}/status", username)
+                    .headers(this::addServiceHeaders)
+                    .retrieve()
+                    .body(SubscriptionStatus.class));
+        } catch (RestClientException ex) {
+            log.warn("Не удалось получить статус подписки {} из subscriber-service", username, ex);
+            return Optional.empty();
+        }
+    }
+
+    private void addServiceHeaders(HttpHeaders headers) {
+        String secret = internalProperties.getServiceSecret();
+        if (secret != null && !secret.isBlank()) {
+            headers.set(InternalServiceTokenFilter.SERVICE_TOKEN_HEADER, secret);
+        }
+    }
+
+    /**
+     * Ответ subscriber-service.
+     *
+     * @param active     подписка действует прямо сейчас: активирована ({@code startsAt} проставлен)
+     *                   и срок ещё не истёк
+     * @param registered есть хоть какая-то подписка, в том числе не активированная
+     * @param expiresAt  когда заканчивается действующая подписка ({@code null}, если её нет)
+     * @param startsAt   когда активирована действующая подписка ({@code null}, если её нет)
+     * @param type       тип действующей подписки ({@code null}, если её нет)
+     */
+    public record SubscriptionStatus(boolean active, boolean registered,
+                                     Instant expiresAt, Instant startsAt, String type) {
+        /** Статус «подписки нет»: им подменяется неизвестный статус там, где нужен fail-closed. */
+        public static SubscriptionStatus denied() {
+            return new SubscriptionStatus(false, false, null, null, null);
+        }
+    }
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/controller/CharacterSheetController.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/controller/CharacterSheetController.java
@@ -42,8 +42,8 @@ public class CharacterSheetController {
 
     private final CharacterSheetService sheetService;
 
-    @Operation(summary = "Создание листа: до 8 активных на пользователя (лимит вернёт 400); "
-            + "data — лист целиком, обязателен")
+    @Operation(summary = "Создание листа: до 8 активных на пользователя, до 20 при действующей "
+            + "подписке (лимит вернёт 400); data — лист целиком, обязателен")
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
     public CharacterSheetResponse create(@RequestBody @Valid final CharacterSheetRequest request) {
@@ -72,8 +72,8 @@ public class CharacterSheetController {
         return sheetService.update(id, request);
     }
 
-    @Operation(summary = "Мягкое удаление: лист уходит в историю (хранятся последние 20 удалённых) "
-            + "и может быть восстановлен")
+    @Operation(summary = "Мягкое удаление: лист уходит в историю (хранятся последние 20 удалённых, "
+            + "30 при действующей подписке) и может быть восстановлен")
     @DeleteMapping("/{id}")
     public void delete(@PathVariable final UUID id) {
         sheetService.delete(id);

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/controller/CharacterSheetSavedController.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/controller/CharacterSheetSavedController.java
@@ -41,7 +41,8 @@ public class CharacterSheetSavedController {
         return savedSheetService.findMine();
     }
 
-    @Operation(summary = "Сохранение чужого листа по токену ссылки: до 16 записей (лимит вернёт 400). "
+    @Operation(summary = "Сохранение чужого листа по токену ссылки: до 16 записей, до 40 при "
+            + "действующей подписке (лимит вернёт 400). "
             + "Повторное сохранение того же листа обновляет ссылку, свой лист — 400")
     @PostMapping
     public SavedCharacterSheetResponse save(@RequestBody @Valid final SavedCharacterSheetRequest request) {

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/dto/CharacterSheetListResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/dto/CharacterSheetListResponse.java
@@ -14,11 +14,19 @@ import java.util.List;
 @Setter
 public class CharacterSheetListResponse {
 
-    @Schema(description = "Максимум активных листов у пользователя (в будущем зависит от подписки)")
+    @Schema(description = "Максимум активных листов у пользователя: 8, при действующей подписке — 20")
     private int limit;
 
-    @Schema(description = "Максимум удалённых листов в истории: более старые вытесняются новыми удалениями")
+    @Schema(description = "Максимум активных листов, который даёт подписка. Равен limit, если "
+            + "подписка уже действует — по этому равенству клиент и понимает, предлагать ли её")
+    private int subscriberLimit;
+
+    @Schema(description = "Максимум удалённых листов в истории (20, при действующей подписке — 30): "
+            + "более старые вытесняются новыми удалениями")
     private int historyLimit;
+
+    @Schema(description = "Глубина истории удалённых, которую даёт подписка")
+    private int subscriberHistoryLimit;
 
     @Schema(description = "Текущее число активных (неудалённых) листов")
     private int count;

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/dto/SavedCharacterSheetListResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/rest/dto/SavedCharacterSheetListResponse.java
@@ -14,8 +14,13 @@ import java.util.List;
 @Setter
 public class SavedCharacterSheetListResponse {
 
-    @Schema(description = "Максимум сохранённых чужих листов у пользователя (в будущем зависит от подписки)")
+    @Schema(description = "Максимум сохранённых чужих листов у пользователя: 16, "
+            + "при действующей подписке — 40")
     private int limit;
+
+    @Schema(description = "Максимум сохранённых чужих листов, который даёт подписка. Равен limit, "
+            + "если подписка уже действует — по этому равенству клиент и понимает, предлагать ли её")
+    private int subscriberLimit;
 
     @Schema(description = "Текущее число сохранённых записей, включая ставшие недоступными")
     private int count;

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/service/CharacterSheetLimits.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/service/CharacterSheetLimits.java
@@ -1,0 +1,61 @@
+package club.ttg.dnd5.domain.tool.sheet.service;
+
+import club.ttg.dnd5.domain.subscription.client.SubscriptionStatusClient;
+import club.ttg.dnd5.domain.subscription.client.SubscriptionStatusClient.SubscriptionStatus;
+import club.ttg.dnd5.domain.user.model.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/**
+ * Считает лимиты листов персонажей: базовые для всех и расширенные для тех, у кого подписка
+ * действует прямо сейчас (активирована и не истекла). Единственное место, где живёт таблица
+ * лимитов, — своими и сохранёнными листами заведуют разные сервисы, но лимит у них общий по
+ * происхождению.
+ * <p>
+ * Статус подписки берётся из subscriber-service на каждую операцию, а не из роли в токене:
+ * роль в JWT живёт до перелогина, поэтому истёкшая подписка ещё долго держала бы расширенный
+ * лимит. Недоступность сервиса — не подписка (fail-closed): расширенный лимит не выдаётся,
+ * уже созданные сверх базового лимита листы при этом никуда не деваются, просто нельзя
+ * создать новый до восстановления связи.
+ */
+@RequiredArgsConstructor
+@Component
+public class CharacterSheetLimits {
+
+    /** Лимиты пользователя без действующей подписки. */
+    private static final SheetLimits BASE = new SheetLimits(8, 16, 20, 20);
+
+    /** Лимиты по действующей подписке. */
+    private static final SheetLimits SUBSCRIBER = new SheetLimits(20, 40, 30, 30);
+
+    private final SubscriptionStatusClient subscriptionStatusClient;
+
+    /**
+     * Лимиты пользователя. Один поход в subscriber-service на вызов — результат забирается целиком
+     * и раздаётся всем лимитам операции.
+     */
+    public SheetLimits forUser(User user) {
+        Optional<SubscriptionStatus> status = subscriptionStatusClient.status(user.getUsername());
+        if (status.map(SubscriptionStatus::active).orElse(false)) {
+            return SUBSCRIBER;
+        }
+        if (status.isEmpty()) {
+            // Статус неизвестен: платные лимиты наугад не выдаём, но историю бережём по максимуму —
+            // вытеснение необратимо, а сбой subscriber-service не должен стоить подписчику листов.
+            return new SheetLimits(BASE.activeSheets(), BASE.savedSheets(), BASE.deletedHistory(),
+                    SUBSCRIBER.deletedHistory());
+        }
+        return BASE;
+    }
+
+    /**
+     * Лимиты, которые даёт подписка, — независимо от того, есть ли она у пользователя. Клиент
+     * показывает их подсказкой «с подпиской доступно больше», поэтому числа отдаёт сервер:
+     * на клиенте они не хардкодятся.
+     */
+    public SheetLimits subscriberLimits() {
+        return SUBSCRIBER;
+    }
+}

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/service/CharacterSheetService.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/service/CharacterSheetService.java
@@ -36,23 +36,25 @@ public class CharacterSheetService {
      */
     static final String SHARED_NOT_FOUND_MESSAGE = "Лист персонажа по этой ссылке не найден";
 
-    private static final int MAX_ACTIVE_SHEETS = 8;
-    private static final int MAX_DELETED_HISTORY_PER_USER = 20;
     private static final String DEFAULT_NAME = "Новый персонаж";
 
     private final CharacterSheetRepository sheetRepository;
     private final CharacterSheetMapper sheetMapper;
+    private final CharacterSheetLimits sheetLimits;
 
     /**
-     * Создаёт лист. Лимит — {@link #getLimitFor(User)} активных листов; документ обязателен.
+     * Создаёт лист. Лимит активных листов зависит от подписки ({@link CharacterSheetLimits});
+     * документ обязателен.
      */
     @Transactional
     public CharacterSheetResponse create(CharacterSheetRequest request) {
         User user = SecurityUtils.getUser();
-        validateLimit(user);
+        // Тело проверяем до лимита: лимит стоит похода в subscriber-service, а пустой запрос
+        // отвергается и без него.
         if (request == null || request.getData() == null || request.getData().isNull()) {
             throw new ApiException(HttpStatus.BAD_REQUEST, "Не переданы данные листа персонажа (data)");
         }
+        validateLimit(user, sheetLimits.forUser(user).activeSheets());
         CharacterSheet sheet = new CharacterSheet();
         sheet.setUserId(user.getUuid());
         sheet.setName(nameOrDefault(request));
@@ -66,14 +68,20 @@ public class CharacterSheetService {
      * на клиенте). {@code includeDeleted=true} — вместе с историей удалённых (без документа).
      * Глубина истории отдаётся тем же ответом: сколько удалённых листов ещё можно восстановить,
      * клиенту иначе неоткуда узнать.
+     * <p>
+     * Рядом с выданными лимитами уходят и лимиты подписки: по разнице клиент понимает, стоит ли
+     * предлагать её, и не хардкодит числа у себя.
      */
     public CharacterSheetListResponse findMine(boolean includeDeleted) {
         User user = SecurityUtils.getUser();
+        SheetLimits limits = sheetLimits.forUser(user);
+        SheetLimits subscriberLimits = sheetLimits.subscriberLimits();
         List<CharacterSheet> sheets = includeDeleted
                 ? sheetRepository.findAllByUserIdOrderByCreatedAtDesc(user.getUuid())
                 : sheetRepository.findAllByUserIdAndDeletedFalseOrderByCreatedAtDesc(user.getUuid());
         long activeCount = sheets.stream().filter(sheet -> !sheet.isDeleted()).count();
-        return new CharacterSheetListResponse(getLimitFor(user), MAX_DELETED_HISTORY_PER_USER,
+        return new CharacterSheetListResponse(limits.activeSheets(), subscriberLimits.activeSheets(),
+                limits.deletedHistory(), subscriberLimits.deletedHistory(),
                 (int) activeCount, sheetMapper.toListItemResponseList(sheets));
     }
 
@@ -98,14 +106,15 @@ public class CharacterSheetService {
 
     /**
      * Мягкое удаление: лист скрыт из активных, документ сохраняется — восстановление без потерь.
-     * История ограничивается последними {@value MAX_DELETED_HISTORY_PER_USER} удалёнными листами —
-     * иначе цикл «создать → удалить» рос бы в БД без ограничений: лимит активных удалённые не считает.
+     * История ограничивается последними удалёнными листами (глубина зависит от подписки) — иначе
+     * цикл «создать → удалить» рос бы в БД без ограничений: лимит активных удалённые не считает.
      */
     @Transactional
     public void delete(UUID sheetId) {
+        User user = SecurityUtils.getUser();
         CharacterSheet sheet = getOwnedActive(sheetId);
         sheet.setDeleted(true);
-        trimDeletedHistory(sheet.getUserId());
+        trimDeletedHistory(user);
     }
 
     /**
@@ -122,7 +131,7 @@ public class CharacterSheetService {
         if (!sheet.isDeleted()) {
             throw new ApiException(HttpStatus.BAD_REQUEST, "Лист персонажа не удалён");
         }
-        validateLimit(user);
+        validateLimit(user, sheetLimits.forUser(user).activeSheets());
         sheet.setDeleted(false);
         return sheetMapper.toResponse(sheet);
     }
@@ -179,26 +188,25 @@ public class CharacterSheetService {
         }
     }
 
-    /**
-     * Лимит активных листов пользователя. Пока константа; с появлением подписок здесь появится
-     * расчёт по уровню подписки пользователя.
-     */
-    private int getLimitFor(User user) {
-        return MAX_ACTIVE_SHEETS;
-    }
-
-    private void validateLimit(User user) {
-        int limit = getLimitFor(user);
+    private void validateLimit(User user, int limit) {
         if (sheetRepository.countByUserIdAndDeletedFalse(user.getUuid()) >= limit) {
             throw new ApiException(HttpStatus.BAD_REQUEST, String.format(
                     "Достигнут лимит листов персонажей: %d. Удалите один из существующих", limit));
         }
     }
 
-    private void trimDeletedHistory(UUID userId) {
-        List<CharacterSheet> deleted = sheetRepository.findAllByUserIdAndDeletedTrueOrderByUpdatedAtDesc(userId);
-        if (deleted.size() > MAX_DELETED_HISTORY_PER_USER) {
-            sheetRepository.deleteAll(deleted.subList(MAX_DELETED_HISTORY_PER_USER, deleted.size()));
+    /**
+     * Вытесняет из истории самые старые удалённые листы. Подрезаем по
+     * {@link SheetLimits#deletedHistoryToTrim()}, а не по показанной клиенту глубине: удаление
+     * здесь физическое и необратимое, поэтому при неизвестном статусе подписки история сохраняется
+     * по максимуму.
+     */
+    private void trimDeletedHistory(User user) {
+        int keep = sheetLimits.forUser(user).deletedHistoryToTrim();
+        List<CharacterSheet> deleted = sheetRepository
+                .findAllByUserIdAndDeletedTrueOrderByUpdatedAtDesc(user.getUuid());
+        if (deleted.size() > keep) {
+            sheetRepository.deleteAll(deleted.subList(keep, deleted.size()));
         }
     }
 

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/service/SavedCharacterSheetService.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/service/SavedCharacterSheetService.java
@@ -30,11 +30,11 @@ import java.util.stream.Collectors;
 @Service
 public class SavedCharacterSheetService {
 
-    private static final int MAX_SAVED_SHEETS = 16;
     private static final String NOT_FOUND_MESSAGE = "Сохранённый лист персонажа не найден";
 
     private final SavedCharacterSheetRepository savedRepository;
     private final CharacterSheetRepository sheetRepository;
+    private final CharacterSheetLimits sheetLimits;
 
     /**
      * Сохранённые ссылки пользователя, новые первее, с лимитом и числом записей (для «N из M»
@@ -51,7 +51,8 @@ public class SavedCharacterSheetService {
         List<SavedCharacterSheetResponse> responses = saved.stream()
                 .map(savedSheet -> toResponse(savedSheet, sheets.get(savedSheet.getSheetId())))
                 .toList();
-        return new SavedCharacterSheetListResponse(getSavedLimitFor(user), responses.size(), responses);
+        return new SavedCharacterSheetListResponse(sheetLimits.forUser(user).savedSheets(),
+                sheetLimits.subscriberLimits().savedSheets(), responses.size(), responses);
     }
 
     /**
@@ -90,16 +91,8 @@ public class SavedCharacterSheetService {
         savedRepository.delete(savedSheet);
     }
 
-    /**
-     * Лимит сохранённых чужих листов. Пока константа; с появлением подписок здесь появится
-     * расчёт по уровню подписки пользователя — как и у лимита своих листов.
-     */
-    private int getSavedLimitFor(User user) {
-        return MAX_SAVED_SHEETS;
-    }
-
     private void validateLimit(User user) {
-        int limit = getSavedLimitFor(user);
+        int limit = sheetLimits.forUser(user).savedSheets();
         if (savedRepository.countByUserId(user.getUuid()) >= limit) {
             throw new ApiException(HttpStatus.BAD_REQUEST, String.format(
                     "Достигнут лимит сохранённых листов: %d. Уберите один из сохранённых", limit));

--- a/src/main/java/club/ttg/dnd5/domain/tool/sheet/service/SheetLimits.java
+++ b/src/main/java/club/ttg/dnd5/domain/tool/sheet/service/SheetLimits.java
@@ -1,0 +1,18 @@
+package club.ttg.dnd5.domain.tool.sheet.service;
+
+/**
+ * Лимиты листов персонажей одного пользователя, посчитанные разом: подписка спрашивается
+ * у subscriber-service один раз на операцию, а не по разу на каждый лимит.
+ *
+ * @param activeSheets         максимум активных (неудалённых) листов
+ * @param savedSheets          максимум чужих листов, сохранённых по ссылке
+ * @param deletedHistory       глубина истории удалённых листов — её видит клиент
+ * @param deletedHistoryToTrim глубина, по которую история подрезается при удалении листа.
+ *                             Отличается от {@code deletedHistory} только когда статус подписки
+ *                             неизвестен: вытеснение стирает листы безвозвратно, поэтому при
+ *                             недоступном subscriber-service подрезаем по лимиту подписчика —
+ *                             чужой сбой не должен стоить пользователю истории. Показываем при
+ *                             этом базовую глубину: выдавать платный лимит наугад нельзя.
+ */
+public record SheetLimits(int activeSheets, int savedSheets, int deletedHistory, int deletedHistoryToTrim) {
+}

--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgAccessService.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgAccessService.java
@@ -1,25 +1,21 @@
 package club.ttg.dnd5.domain.vttg.service;
 
-import club.ttg.dnd5.config.properties.InternalServiceProperties;
+import club.ttg.dnd5.domain.subscription.client.SubscriptionStatusClient;
+import club.ttg.dnd5.domain.subscription.client.SubscriptionStatusClient.SubscriptionStatus;
 import club.ttg.dnd5.exception.ApiException;
-import club.ttg.dnd5.security.InternalServiceTokenFilter;
 import club.ttg.dnd5.security.SecurityUtils;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestClient;
-import org.springframework.web.client.RestClientException;
-
-import java.time.Instant;
 
 /**
  * Решает, какой объём контента отдавать на экспорт VTTG: весь ({@code srdOnly = false})
  * или только SRD ({@code srdOnly = true}). Вычисляется на каждый запрос.
  * <p>
- * Статус подписки берётся из subscriber-service (домен подписок вынесен в отдельный
- * сервис). Полноту контента определяем по факту <b>действующей подписки</b>, а НЕ по
- * роли {@code SUBSCRIBER} из токена: роль кэшируется в JWT и остаётся до перелогина.
+ * Статус подписки берётся из subscriber-service (см. {@link SubscriptionStatusClient}).
+ * Полноту контента определяем по факту <b>действующей подписки</b>, а НЕ по роли
+ * {@code SUBSCRIBER} из токена: роль кэшируется в JWT и остаётся до перелогина.
  * Если бы доступ зависел от роли, истёкшая подписка всё равно открывала бы весь контент.
  * <p>
  * Fail-closed: при любой ошибке вызова subscriber-service (недоступен/таймаут/не-2xx)
@@ -28,16 +24,10 @@ import java.time.Instant;
  * поэтому от недоступности subscriber-service не страдает.
  */
 @Slf4j
+@RequiredArgsConstructor
 @Service
 public class VttgAccessService {
-    private final InternalServiceProperties internalProperties;
-    private final RestClient restClient;
-
-    public VttgAccessService(InternalServiceProperties internalProperties,
-                             RestClient subscriberServiceRestClient) {
-        this.internalProperties = internalProperties;
-        this.restClient = subscriberServiceRestClient;
-    }
+    private final SubscriptionStatusClient subscriptionStatusClient;
 
     /**
      * Вычисляет объём контента для текущего пользователя. Админ — всегда полный;
@@ -54,7 +44,8 @@ public class VttgAccessService {
         }
 
         String username = SecurityUtils.getUser().getUsername();
-        SubscriptionStatus status = fetchStatus(username);
+        SubscriptionStatus status = subscriptionStatusClient.status(username)
+                .orElseGet(SubscriptionStatus::denied);
 
         // Подписка действует, только если уже стартовала и срок ещё не истёк — отдаём весь контент.
         if (status.active()) {
@@ -68,43 +59,6 @@ public class VttgAccessService {
         }
 
         return new VttgAccess(true);
-    }
-
-    /**
-     * Запрашивает статус подписки в subscriber-service. Любая ошибка → fail-closed:
-     * {@code active = false, registered = false}.
-     */
-    private SubscriptionStatus fetchStatus(String username) {
-        try {
-            SubscriptionStatus status = restClient.get()
-                    .uri("/api/internal/subscriptions/{username}/status", username)
-                    .headers(this::addServiceHeaders)
-                    .retrieve()
-                    .body(SubscriptionStatus.class);
-
-            return status == null ? SubscriptionStatus.denied() : status;
-        } catch (RestClientException ex) {
-            log.warn("Не удалось получить статус подписки {} из subscriber-service, fail-closed", username, ex);
-            return SubscriptionStatus.denied();
-        }
-    }
-
-    private void addServiceHeaders(HttpHeaders headers) {
-        String secret = internalProperties.getServiceSecret();
-        if (secret != null && !secret.isBlank()) {
-            headers.set(InternalServiceTokenFilter.SERVICE_TOKEN_HEADER, secret);
-        }
-    }
-
-    /**
-     * Ответ subscriber-service. Нас интересуют только {@code active}/{@code registered};
-     * остальные поля контракта десериализуются, но в логике доступа не используются.
-     */
-    public record SubscriptionStatus(boolean active, boolean registered,
-                                     Instant expiresAt, Instant startsAt, String type) {
-        static SubscriptionStatus denied() {
-            return new SubscriptionStatus(false, false, null, null, null);
-        }
     }
 
     /**

--- a/src/test/java/club/ttg/dnd5/domain/tool/sheet/service/CharacterSheetLimitsTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/tool/sheet/service/CharacterSheetLimitsTest.java
@@ -1,0 +1,84 @@
+package club.ttg.dnd5.domain.tool.sheet.service;
+
+import club.ttg.dnd5.domain.subscription.client.SubscriptionStatusClient;
+import club.ttg.dnd5.domain.subscription.client.SubscriptionStatusClient.SubscriptionStatus;
+import club.ttg.dnd5.domain.user.model.User;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Расчёт лимитов по подписке: базовые, расширенные и поведение при недоступном subscriber-service.
+ */
+class CharacterSheetLimitsTest {
+
+    private final SubscriptionStatusClient subscriptionStatusClient = mock(SubscriptionStatusClient.class);
+    private final CharacterSheetLimits limits = new CharacterSheetLimits(subscriptionStatusClient);
+
+    @Test
+    void subscriberLimitsAreReportedRegardlessOfSubscription() {
+        // Ими клиент подсказывает, что даст подписка, поэтому статус тут не спрашивается
+        SheetLimits actual = limits.subscriberLimits();
+
+        assertEquals(20, actual.activeSheets());
+        assertEquals(40, actual.savedSheets());
+        assertEquals(30, actual.deletedHistory());
+        verifyNoInteractions(subscriptionStatusClient);
+    }
+
+    @Test
+    void userWithoutSubscriptionGetsBaseLimits() {
+        User user = user();
+        when(subscriptionStatusClient.status(user.getUsername()))
+                .thenReturn(Optional.of(new SubscriptionStatus(false, true, null, null, null)));
+
+        SheetLimits actual = limits.forUser(user);
+
+        assertEquals(8, actual.activeSheets());
+        assertEquals(16, actual.savedSheets());
+        assertEquals(20, actual.deletedHistory());
+        assertEquals(20, actual.deletedHistoryToTrim());
+    }
+
+    @Test
+    void activeSubscriptionRaisesLimits() {
+        User user = user();
+        when(subscriptionStatusClient.status(user.getUsername()))
+                .thenReturn(Optional.of(new SubscriptionStatus(true, true, null, null, null)));
+
+        SheetLimits actual = limits.forUser(user);
+
+        assertEquals(20, actual.activeSheets());
+        assertEquals(40, actual.savedSheets());
+        assertEquals(30, actual.deletedHistory());
+        assertEquals(30, actual.deletedHistoryToTrim());
+    }
+
+    @Test
+    void unknownStatusKeepsBaseLimitsButSparesHistory() {
+        User user = user();
+        when(subscriptionStatusClient.status(user.getUsername())).thenReturn(Optional.empty());
+
+        SheetLimits actual = limits.forUser(user);
+
+        // Платные лимиты наугад не выдаём...
+        assertEquals(8, actual.activeSheets());
+        assertEquals(16, actual.savedSheets());
+        assertEquals(20, actual.deletedHistory());
+        // ...но вытеснение необратимо, поэтому историю подписчика сбой subscriber-service не стирает
+        assertEquals(30, actual.deletedHistoryToTrim());
+    }
+
+    private static User user() {
+        User user = new User();
+        user.setUuid(UUID.randomUUID());
+        user.setUsername("gimli");
+        return user;
+    }
+}

--- a/src/test/java/club/ttg/dnd5/domain/tool/sheet/service/CharacterSheetServiceTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/tool/sheet/service/CharacterSheetServiceTest.java
@@ -2,7 +2,9 @@ package club.ttg.dnd5.domain.tool.sheet.service;
 
 import club.ttg.dnd5.domain.tool.sheet.model.CharacterSheet;
 import club.ttg.dnd5.domain.tool.sheet.repository.CharacterSheetRepository;
+import club.ttg.dnd5.domain.tool.sheet.rest.dto.CharacterSheetListResponse;
 import club.ttg.dnd5.domain.tool.sheet.rest.dto.CharacterSheetPublicResponse;
+import club.ttg.dnd5.domain.tool.sheet.rest.dto.CharacterSheetRequest;
 import club.ttg.dnd5.domain.tool.sheet.rest.dto.CharacterSheetShareResponse;
 import club.ttg.dnd5.domain.tool.sheet.rest.mapper.CharacterSheetMapper;
 import club.ttg.dnd5.domain.user.model.User;
@@ -10,11 +12,13 @@ import club.ttg.dnd5.exception.ApiException;
 import club.ttg.dnd5.exception.EntityNotFoundException;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -24,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -31,17 +36,104 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Доступ к листу по ссылке: выпуск и отзыв токена владельцем и анонимный просмотр.
+ * Доступ к листу по ссылке (выпуск и отзыв токена владельцем, анонимный просмотр) и лимиты,
+ * зависящие от подписки.
  */
 class CharacterSheetServiceTest {
 
+    private static final SheetLimits FREE_LIMITS = new SheetLimits(8, 16, 20, 20);
+    private static final SheetLimits SUBSCRIBER_LIMITS = new SheetLimits(20, 40, 30, 30);
+
     private final CharacterSheetRepository sheetRepository = mock(CharacterSheetRepository.class);
     private final CharacterSheetMapper sheetMapper = mock(CharacterSheetMapper.class);
-    private final CharacterSheetService service = new CharacterSheetService(sheetRepository, sheetMapper);
+    private final CharacterSheetLimits sheetLimits = mock(CharacterSheetLimits.class);
+    private final CharacterSheetService service =
+            new CharacterSheetService(sheetRepository, sheetMapper, sheetLimits);
+
+    @BeforeEach
+    void withoutSubscriptionByDefault() {
+        when(sheetLimits.forUser(any())).thenReturn(FREE_LIMITS);
+        when(sheetLimits.subscriberLimits()).thenReturn(SUBSCRIBER_LIMITS);
+    }
 
     @AfterEach
     void clearSecurityContext() {
         SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void createOverBaseLimitIsRejected() {
+        UUID owner = authenticate();
+        when(sheetRepository.countByUserIdAndDeletedFalse(owner)).thenReturn(8L);
+
+        ApiException exception = assertThrows(ApiException.class, () -> service.create(request()));
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatus());
+        verify(sheetRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void subscriberCreatesSheetsBeyondBaseLimit() {
+        UUID owner = authenticate();
+        when(sheetLimits.forUser(any())).thenReturn(SUBSCRIBER_LIMITS);
+        when(sheetRepository.countByUserIdAndDeletedFalse(owner)).thenReturn(8L);
+        when(sheetRepository.saveAndFlush(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.create(request());
+
+        verify(sheetRepository).saveAndFlush(any());
+    }
+
+    @Test
+    void findMineReportsSubscriberLimits() {
+        UUID owner = authenticate();
+        when(sheetLimits.forUser(any())).thenReturn(SUBSCRIBER_LIMITS);
+        when(sheetRepository.findAllByUserIdAndDeletedFalseOrderByCreatedAtDesc(owner))
+                .thenReturn(List.of(sheet(owner)));
+
+        CharacterSheetListResponse response = service.findMine(false);
+
+        assertEquals(20, response.getLimit());
+        assertEquals(30, response.getHistoryLimit());
+        assertEquals(1, response.getCount());
+        // Лимит подписчика совпал с выданным — клиенту нечего предлагать
+        assertEquals(response.getLimit(), response.getSubscriberLimit());
+        assertEquals(response.getHistoryLimit(), response.getSubscriberHistoryLimit());
+    }
+
+    @Test
+    void findMineReportsWhatSubscriptionWouldGive() {
+        UUID owner = authenticate();
+        when(sheetRepository.findAllByUserIdAndDeletedFalseOrderByCreatedAtDesc(owner))
+                .thenReturn(List.of(sheet(owner)));
+
+        CharacterSheetListResponse response = service.findMine(false);
+
+        // Лимит подписчика выше выданного — клиент покажет подсказку про подписку
+        assertEquals(8, response.getLimit());
+        assertEquals(20, response.getSubscriberLimit());
+        assertEquals(20, response.getHistoryLimit());
+        assertEquals(30, response.getSubscriberHistoryLimit());
+    }
+
+    @Test
+    void deleteTrimsHistoryByTrimDepthSoOutageDoesNotWipeIt() {
+        UUID owner = authenticate();
+        CharacterSheet sheet = sheet(owner);
+        when(sheetRepository.findById(sheet.getId())).thenReturn(Optional.of(sheet));
+        // Статус подписки неизвестен: показываем базовые 20, но подрезаем по 30
+        when(sheetLimits.forUser(any())).thenReturn(new SheetLimits(8, 16, 20, 30));
+        List<CharacterSheet> deleted = new ArrayList<>();
+        for (int i = 0; i < 31; i++) {
+            deleted.add(sheet(owner));
+        }
+        when(sheetRepository.findAllByUserIdAndDeletedTrueOrderByUpdatedAtDesc(owner)).thenReturn(deleted);
+
+        service.delete(sheet.getId());
+
+        assertTrue(sheet.isDeleted());
+        // Вытесняется только самый старый лист — те, что между 20 и 30, остаются
+        verify(sheetRepository).deleteAll(List.of(deleted.getLast()));
     }
 
     @Test
@@ -112,6 +204,12 @@ class CharacterSheetServiceTest {
         assertThrows(EntityNotFoundException.class, () -> service.findShared("  "));
 
         verify(sheetRepository, never()).findByShareTokenAndDeletedFalse(any());
+    }
+
+    private static CharacterSheetRequest request() {
+        CharacterSheetRequest request = new CharacterSheetRequest();
+        request.setData(JsonNodeFactory.instance.objectNode());
+        return request;
     }
 
     private static CharacterSheet sheet(UUID ownerId) {

--- a/src/test/java/club/ttg/dnd5/domain/tool/sheet/service/SavedCharacterSheetServiceTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/tool/sheet/service/SavedCharacterSheetServiceTest.java
@@ -11,6 +11,7 @@ import club.ttg.dnd5.exception.ApiException;
 import club.ttg.dnd5.exception.EntityNotFoundException;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -36,10 +37,20 @@ import static org.mockito.Mockito.when;
  */
 class SavedCharacterSheetServiceTest {
 
+    private static final SheetLimits FREE_LIMITS = new SheetLimits(8, 16, 20, 20);
+    private static final SheetLimits SUBSCRIBER_LIMITS = new SheetLimits(20, 40, 30, 30);
+
     private final SavedCharacterSheetRepository savedRepository = mock(SavedCharacterSheetRepository.class);
     private final CharacterSheetRepository sheetRepository = mock(CharacterSheetRepository.class);
+    private final CharacterSheetLimits sheetLimits = mock(CharacterSheetLimits.class);
     private final SavedCharacterSheetService service =
-            new SavedCharacterSheetService(savedRepository, sheetRepository);
+            new SavedCharacterSheetService(savedRepository, sheetRepository, sheetLimits);
+
+    @BeforeEach
+    void withoutSubscriptionByDefault() {
+        when(sheetLimits.forUser(any())).thenReturn(FREE_LIMITS);
+        when(sheetLimits.subscriberLimits()).thenReturn(SUBSCRIBER_LIMITS);
+    }
 
     @AfterEach
     void clearSecurityContext() {
@@ -120,6 +131,23 @@ class SavedCharacterSheetServiceTest {
     }
 
     @Test
+    void subscriberSavesBeyondBaseLimit() {
+        UUID viewer = authenticate();
+        CharacterSheet sheet = sharedSheet();
+        when(sheetLimits.forUser(any())).thenReturn(SUBSCRIBER_LIMITS);
+        when(sheetRepository.findByShareTokenAndDeletedFalse(sheet.getShareToken()))
+                .thenReturn(Optional.of(sheet));
+        when(savedRepository.findByUserIdAndSheetId(viewer, sheet.getId())).thenReturn(Optional.empty());
+        when(savedRepository.countByUserId(viewer)).thenReturn(16L);
+        when(savedRepository.saveAndFlush(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        SavedCharacterSheetResponse response = service.save(sheet.getShareToken().toString());
+
+        assertEquals(sheet.getId(), response.getSheetId());
+        verify(savedRepository).saveAndFlush(any());
+    }
+
+    @Test
     void saveWithMalformedTokenIsNotFoundInsteadOfServerError() {
         authenticate();
 
@@ -144,6 +172,8 @@ class SavedCharacterSheetServiceTest {
         SavedCharacterSheetListResponse response = service.findMine();
 
         assertEquals(16, response.getLimit());
+        // Лимит подписчика выше выданного — клиент покажет подсказку про подписку
+        assertEquals(40, response.getSubscriberLimit());
         assertEquals(2, response.getCount());
         SavedCharacterSheetResponse first = response.getSheets().getFirst();
         assertFalse(first.isAvailable());

--- a/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgAccessServiceTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgAccessServiceTest.java
@@ -1,6 +1,7 @@
 package club.ttg.dnd5.domain.vttg.service;
 
 import club.ttg.dnd5.config.properties.InternalServiceProperties;
+import club.ttg.dnd5.domain.subscription.client.SubscriptionStatusClient;
 import club.ttg.dnd5.domain.user.model.Role;
 import club.ttg.dnd5.domain.user.model.User;
 import club.ttg.dnd5.exception.ApiException;
@@ -44,7 +45,7 @@ class VttgAccessServiceTest {
         InternalServiceProperties internalProperties = new InternalServiceProperties();
         internalProperties.setServiceSecret(SECRET);
 
-        service = new VttgAccessService(internalProperties, restClient);
+        service = new VttgAccessService(new SubscriptionStatusClient(internalProperties, restClient));
     }
 
     @AfterEach


### PR DESCRIPTION
Лимиты листов персонажей теперь зависят от подписки: 20 активных листов вместо 8, 40 чужих листов по ссылке вместо 16 и 30 удалённых в истории вместо 20.

Статус подписки берётся из subscriber-service
(GET /api/internal/subscriptions/{username}/status), а не из роли SUBSCRIBER в токене: роль кэшируется в JWT до перелогина, поэтому истёкшая подписка продолжала бы держать расширенный лимит.

- SubscriptionStatusClient: общий клиент статуса подписки. Недоступность сервиса отдаётся как Optional.empty() — «неизвестно» и «подписки нет» разные вещи, решение принимает вызывающий
- VttgAccessService переведён на этот клиент, дублирующий HTTP-код удалён; поведение fail-closed прежнее
- CharacterSheetLimits и SheetLimits: единственное место с таблицей лимитов, один запрос статуса на операцию
- выдача лимитов fail-closed: при недоступном subscriber-service лимиты остаются базовыми, уже созданные сверх них листы не страдают
- вытеснение истории, наоборот, подрезается по лимиту подписчика: удаление здесь физическое, и сбой стороннего сервиса не должен стоить подписчику части истории
- в ответы списков добавлены subscriberLimit и subscriberHistoryLimit: по разнице с выданным лимитом клиент показывает подсказку про подписку и не хардкодит числа у себя
- тело запроса при создании листа проверяется до похода за лимитом