### PR TITLE
feat(item): категория и типы предмета в ответе поиска

### DIFF
--- a/src/main/java/club/ttg/dnd5/domain/item/rest/dto/ItemShortResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/item/rest/dto/ItemShortResponse.java
@@ -1,15 +1,21 @@
 package club.ttg.dnd5.domain.item.rest.dto;
 
 import club.ttg.dnd5.domain.common.rest.dto.ShortResponse;
+import club.ttg.dnd5.domain.item.model.ItemCategory;
+import club.ttg.dnd5.domain.item.model.ItemType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.Collection;
+
 @Getter
 @Setter
 public class ItemShortResponse extends ShortResponse {
-    @Schema(description = "Тип объекта", examples = {"ARMOR, WEAPON","OBJECT"})
-    private String type;
+    @Schema(description = "Категория объекта", examples = {"ITEM", "ARMOR", "WEAPON"})
+    private ItemCategory category;
+    @Schema(description = "Типы объекта", examples = {"WEAPON", "MARTIAL_WEAPON", "MELEE_WEAPON"})
+    private Collection<ItemType> types;
     @Schema(description = "Стоимость", examples = "1 зм")
     private String cost;
 }


### PR DESCRIPTION
Ответ поиска отдавал только стоимость, поэтому раздел снаряжения не мог группировать предметы по категории. Вместо поля `type`, которое маппер никогда не заполнял, `ItemShortResponse` получает `category` и `types` — их и раскладывает фронт в иерархию групп.