### PR TITLE
feat(background): структурное стартовое снаряжение предысторий

### DIFF
--- a/src/main/java/club/ttg/dnd5/domain/background/model/Background.java
+++ b/src/main/java/club/ttg/dnd5/domain/background/model/Background.java
@@ -3,6 +3,7 @@ package club.ttg.dnd5.domain.background.model;
 import club.ttg.dnd5.domain.source.model.Source;
 import club.ttg.dnd5.domain.common.dictionary.Ability;
 import club.ttg.dnd5.domain.common.dictionary.Skill;
+import club.ttg.dnd5.domain.common.model.EquipmentOption;
 import club.ttg.dnd5.domain.common.model.NamedEntity;
 import club.ttg.dnd5.domain.feat.model.Feat;
 import io.hypersistence.utils.hibernate.type.json.JsonType;
@@ -12,6 +13,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.Type;
 
+import java.util.List;
 import java.util.Set;
 
 @Getter
@@ -51,6 +53,13 @@ public class Background extends NamedEntity {
     private String toolProficiency;
     /** Снаряжение */
     private String equipment;
+
+    /**
+     * Стартовое снаряжение вариантами выбора: «А» — предметы, «Б» — монеты и т.д.
+     */
+    @Type(JsonType.class)
+    @Column(columnDefinition = "jsonb", name = "starting_equipment")
+    private List<EquipmentOption> startingEquipment;
     /** Предлагаемый класс */
     private String proposeClasses;
 

--- a/src/main/java/club/ttg/dnd5/domain/background/rest/dto/BackgroundDetailResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/background/rest/dto/BackgroundDetailResponse.java
@@ -1,11 +1,14 @@
 package club.ttg.dnd5.domain.background.rest.dto;
 
 import club.ttg.dnd5.domain.common.rest.dto.BaseResponse;
+import club.ttg.dnd5.domain.common.rest.dto.EquipmentOptionDto;
 import club.ttg.dnd5.dto.base.serializer.MarkupDescriptionSerializer;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
+
+import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 
@@ -26,4 +29,6 @@ public class BackgroundDetailResponse extends BaseResponse {
     @JsonSerialize(using = MarkupDescriptionSerializer.class)
     @Schema(description = "Снаряжение")
     private String equipment;
+    @Schema(description = "Стартовое снаряжение вариантами выбора")
+    private List<EquipmentOptionDto> startingEquipment;
 }

--- a/src/main/java/club/ttg/dnd5/domain/background/rest/dto/BackgroundRequest.java
+++ b/src/main/java/club/ttg/dnd5/domain/background/rest/dto/BackgroundRequest.java
@@ -2,6 +2,7 @@ package club.ttg.dnd5.domain.background.rest.dto;
 
 import club.ttg.dnd5.domain.common.dictionary.Ability;
 import club.ttg.dnd5.domain.common.dictionary.Skill;
+import club.ttg.dnd5.domain.common.model.EquipmentOption;
 import club.ttg.dnd5.domain.common.rest.dto.BaseRequest;
 import club.ttg.dnd5.dto.base.deserializer.MarkupDescriptionDeserializer;
 import club.ttg.dnd5.dto.base.serializer.FormattedMarkupDescriptionSerializer;
@@ -13,6 +14,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.List;
 import java.util.Set;
 
 @Schema(description = "Предыстория запрос")
@@ -37,4 +39,6 @@ public class BackgroundRequest extends BaseRequest {
     @JsonSerialize(using = FormattedMarkupDescriptionSerializer.class)
     @Schema(description = "Снаряжение")
     private String equipment;
+    @Schema(description = "Стартовое снаряжение вариантами выбора: предметы с количеством и монеты")
+    private List<EquipmentOption> startingEquipment;
 }

--- a/src/main/java/club/ttg/dnd5/domain/background/rest/mapper/BackgroundMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/background/rest/mapper/BackgroundMapper.java
@@ -8,8 +8,10 @@ import club.ttg.dnd5.domain.background.rest.dto.BackgroundShortResponse;
 import club.ttg.dnd5.domain.source.model.Source;
 import club.ttg.dnd5.domain.common.dictionary.Ability;
 import club.ttg.dnd5.domain.common.dictionary.Skill;
+import club.ttg.dnd5.domain.common.rest.mapper.EquipmentMapping;
 import club.ttg.dnd5.domain.feat.model.Feat;
 import club.ttg.dnd5.dto.base.mapping.BaseMapping;
+import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
@@ -22,7 +24,10 @@ import java.util.stream.Collectors;
 
 import org.mapstruct.ReportingPolicy;
 
-@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE, componentModel = "spring")
+@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE,
+        uses = {EquipmentMapping.class},
+        componentModel = "spring",
+        injectionStrategy = InjectionStrategy.CONSTRUCTOR)
 public interface BackgroundMapper {
     @BaseMapping.BaseShortResponseNameMapping
     @BaseMapping.BaseSourceMapping
@@ -34,6 +39,7 @@ public interface BackgroundMapper {
     @Mapping(source = ".", target = "feat", qualifiedByName = "featToMarkup")
     @Mapping(source = "abilities", target = "abilityScores", qualifiedByName = "abilitiesToString")
     @Mapping(source = "skillProficiencies", target = "skillProficiencies", qualifiedByName = "skillsToString")
+    @Mapping(source = "startingEquipment", target = "startingEquipment", qualifiedByName = "toEquipmentOptionDtos")
     BackgroundDetailResponse toDetail(Background background);
 
     @BaseMapping.BaseShortResponseNameMapping
@@ -42,6 +48,7 @@ public interface BackgroundMapper {
     @Mapping(source = "skillProficiencies", target = "skillsProficiencies")
     @Mapping(source = "source.url", target = "source.url")
     @Mapping(source = "sourcePage", target = "source.page")
+    @Mapping(source = "startingEquipment", target = "startingEquipment", qualifiedByName = "toEquipmentForm")
     BackgroundRequest toRequest(Background background);
 
     @BaseMapping.BaseShortResponseNameMapping
@@ -62,6 +69,7 @@ public interface BackgroundMapper {
     @Mapping(source = "request.srdVersion", target = "srdVersion")
     @Mapping(source = "feat", target = "feat")
     @Mapping(source = "source", target = "source")
+    @Mapping(source = "request.startingEquipment", target = "startingEquipment", qualifiedByName = "toEquipmentEntities")
     Background toEntity(BackgroundRequest request, Feat feat, Source source);
 
     @BaseMapping.BaseEntityNameMapping
@@ -75,6 +83,7 @@ public interface BackgroundMapper {
     @Mapping(source = "request.srdVersion", target = "srdVersion")
     @Mapping(source = "feat", target = "feat")
     @Mapping(source = "source", target = "source")
+    @Mapping(source = "request.startingEquipment", target = "startingEquipment", qualifiedByName = "toEquipmentEntities")
     void updateEntity(BackgroundRequest request, Feat feat, Source source, @MappingTarget Background background);
 
     @Named("featToMarkup")

--- a/src/main/java/club/ttg/dnd5/domain/background/service/BackgroundServiceImpl.java
+++ b/src/main/java/club/ttg/dnd5/domain/background/service/BackgroundServiceImpl.java
@@ -10,6 +10,7 @@ import club.ttg.dnd5.domain.background.rest.mapper.BackgroundMapper;
 import club.ttg.dnd5.domain.source.service.SourceService;
 import club.ttg.dnd5.domain.feat.model.Feat;
 import club.ttg.dnd5.domain.feat.repository.FeatRepository;
+import club.ttg.dnd5.domain.item.service.EquipmentNameResolver;
 import club.ttg.dnd5.domain.revision.model.RevisionOperation;
 import club.ttg.dnd5.domain.revision.service.EntityRevisionService;
 import club.ttg.dnd5.exception.EntityExistException;
@@ -36,11 +37,14 @@ public class BackgroundServiceImpl implements BackgroundService {
     private final SourceService sourceService;
     private final BackgroundMapper backgroundMapper;
     private final EntityRevisionService revisionService;
+    private final EquipmentNameResolver equipmentNameResolver;
 
 
     @Override
     public BackgroundDetailResponse getBackground(final String backgroundUrl) {
-        return backgroundMapper.toDetail(findByUrl(backgroundUrl));
+        BackgroundDetailResponse response = backgroundMapper.toDetail(findByUrl(backgroundUrl));
+        equipmentNameResolver.resolveNames(response.getStartingEquipment());
+        return response;
     }
 
 
@@ -137,7 +141,9 @@ public class BackgroundServiceImpl implements BackgroundService {
     public BackgroundDetailResponse preview(final BackgroundRequest request) {
         var book = sourceService.findByUrl(request.getSource().getUrl());
         var feat = getFeat(request.getFeatUrl());
-        return backgroundMapper.toDetail(backgroundMapper.toEntity(request, feat, book));
+        BackgroundDetailResponse response = backgroundMapper.toDetail(backgroundMapper.toEntity(request, feat, book));
+        equipmentNameResolver.resolveNames(response.getStartingEquipment());
+        return response;
     }
 
     @Override

--- a/src/main/java/club/ttg/dnd5/domain/character_class/model/CharacterClass.java
+++ b/src/main/java/club/ttg/dnd5/domain/character_class/model/CharacterClass.java
@@ -4,6 +4,7 @@ import club.ttg.dnd5.domain.common.dictionary.Delimiter;
 import club.ttg.dnd5.domain.source.model.Source;
 import club.ttg.dnd5.domain.common.dictionary.Ability;
 import club.ttg.dnd5.domain.common.dictionary.Dice;
+import club.ttg.dnd5.domain.common.model.EquipmentOption;
 import club.ttg.dnd5.domain.common.model.NamedEntity;
 import io.hypersistence.utils.hibernate.type.json.JsonType;
 import jakarta.persistence.Column;
@@ -113,7 +114,7 @@ public class CharacterClass extends NamedEntity {
      */
     @Type(JsonType.class)
     @Column(columnDefinition = "jsonb", name = "starting_equipment")
-    private List<ClassEquipmentOption> startingEquipment;
+    private List<EquipmentOption> startingEquipment;
 
     /**
      * Тип заклинателя

--- a/src/main/java/club/ttg/dnd5/domain/character_class/rest/dto/ClassDetailedResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/character_class/rest/dto/ClassDetailedResponse.java
@@ -3,6 +3,7 @@ package club.ttg.dnd5.domain.character_class.rest.dto;
 import club.ttg.dnd5.domain.character_class.model.CasterType;
 import club.ttg.dnd5.domain.character_class.model.ClassTableColumn;
 import club.ttg.dnd5.domain.common.rest.dto.BaseResponse;
+import club.ttg.dnd5.domain.common.rest.dto.EquipmentOptionDto;
 import club.ttg.dnd5.domain.common.rest.dto.select.DiceOptionDto;
 import club.ttg.dnd5.dto.base.serializer.MarkupDescriptionSerializer;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -34,7 +35,7 @@ public class ClassDetailedResponse extends BaseResponse {
     private String equipment;
 
     @Schema(description = "Стартовое снаряжение вариантами выбора")
-    private List<ClassEquipmentOptionDto> startingEquipment;
+    private List<EquipmentOptionDto> startingEquipment;
 
     @Schema(description = "Спасброски класса")
     private String savingThrows;

--- a/src/main/java/club/ttg/dnd5/domain/character_class/rest/dto/ClassRequest.java
+++ b/src/main/java/club/ttg/dnd5/domain/character_class/rest/dto/ClassRequest.java
@@ -1,7 +1,7 @@
 package club.ttg.dnd5.domain.character_class.rest.dto;
 
 import club.ttg.dnd5.domain.character_class.model.CasterType;
-import club.ttg.dnd5.domain.character_class.model.ClassEquipmentOption;
+import club.ttg.dnd5.domain.common.model.EquipmentOption;
 import club.ttg.dnd5.domain.character_class.model.ClassTableColumn;
 import club.ttg.dnd5.domain.character_class.model.MulticlassProficiency;
 import club.ttg.dnd5.domain.common.dictionary.Ability;
@@ -49,7 +49,7 @@ public class ClassRequest extends BaseRequest {
     private String equipment;
 
     @Schema(description = "Стартовое снаряжение вариантами выбора: предметы с количеством и монеты")
-    private List<ClassEquipmentOption> startingEquipment;
+    private List<EquipmentOption> startingEquipment;
 
     @Schema(description = "Особенности класса")
     private List<ClassFeatureRequest> features;

--- a/src/main/java/club/ttg/dnd5/domain/character_class/rest/mapper/ClassMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/character_class/rest/mapper/ClassMapper.java
@@ -4,11 +4,11 @@ import club.ttg.dnd5.domain.source.model.Source;
 import club.ttg.dnd5.domain.character_class.model.*;
 import club.ttg.dnd5.domain.character_class.rest.dto.*;
 import club.ttg.dnd5.domain.common.dictionary.Ability;
-import club.ttg.dnd5.domain.common.dictionary.Coin;
 import club.ttg.dnd5.domain.common.dictionary.Delimiter;
 import club.ttg.dnd5.domain.common.dictionary.Dice;
 import club.ttg.dnd5.domain.common.dictionary.WeaponCategory;
 import club.ttg.dnd5.domain.common.rest.dto.select.DiceOptionDto;
+import club.ttg.dnd5.domain.common.rest.mapper.EquipmentMapping;
 import club.ttg.dnd5.dto.base.mapping.BaseMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -29,7 +29,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-@Mapper(unmappedTargetPolicy = ReportingPolicy.ERROR, uses = {BaseMapping.class}, componentModel = "spring")
+@Mapper(unmappedTargetPolicy = ReportingPolicy.ERROR, uses = {BaseMapping.class, EquipmentMapping.class}, componentModel = "spring")
 public interface ClassMapper
 {
     @Named("toShortResponse")
@@ -278,117 +278,6 @@ public interface ClassMapper
                 .flatMap(List::stream)
                 .sorted(Comparator.comparing(ClassFeatureDto::getLevel))
                 .collect(Collectors.toList());
-    }
-
-    /**
-     * Метки вариантов снаряжения — выводятся из порядка вариантов, в базе не хранятся.
-     */
-    String EQUIPMENT_LABELS = "АБВГДЕЖЗИКЛМНОПРСТУФХЦЧШЩЭЮЯ";
-
-    /**
-     * Количество вариантов снаряжения, которые редактор показывает у класса без снаряжения.
-     */
-    int DEFAULT_EQUIPMENT_OPTIONS = 2;
-
-    /**
-     * Варианты снаряжения для формы редактора: если у класса их нет,
-     * отдаём пустые подблоки «А» и «Б», чтобы редактору было что показать.
-     */
-    @Named("toEquipmentForm")
-    default List<ClassEquipmentOption> toEquipmentForm(List<ClassEquipmentOption> options)
-    {
-        if (!CollectionUtils.isEmpty(options))
-        {
-            return options;
-        }
-
-        List<ClassEquipmentOption> defaults = new ArrayList<>(DEFAULT_EQUIPMENT_OPTIONS);
-        for (int index = 0; index < DEFAULT_EQUIPMENT_OPTIONS; index++)
-        {
-            ClassEquipmentOption option = new ClassEquipmentOption();
-            option.setItems(new ArrayList<>());
-            defaults.add(option);
-        }
-
-        return defaults;
-    }
-
-    /**
-     * Варианты снаряжения для сохранения: пустые предметы и пустые подблоки отбрасываются,
-     * чтобы дефолтные подблоки редактора не попадали в базу.
-     */
-    @Named("toEquipmentEntities")
-    default List<ClassEquipmentOption> toEquipmentEntities(List<ClassEquipmentOption> options)
-    {
-        if (CollectionUtils.isEmpty(options))
-        {
-            return null;
-        }
-
-        List<ClassEquipmentOption> cleaned = new ArrayList<>(options.size());
-        for (ClassEquipmentOption option : options)
-        {
-            if (option == null)
-            {
-                continue;
-            }
-
-            option.setItems(cleanEquipmentItems(option.getItems()));
-
-            if (!option.getItems().isEmpty() || option.getCoins() != null)
-            {
-                cleaned.add(option);
-            }
-        }
-
-        return cleaned.isEmpty() ? null : cleaned;
-    }
-
-    private List<ClassEquipmentItem> cleanEquipmentItems(List<ClassEquipmentItem> items)
-    {
-        if (CollectionUtils.isEmpty(items))
-        {
-            return Collections.emptyList();
-        }
-
-        return items.stream()
-                .filter(Objects::nonNull)
-                .filter(item -> StringUtils.hasText(item.getUrl()) || StringUtils.hasText(item.getDescription()))
-                .toList();
-    }
-
-    @Named("toEquipmentOptionDtos")
-    default List<ClassEquipmentOptionDto> toEquipmentOptionDtos(List<ClassEquipmentOption> options)
-    {
-        if (CollectionUtils.isEmpty(options))
-        {
-            return Collections.emptyList();
-        }
-
-        List<ClassEquipmentOptionDto> dtos = new ArrayList<>(options.size());
-        for (int index = 0; index < options.size(); index++)
-        {
-            ClassEquipmentOption option = options.get(index);
-            Coin coin = option.getCoin() == null ? Coin.GC : option.getCoin();
-
-            dtos.add(new ClassEquipmentOptionDto(
-                    equipmentLabel(index),
-                    toEquipmentItemDtos(option.getItems()),
-                    option.getCoins(),
-                    coin.getShortName()
-            ));
-        }
-
-        return dtos;
-    }
-
-    List<ClassEquipmentItemDto> toEquipmentItemDtos(List<ClassEquipmentItem> items);
-
-    default String equipmentLabel(int index)
-    {
-        return index < EQUIPMENT_LABELS.length()
-                ? String.valueOf(EQUIPMENT_LABELS.charAt(index))
-                : String.valueOf(index + 1);
     }
 
     @Named("hasSubclasses")

--- a/src/main/java/club/ttg/dnd5/domain/character_class/service/ClassService.java
+++ b/src/main/java/club/ttg/dnd5/domain/character_class/service/ClassService.java
@@ -10,8 +10,6 @@ import club.ttg.dnd5.domain.character_class.model.CasterType;
 import club.ttg.dnd5.domain.character_class.model.CharacterClass;
 import club.ttg.dnd5.domain.character_class.repository.ClassRepository;
 import club.ttg.dnd5.domain.character_class.rest.dto.ClassDetailedResponse;
-import club.ttg.dnd5.domain.character_class.rest.dto.ClassEquipmentItemDto;
-import club.ttg.dnd5.domain.character_class.rest.dto.ClassEquipmentOptionDto;
 import club.ttg.dnd5.domain.character_class.rest.dto.ClassRequest;
 import club.ttg.dnd5.domain.character_class.rest.dto.ClassShortResponse;
 import club.ttg.dnd5.domain.character_class.rest.mapper.ClassMapper;
@@ -19,8 +17,8 @@ import club.ttg.dnd5.domain.common.model.Gallery;
 import club.ttg.dnd5.domain.common.model.SectionType;
 import club.ttg.dnd5.domain.common.repository.GalleryRepository;
 import club.ttg.dnd5.domain.common.rest.dto.SourceRequest;
-import club.ttg.dnd5.domain.item.repository.ItemNameRef;
-import club.ttg.dnd5.domain.item.repository.ItemRepository;
+import club.ttg.dnd5.domain.common.rest.mapper.EquipmentMapping;
+import club.ttg.dnd5.domain.item.service.EquipmentNameResolver;
 import club.ttg.dnd5.domain.revision.model.RevisionOperation;
 import club.ttg.dnd5.domain.revision.service.EntityRevisionService;
 import club.ttg.dnd5.exception.EntityExistException;
@@ -36,8 +34,7 @@ import org.springframework.util.StringUtils;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -55,7 +52,8 @@ public class ClassService {
     private final GalleryRepository galleryRepository;
     private final SourceSavedFilterService sourceSavedFilterService;
     private final EntityRevisionService revisionService;
-    private final ItemRepository itemRepository;
+    private final EquipmentNameResolver equipmentNameResolver;
+    private final EquipmentMapping equipmentMapping;
 
     public List<ClassShortResponse> search(ClassQueryRequest request) {
         var predicate = ClassPredicateBuilder.build(request);
@@ -109,7 +107,7 @@ public class ClassService {
         revisionService.record(REVISION_ENTITY_TYPE, saved.getUrl(), RevisionOperation.CREATE,
                 findFormByUrl(saved.getUrl()));
         ClassDetailedResponse response = classMapper.toDetailedResponse(saved);
-        resolveEquipmentNames(response.getStartingEquipment());
+        equipmentNameResolver.resolveNames(response.getStartingEquipment());
         return response;
     }
 
@@ -184,7 +182,7 @@ public class ClassService {
         var charClass = findByUrl(url);
         var response = classMapper.toDetailedResponse(charClass);
         fillResponseFieldsFromParentClass(charClass, response);
-        resolveEquipmentNames(response.getStartingEquipment());
+        equipmentNameResolver.resolveNames(response.getStartingEquipment());
         response.setGallery(galleryRepository.findAllByUrlAndType(url, SectionType.CLASS)
                 .stream()
                 .map(Gallery::getImage)
@@ -199,37 +197,6 @@ public class ClassService {
                 .map(Gallery::getImage)
                 .toList());
         return request;
-    }
-
-    /**
-     * Подставляет актуальные названия предметов из справочника: в снаряжении класса хранится
-     * ссылка на предмет и название на момент сохранения, и снимок мог устареть после переименования.
-     * Название из снимка остаётся запасным — для предметов, которых уже нет в справочнике.
-     */
-    private void resolveEquipmentNames(List<ClassEquipmentOptionDto> options) {
-        if (CollectionUtils.isEmpty(options)) {
-            return;
-        }
-
-        List<ClassEquipmentItemDto> items = options.stream()
-                .map(ClassEquipmentOptionDto::getItems)
-                .filter(Objects::nonNull)
-                .flatMap(List::stream)
-                .filter(item -> StringUtils.hasText(item.getUrl()))
-                .toList();
-
-        if (items.isEmpty()) {
-            return;
-        }
-
-        Set<String> urls = items.stream()
-                .map(ClassEquipmentItemDto::getUrl)
-                .collect(Collectors.toSet());
-
-        Map<String, String> names = itemRepository.findNamesByUrls(urls).stream()
-                .collect(Collectors.toMap(ItemNameRef::getUrl, ItemNameRef::getName));
-
-        items.forEach(item -> item.setName(names.getOrDefault(item.getUrl(), item.getName())));
     }
 
     private void fillResponseFieldsFromParentClass(CharacterClass characterClass, ClassDetailedResponse response) {
@@ -255,7 +222,7 @@ public class ClassService {
         }
 
         if (CollectionUtils.isEmpty(response.getStartingEquipment())) {
-            response.setStartingEquipment(classMapper.toEquipmentOptionDtos(parent.getStartingEquipment()));
+            response.setStartingEquipment(equipmentMapping.toEquipmentOptionDtos(parent.getStartingEquipment()));
         }
 
         if (response.getTable() == null) {
@@ -295,7 +262,7 @@ public class ClassService {
         var entity = classMapper.toEntity(request, source);
         entity.setParent(parent);
         var response = classMapper.toDetailedResponse(entity);
-        resolveEquipmentNames(response.getStartingEquipment());
+        equipmentNameResolver.resolveNames(response.getStartingEquipment());
         response.setGallery(galleryRepository.findAllByUrlAndType(response.getUrl(), SectionType.CLASS)
                 .stream()
                 .map(Gallery::getImage)

--- a/src/main/java/club/ttg/dnd5/domain/common/model/EquipmentItem.java
+++ b/src/main/java/club/ttg/dnd5/domain/common/model/EquipmentItem.java
@@ -1,20 +1,25 @@
-package club.ttg.dnd5.domain.character_class.rest.dto;
+package club.ttg.dnd5.domain.common.model;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+/**
+ * Предмет в варианте стартового снаряжения.
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
 @Getter
 @Setter
-@NoArgsConstructor
-@AllArgsConstructor
-public class ClassEquipmentItemDto {
+public class EquipmentItem {
     @Schema(description = "URL предмета", example = "dagger")
     private String url;
 
-    @Schema(description = "Название предмета", example = "Кинжал")
+    @Schema(description = "Название предмета на момент сохранения", example = "Кинжал")
     private String name;
 
     @Schema(description = "Количество предметов", example = "2")

--- a/src/main/java/club/ttg/dnd5/domain/common/model/EquipmentOption.java
+++ b/src/main/java/club/ttg/dnd5/domain/common/model/EquipmentOption.java
@@ -1,4 +1,4 @@
-package club.ttg.dnd5.domain.character_class.model;
+package club.ttg.dnd5.domain.common.model;
 
 import club.ttg.dnd5.domain.common.dictionary.Coin;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -11,7 +11,7 @@ import lombok.Setter;
 import java.util.List;
 
 /**
- * Вариант стартового снаряжения класса — подблок «А», «Б» и т.д.
+ * Вариант стартового снаряжения — подблок «А», «Б» и т.д.
  * Состоит из списка предметов с количеством и суммы монет.
  * Метка варианта не хранится: она выводится из порядка при отдаче ответа.
  */
@@ -20,9 +20,9 @@ import java.util.List;
 @EqualsAndHashCode
 @Getter
 @Setter
-public class ClassEquipmentOption {
+public class EquipmentOption {
     @Schema(description = "Предметы варианта")
-    private List<ClassEquipmentItem> items;
+    private List<EquipmentItem> items;
 
     @Schema(description = "Количество монет", example = "15")
     private Integer coins;

--- a/src/main/java/club/ttg/dnd5/domain/common/rest/dto/EquipmentItemDto.java
+++ b/src/main/java/club/ttg/dnd5/domain/common/rest/dto/EquipmentItemDto.java
@@ -1,25 +1,20 @@
-package club.ttg.dnd5.domain.character_class.model;
+package club.ttg.dnd5.domain.common.rest.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-/**
- * Предмет в варианте стартового снаряжения класса.
- */
-@AllArgsConstructor
-@NoArgsConstructor
-@EqualsAndHashCode
 @Getter
 @Setter
-public class ClassEquipmentItem {
+@NoArgsConstructor
+@AllArgsConstructor
+public class EquipmentItemDto {
     @Schema(description = "URL предмета", example = "dagger")
     private String url;
 
-    @Schema(description = "Название предмета на момент сохранения", example = "Кинжал")
+    @Schema(description = "Название предмета", example = "Кинжал")
     private String name;
 
     @Schema(description = "Количество предметов", example = "2")

--- a/src/main/java/club/ttg/dnd5/domain/common/rest/dto/EquipmentOptionDto.java
+++ b/src/main/java/club/ttg/dnd5/domain/common/rest/dto/EquipmentOptionDto.java
@@ -1,4 +1,4 @@
-package club.ttg.dnd5.domain.character_class.rest.dto;
+package club.ttg.dnd5.domain.common.rest.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -12,12 +12,12 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class ClassEquipmentOptionDto {
+public class EquipmentOptionDto {
     @Schema(description = "Метка варианта", example = "А")
     private String label;
 
     @Schema(description = "Предметы варианта")
-    private List<ClassEquipmentItemDto> items;
+    private List<EquipmentItemDto> items;
 
     @Schema(description = "Количество монет", example = "15")
     private Integer coins;

--- a/src/main/java/club/ttg/dnd5/domain/common/rest/mapper/EquipmentMapping.java
+++ b/src/main/java/club/ttg/dnd5/domain/common/rest/mapper/EquipmentMapping.java
@@ -1,0 +1,135 @@
+package club.ttg.dnd5.domain.common.rest.mapper;
+
+import club.ttg.dnd5.domain.common.dictionary.Coin;
+import club.ttg.dnd5.domain.common.model.EquipmentItem;
+import club.ttg.dnd5.domain.common.model.EquipmentOption;
+import club.ttg.dnd5.domain.common.rest.dto.EquipmentItemDto;
+import club.ttg.dnd5.domain.common.rest.dto.EquipmentOptionDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Named;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Общие преобразования стартового снаряжения вариантами выбора.
+ * Используется сущностями, у которых есть такое снаряжение: классами и предысториями.
+ */
+@Mapper(componentModel = "spring")
+public interface EquipmentMapping
+{
+    /**
+     * Метки вариантов снаряжения — выводятся из порядка вариантов, в базе не хранятся.
+     */
+    String EQUIPMENT_LABELS = "АБВГДЕЖЗИКЛМНОПРСТУФХЦЧШЩЭЮЯ";
+
+    /**
+     * Количество вариантов снаряжения, которые редактор показывает там, где снаряжение не заполнено.
+     */
+    int DEFAULT_EQUIPMENT_OPTIONS = 2;
+
+    /**
+     * Варианты снаряжения для формы редактора: если их нет,
+     * отдаём пустые подблоки «А» и «Б», чтобы редактору было что показать.
+     */
+    @Named("toEquipmentForm")
+    default List<EquipmentOption> toEquipmentForm(List<EquipmentOption> options)
+    {
+        if (!CollectionUtils.isEmpty(options))
+        {
+            return options;
+        }
+
+        List<EquipmentOption> defaults = new ArrayList<>(DEFAULT_EQUIPMENT_OPTIONS);
+        for (int index = 0; index < DEFAULT_EQUIPMENT_OPTIONS; index++)
+        {
+            EquipmentOption option = new EquipmentOption();
+            option.setItems(new ArrayList<>());
+            defaults.add(option);
+        }
+
+        return defaults;
+    }
+
+    /**
+     * Варианты снаряжения для сохранения: пустые предметы и пустые подблоки отбрасываются,
+     * чтобы дефолтные подблоки редактора не попадали в базу.
+     */
+    @Named("toEquipmentEntities")
+    default List<EquipmentOption> toEquipmentEntities(List<EquipmentOption> options)
+    {
+        if (CollectionUtils.isEmpty(options))
+        {
+            return null;
+        }
+
+        List<EquipmentOption> cleaned = new ArrayList<>(options.size());
+        for (EquipmentOption option : options)
+        {
+            if (option == null)
+            {
+                continue;
+            }
+
+            option.setItems(cleanEquipmentItems(option.getItems()));
+
+            if (!option.getItems().isEmpty() || option.getCoins() != null)
+            {
+                cleaned.add(option);
+            }
+        }
+
+        return cleaned.isEmpty() ? null : cleaned;
+    }
+
+    private List<EquipmentItem> cleanEquipmentItems(List<EquipmentItem> items)
+    {
+        if (CollectionUtils.isEmpty(items))
+        {
+            return Collections.emptyList();
+        }
+
+        return items.stream()
+                .filter(Objects::nonNull)
+                .filter(item -> StringUtils.hasText(item.getUrl()) || StringUtils.hasText(item.getDescription()))
+                .toList();
+    }
+
+    @Named("toEquipmentOptionDtos")
+    default List<EquipmentOptionDto> toEquipmentOptionDtos(List<EquipmentOption> options)
+    {
+        if (CollectionUtils.isEmpty(options))
+        {
+            return Collections.emptyList();
+        }
+
+        List<EquipmentOptionDto> dtos = new ArrayList<>(options.size());
+        for (int index = 0; index < options.size(); index++)
+        {
+            EquipmentOption option = options.get(index);
+            Coin coin = option.getCoin() == null ? Coin.GC : option.getCoin();
+
+            dtos.add(new EquipmentOptionDto(
+                    equipmentLabel(index),
+                    toEquipmentItemDtos(option.getItems()),
+                    option.getCoins(),
+                    coin.getShortName()
+            ));
+        }
+
+        return dtos;
+    }
+
+    List<EquipmentItemDto> toEquipmentItemDtos(List<EquipmentItem> items);
+
+    default String equipmentLabel(int index)
+    {
+        return index < EQUIPMENT_LABELS.length()
+                ? String.valueOf(EQUIPMENT_LABELS.charAt(index))
+                : String.valueOf(index + 1);
+    }
+}

--- a/src/main/java/club/ttg/dnd5/domain/item/service/EquipmentNameResolver.java
+++ b/src/main/java/club/ttg/dnd5/domain/item/service/EquipmentNameResolver.java
@@ -1,0 +1,57 @@
+package club.ttg.dnd5.domain.item.service;
+
+import club.ttg.dnd5.domain.common.rest.dto.EquipmentItemDto;
+import club.ttg.dnd5.domain.common.rest.dto.EquipmentOptionDto;
+import club.ttg.dnd5.domain.item.repository.ItemNameRef;
+import club.ttg.dnd5.domain.item.repository.ItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Подставляет в стартовое снаряжение актуальные названия предметов из справочника.
+ * В снаряжении хранится ссылка на предмет и название на момент сохранения, и снимок
+ * мог устареть после переименования. Название из снимка остаётся запасным — для
+ * предметов, которых уже нет в справочнике.
+ */
+@RequiredArgsConstructor
+@Service
+public class EquipmentNameResolver {
+
+    private final ItemRepository itemRepository;
+
+    @Transactional(readOnly = true)
+    public void resolveNames(List<EquipmentOptionDto> options) {
+        if (CollectionUtils.isEmpty(options)) {
+            return;
+        }
+
+        List<EquipmentItemDto> items = options.stream()
+                .map(EquipmentOptionDto::getItems)
+                .filter(Objects::nonNull)
+                .flatMap(List::stream)
+                .filter(item -> StringUtils.hasText(item.getUrl()))
+                .toList();
+
+        if (items.isEmpty()) {
+            return;
+        }
+
+        Set<String> urls = items.stream()
+                .map(EquipmentItemDto::getUrl)
+                .collect(Collectors.toSet());
+
+        Map<String, String> names = itemRepository.findNamesByUrls(urls).stream()
+                .collect(Collectors.toMap(ItemNameRef::getUrl, ItemNameRef::getName));
+
+        items.forEach(item -> item.setName(names.getOrDefault(item.getUrl(), item.getName())));
+    }
+}

--- a/src/main/resources/db/changelog/2026/07/30-01-add-background-starting-equipment.yaml
+++ b/src/main/resources/db/changelog/2026/07/30-01-add-background-starting-equipment.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: 30-01-add-background-starting-equipment
+      author: Magistrus
+      changes:
+        - addColumn:
+            tableName: background
+            columns:
+              - column:
+                  name: starting_equipment
+                  type: jsonb

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -271,3 +271,5 @@ databaseChangeLog:
       file: db/changelog/2026/07/29-01-backfill-ability-improvement-variants.yaml
   - include:
       file: db/changelog/2026/07/29-02-add-class-starting-equipment.yaml
+  - include:
+      file: db/changelog/2026/07/30-01-add-background-starting-equipment.yaml

--- a/src/test/java/club/ttg/dnd5/domain/background/rest/mapper/BackgroundMapperTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/background/rest/mapper/BackgroundMapperTest.java
@@ -1,0 +1,84 @@
+package club.ttg.dnd5.domain.background.rest.mapper;
+
+import club.ttg.dnd5.domain.background.model.Background;
+import club.ttg.dnd5.domain.background.rest.dto.BackgroundRequest;
+import club.ttg.dnd5.domain.common.model.EquipmentItem;
+import club.ttg.dnd5.domain.common.model.EquipmentOption;
+import club.ttg.dnd5.domain.common.rest.dto.NameRequest;
+import club.ttg.dnd5.domain.common.rest.mapper.EquipmentMappingImpl;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class BackgroundMapperTest {
+    private final BackgroundMapper mapper = new BackgroundMapperImpl(new EquipmentMappingImpl());
+
+    @Test
+    void detailResponseDerivesEquipmentLabels() {
+        Background background = new Background();
+        background.setAbilities(Set.of());
+        background.setSkillProficiencies(Set.of());
+        background.setStartingEquipment(List.of(gear(), coins(50)));
+
+        var options = mapper.toDetail(background).getStartingEquipment();
+
+        assertEquals(2, options.size());
+        assertEquals("А", options.getFirst().getLabel());
+        assertEquals("Б", options.get(1).getLabel());
+        assertEquals("зм", options.get(1).getCoin());
+        assertEquals(50, options.get(1).getCoins());
+        assertEquals("bagpipes", options.getFirst().getItems().getFirst().getUrl());
+    }
+
+    @Test
+    void formGetsTwoEmptyOptionsWhenEquipmentIsNotFilled() {
+        assertEquals(2, mapper.toRequest(new Background()).getStartingEquipment().size());
+    }
+
+    @Test
+    void emptyOptionsAreNotSaved() {
+        BackgroundRequest request = request();
+        request.setStartingEquipment(new ArrayList<>(List.of(new EquipmentOption(), new EquipmentOption())));
+
+        assertNull(mapper.toEntity(request, null, null).getStartingEquipment());
+    }
+
+    private EquipmentOption gear() {
+        EquipmentItem instrument = new EquipmentItem();
+        instrument.setUrl("bagpipes");
+        instrument.setQuantity(1);
+
+        EquipmentOption option = new EquipmentOption();
+        option.setItems(List.of(instrument));
+        option.setCoins(11);
+        return option;
+    }
+
+    private EquipmentOption coins(int amount) {
+        EquipmentOption option = new EquipmentOption();
+        option.setCoins(amount);
+        return option;
+    }
+
+    private BackgroundRequest request() {
+        BackgroundRequest request = new BackgroundRequest();
+        request.setUrl("background");
+        request.setName(name());
+        request.setAbilityScores(Set.of());
+        request.setSkillsProficiencies(Set.of());
+        return request;
+    }
+
+    private NameRequest name() {
+        NameRequest name = new NameRequest();
+        name.setName("Предыстория");
+        name.setEnglish("Background");
+        name.setAlternative(List.of());
+        return name;
+    }
+}

--- a/src/test/java/club/ttg/dnd5/domain/background/service/BackgroundServiceImplTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/background/service/BackgroundServiceImplTest.java
@@ -5,9 +5,12 @@ import club.ttg.dnd5.domain.background.repository.BackgroundRepository;
 import club.ttg.dnd5.domain.background.rest.dto.BackgroundRequest;
 import club.ttg.dnd5.domain.background.rest.dto.BackgroundDetailResponse;
 import club.ttg.dnd5.domain.background.rest.mapper.BackgroundMapper;
+import club.ttg.dnd5.domain.background.rest.mapper.BackgroundMapperImpl;
 import club.ttg.dnd5.domain.common.rest.dto.NameRequest;
 import club.ttg.dnd5.domain.common.rest.dto.SourceRequest;
+import club.ttg.dnd5.domain.common.rest.mapper.EquipmentMappingImpl;
 import club.ttg.dnd5.domain.feat.repository.FeatRepository;
+import club.ttg.dnd5.domain.item.service.EquipmentNameResolver;
 import club.ttg.dnd5.domain.revision.service.EntityRevisionService;
 import club.ttg.dnd5.domain.source.model.Source;
 import club.ttg.dnd5.domain.source.model.SourceType;
@@ -15,7 +18,6 @@ import club.ttg.dnd5.domain.source.service.SourceService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mapstruct.factory.Mappers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -41,19 +43,22 @@ class BackgroundServiceImplTest {
     private SourceService sourceService;
     @Mock
     private EntityRevisionService revisionService;
+    @Mock
+    private EquipmentNameResolver equipmentNameResolver;
 
     private BackgroundServiceImpl backgroundService;
 
     @BeforeEach
     void setUp() {
-        BackgroundMapper backgroundMapper = Mappers.getMapper(BackgroundMapper.class);
+        BackgroundMapper backgroundMapper = new BackgroundMapperImpl(new EquipmentMappingImpl());
         backgroundService = new BackgroundServiceImpl(
                 backgroundQueryDslSearchService,
                 backgroundRepository,
                 featRepository,
                 sourceService,
                 backgroundMapper,
-                revisionService
+                revisionService,
+                equipmentNameResolver
         );
     }
 

--- a/src/test/java/club/ttg/dnd5/domain/character_class/service/ClassServiceTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/character_class/service/ClassServiceTest.java
@@ -2,25 +2,19 @@ package club.ttg.dnd5.domain.character_class.service;
 
 import club.ttg.dnd5.domain.character_class.model.CharacterClass;
 import club.ttg.dnd5.domain.character_class.repository.ClassRepository;
-import club.ttg.dnd5.domain.character_class.rest.dto.ClassDetailedResponse;
-import club.ttg.dnd5.domain.character_class.rest.dto.ClassEquipmentItemDto;
-import club.ttg.dnd5.domain.character_class.rest.dto.ClassEquipmentOptionDto;
 import club.ttg.dnd5.domain.character_class.rest.dto.ClassRequest;
 import club.ttg.dnd5.domain.character_class.rest.mapper.ClassMapper;
 import club.ttg.dnd5.domain.common.repository.GalleryRepository;
-import club.ttg.dnd5.domain.item.repository.ItemNameRef;
-import club.ttg.dnd5.domain.item.repository.ItemRepository;
+import club.ttg.dnd5.domain.common.rest.mapper.EquipmentMapping;
+import club.ttg.dnd5.domain.item.service.EquipmentNameResolver;
 import club.ttg.dnd5.domain.revision.service.EntityRevisionService;
 import club.ttg.dnd5.domain.source.service.SourceSavedFilterService;
 import club.ttg.dnd5.domain.source.service.SourceService;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -36,7 +30,8 @@ class ClassServiceTest {
     private final GalleryRepository galleryRepository = mock(GalleryRepository.class);
     private final SourceSavedFilterService sourceSavedFilterService = mock(SourceSavedFilterService.class);
     private final EntityRevisionService revisionService = mock(EntityRevisionService.class);
-    private final ItemRepository itemRepository = mock(ItemRepository.class);
+    private final EquipmentNameResolver equipmentNameResolver = mock(EquipmentNameResolver.class);
+    private final EquipmentMapping equipmentMapping = mock(EquipmentMapping.class);
     private final ClassService service = new ClassService(
             classRepository,
             classMapper,
@@ -45,7 +40,8 @@ class ClassServiceTest {
             galleryRepository,
             sourceSavedFilterService,
             revisionService,
-            itemRepository
+            equipmentNameResolver,
+            equipmentMapping
     );
 
     @Test
@@ -71,37 +67,5 @@ class ClassServiceTest {
         verify(classRepository).save(captor.capture());
         verify(classRepository, never()).getReferenceById(any());
         assertNull(captor.getValue().getParent());
-    }
-
-    @Test
-    void detailedResponseUsesActualItemNames() {
-        CharacterClass characterClass = new CharacterClass();
-        characterClass.setUrl("bard");
-
-        var renamed = new ClassEquipmentItemDto("dagger", "Название на момент сохранения", 2, null);
-        var missing = new ClassEquipmentItemDto("lost-item", "Снимок", 1, null);
-        ClassDetailedResponse response = new ClassDetailedResponse();
-        response.setStartingEquipment(List.of(
-                new ClassEquipmentOptionDto("А", List.of(renamed, missing), 15, "зм")
-        ));
-
-        List<ItemNameRef> found = List.of(itemName("dagger", "Кинжал"));
-
-        when(classRepository.findById("bard")).thenReturn(Optional.of(characterClass));
-        when(classMapper.toDetailedResponse(characterClass)).thenReturn(response);
-        when(itemRepository.findNamesByUrls(Set.of("dagger", "lost-item"))).thenReturn(found);
-
-        var items = service.findDetailedByUrl("bard").getStartingEquipment().getFirst().getItems();
-
-        assertEquals("Кинжал", items.getFirst().getName());
-        // Предмета уже нет в справочнике — остаётся название из снимка.
-        assertEquals("Снимок", items.get(1).getName());
-    }
-
-    private ItemNameRef itemName(String url, String name) {
-        ItemNameRef ref = mock(ItemNameRef.class);
-        when(ref.getUrl()).thenReturn(url);
-        when(ref.getName()).thenReturn(name);
-        return ref;
     }
 }

--- a/src/test/java/club/ttg/dnd5/domain/common/rest/mapper/EquipmentMappingTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/common/rest/mapper/EquipmentMappingTest.java
@@ -1,13 +1,8 @@
-package club.ttg.dnd5.domain.character_class.rest.mapper;
+package club.ttg.dnd5.domain.common.rest.mapper;
 
-import club.ttg.dnd5.domain.character_class.model.ClassEquipmentItem;
-import club.ttg.dnd5.domain.character_class.model.ClassEquipmentOption;
-import club.ttg.dnd5.dto.base.mapping.BaseMapping;
+import club.ttg.dnd5.domain.common.model.EquipmentItem;
+import club.ttg.dnd5.domain.common.model.EquipmentOption;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,19 +11,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(MockitoExtension.class)
-class ClassMapperTest
+class EquipmentMappingTest
 {
-    @Mock
-    private BaseMapping baseMapping;
-
-    @InjectMocks
-    private ClassMapperImpl mapper;
+    private final EquipmentMapping mapping = new EquipmentMappingImpl();
 
     @Test
-    void formGetsTwoEmptyOptionsWhenClassHasNoEquipment()
+    void formGetsTwoEmptyOptionsWhenEquipmentIsNotFilled()
     {
-        var options = mapper.toEquipmentForm(null);
+        var options = mapping.toEquipmentForm(null);
 
         assertEquals(2, options.size());
         assertTrue(options.get(0).getItems().isEmpty());
@@ -38,18 +28,18 @@ class ClassMapperTest
     @Test
     void formKeepsSavedOptionsAsIs()
     {
-        List<ClassEquipmentOption> saved = List.of(coins(75));
+        List<EquipmentOption> saved = List.of(coins(75));
 
-        assertEquals(saved, mapper.toEquipmentForm(saved));
+        assertEquals(saved, mapping.toEquipmentForm(saved));
     }
 
     @Test
     void emptyOptionsAndItemsAreNotSaved()
     {
-        ClassEquipmentOption filled = new ClassEquipmentOption();
+        EquipmentOption filled = new EquipmentOption();
         filled.setItems(new ArrayList<>(List.of(item("dagger", 2, null), item(null, null, null))));
 
-        var options = mapper.toEquipmentEntities(new ArrayList<>(List.of(filled, new ClassEquipmentOption())));
+        var options = mapping.toEquipmentEntities(new ArrayList<>(List.of(filled, new EquipmentOption())));
 
         assertEquals(1, options.size());
         assertEquals(1, options.getFirst().getItems().size());
@@ -59,10 +49,10 @@ class ClassMapperTest
     @Test
     void itemWithOnlyDescriptionIsSaved()
     {
-        ClassEquipmentOption option = new ClassEquipmentOption();
+        EquipmentOption option = new EquipmentOption();
         option.setItems(new ArrayList<>(List.of(item(null, null, "музыкальный инструмент по вашему выбору"))));
 
-        var options = mapper.toEquipmentEntities(new ArrayList<>(List.of(option)));
+        var options = mapping.toEquipmentEntities(new ArrayList<>(List.of(option)));
 
         assertEquals(1, options.size());
         assertEquals(1, options.getFirst().getItems().size());
@@ -71,17 +61,17 @@ class ClassMapperTest
     @Test
     void formDefaultsAreNotSaved()
     {
-        assertNull(mapper.toEquipmentEntities(mapper.toEquipmentForm(null)));
+        assertNull(mapping.toEquipmentEntities(mapping.toEquipmentForm(null)));
     }
 
     @Test
     void responseDerivesLabelsFromOrderAndCoinName()
     {
-        ClassEquipmentOption gear = new ClassEquipmentOption();
+        EquipmentOption gear = new EquipmentOption();
         gear.setItems(List.of(item("musical-instrument", 1, "по вашему выбору")));
         gear.setCoins(19);
 
-        var response = mapper.toEquipmentOptionDtos(List.of(gear, coins(75)));
+        var response = mapping.toEquipmentOptionDtos(List.of(gear, coins(75)));
 
         assertEquals("А", response.get(0).getLabel());
         assertEquals("Б", response.get(1).getLabel());
@@ -92,16 +82,16 @@ class ClassMapperTest
         assertEquals(75, response.get(1).getCoins());
     }
 
-    private ClassEquipmentOption coins(int amount)
+    private EquipmentOption coins(int amount)
     {
-        ClassEquipmentOption option = new ClassEquipmentOption();
+        EquipmentOption option = new EquipmentOption();
         option.setCoins(amount);
         return option;
     }
 
-    private ClassEquipmentItem item(String url, Integer quantity, String description)
+    private EquipmentItem item(String url, Integer quantity, String description)
     {
-        ClassEquipmentItem item = new ClassEquipmentItem();
+        EquipmentItem item = new EquipmentItem();
         item.setUrl(url);
         item.setQuantity(quantity);
         item.setDescription(description);

--- a/src/test/java/club/ttg/dnd5/domain/item/service/EquipmentNameResolverTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/item/service/EquipmentNameResolverTest.java
@@ -1,0 +1,49 @@
+package club.ttg.dnd5.domain.item.service;
+
+import club.ttg.dnd5.domain.common.rest.dto.EquipmentItemDto;
+import club.ttg.dnd5.domain.common.rest.dto.EquipmentOptionDto;
+import club.ttg.dnd5.domain.item.repository.ItemNameRef;
+import club.ttg.dnd5.domain.item.repository.ItemRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class EquipmentNameResolverTest {
+    private final ItemRepository itemRepository = mock(ItemRepository.class);
+    private final EquipmentNameResolver resolver = new EquipmentNameResolver(itemRepository);
+
+    @Test
+    void actualNameFromCatalogWinsOverSnapshot() {
+        var renamed = new EquipmentItemDto("dagger", "Название на момент сохранения", 2, null);
+        var missing = new EquipmentItemDto("lost-item", "Снимок", 1, null);
+        List<ItemNameRef> found = List.of(itemName("dagger", "Кинжал"));
+
+        when(itemRepository.findNamesByUrls(Set.of("dagger", "lost-item"))).thenReturn(found);
+
+        resolver.resolveNames(List.of(new EquipmentOptionDto("А", List.of(renamed, missing), 15, "зм")));
+
+        assertEquals("Кинжал", renamed.getName());
+        // Предмета уже нет в справочнике — остаётся название из снимка.
+        assertEquals("Снимок", missing.getName());
+    }
+
+    @Test
+    void optionWithoutItemsDoesNotHitRepository() {
+        resolver.resolveNames(List.of(new EquipmentOptionDto("А", List.of(), 75, "зм")));
+
+        verifyNoInteractions(itemRepository);
+    }
+
+    private ItemNameRef itemName(String url, String name) {
+        ItemNameRef ref = mock(ItemNameRef.class);
+        when(ref.getUrl()).thenReturn(url);
+        when(ref.getName()).thenReturn(name);
+        return ref;
+    }
+}


### PR DESCRIPTION
Предыстория получает такое же снаряжение вариантами выбора, как класс: подблоки с предметами (количество и текстовое уточнение) и суммой монет. Хранится в jsonb-колонке background.starting_equipment рядом с прежним markdown-описанием.

Модель, DTO и преобразования снаряжения переехали из домена классов в common, чтобы не дублировать их между сущностями: EquipmentOption и EquipmentItem, EquipmentOptionDto и EquipmentItemDto, а также маппер EquipmentMapping с дефолтами формы, очисткой при сохранении и выводом меток вариантов. Подстановка актуальных названий предметов вынесена из ClassService в EquipmentNameResolver и используется обоими доменами.