### PR TITLE
feat(item): Улучшение раздела Предметы

### DIFF
--- a/src/main/java/club/ttg/dnd5/domain/item/rest/dto/ItemQueryRequest.java
+++ b/src/main/java/club/ttg/dnd5/domain/item/rest/dto/ItemQueryRequest.java
@@ -1,7 +1,9 @@
 package club.ttg.dnd5.domain.item.rest.dto;
 
+import club.ttg.dnd5.domain.common.dictionary.DamageType;
 import club.ttg.dnd5.domain.filter.rest.FilterParam;
 import club.ttg.dnd5.domain.item.model.ItemType;
+import club.ttg.dnd5.domain.item.model.weapon.Property;
 import club.ttg.dnd5.dto.base.filters.AbstractQueryRequest;
 import club.ttg.dnd5.dto.base.filters.QueryFilter;
 import lombok.Data;
@@ -15,4 +17,10 @@ public class ItemQueryRequest extends AbstractQueryRequest
 {
     @FilterParam(value = "itemType", enumClass = ItemType.class)
     private QueryFilter<ItemType> itemType;
+
+    @FilterParam(value = "weaponProperty", enumClass = Property.class)
+    private QueryFilter<Property> weaponProperty;
+
+    @FilterParam(value = "damageType", enumClass = DamageType.class)
+    private QueryFilter<DamageType> damageType;
 }

--- a/src/main/java/club/ttg/dnd5/domain/item/rest/dto/ItemShortResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/item/rest/dto/ItemShortResponse.java
@@ -1,15 +1,21 @@
 package club.ttg.dnd5.domain.item.rest.dto;
 
 import club.ttg.dnd5.domain.common.rest.dto.ShortResponse;
+import club.ttg.dnd5.domain.item.model.ItemCategory;
+import club.ttg.dnd5.domain.item.model.ItemType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.Collection;
+
 @Getter
 @Setter
 public class ItemShortResponse extends ShortResponse {
-    @Schema(description = "Тип объекта", examples = {"ARMOR, WEAPON","OBJECT"})
-    private String type;
+    @Schema(description = "Категория объекта", examples = {"ITEM", "ARMOR", "WEAPON"})
+    private ItemCategory category;
+    @Schema(description = "Типы объекта", examples = {"WEAPON", "MARTIAL_WEAPON", "MELEE_WEAPON"})
+    private Collection<ItemType> types;
     @Schema(description = "Стоимость", examples = "1 зм")
     private String cost;
 }

--- a/src/main/java/club/ttg/dnd5/domain/item/service/ItemFilterService.java
+++ b/src/main/java/club/ttg/dnd5/domain/item/service/ItemFilterService.java
@@ -8,7 +8,9 @@ import club.ttg.dnd5.domain.filter.rest.dto.SupportsConfig;
 import club.ttg.dnd5.domain.filter.rest.dto.FilterMetadataResponse;
 import club.ttg.dnd5.domain.filter.rest.dto.FilterMetadataResponse.FilterGroupMeta;
 import club.ttg.dnd5.domain.filter.rest.dto.FilterMetadataResponse.FilterValueMeta;
+import club.ttg.dnd5.domain.common.dictionary.DamageType;
 import club.ttg.dnd5.domain.item.model.ItemType;
+import club.ttg.dnd5.domain.item.model.weapon.Property;
 import club.ttg.dnd5.domain.source.service.SourceSavedFilterService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -36,13 +38,44 @@ public class ItemFilterService
 
     private List<FilterGroupMeta> buildFilterGroups()
     {
-        List<FilterGroupMeta> groups = new ArrayList<>(2);
+        List<FilterGroupMeta> groups = new ArrayList<>(4);
 
         groups.add(FilterGroupMeta.builder()
                 .key(FilterKeys.keyOf(ItemQueryRequest.class, "itemType"))
                 .name("Категория")
                 .supports(SupportsConfig.builder().mode(true).union(true).build())
                 .values(Arrays.stream(ItemType.values())
+                        .map(v -> FilterValueMeta.builder()
+                                .id(v.name())
+                                .value(v.name())
+                                .name(v.getName())
+                                .build())
+                        .sorted(Comparator.comparing(FilterValueMeta::getName))
+                        .toList())
+                .build());
+
+        // Свойств у оружия несколько, поэтому объединение (И) имеет смысл:
+        // «тяжёлое и двуручное».
+        groups.add(FilterGroupMeta.builder()
+                .key(FilterKeys.keyOf(ItemQueryRequest.class, "weaponProperty"))
+                .name("Свойства оружия")
+                .supports(SupportsConfig.builder().mode(true).union(true).build())
+                .values(Arrays.stream(Property.values())
+                        .map(v -> FilterValueMeta.builder()
+                                .id(v.name())
+                                .value(v.name())
+                                .name(v.getName())
+                                .build())
+                        .sorted(Comparator.comparing(FilterValueMeta::getName))
+                        .toList())
+                .build());
+
+        // Тип урона у оружия один, поэтому объединение (И) не предлагается.
+        groups.add(FilterGroupMeta.builder()
+                .key(FilterKeys.keyOf(ItemQueryRequest.class, "damageType"))
+                .name("Тип урона")
+                .supports(SupportsConfig.builder().mode(true).union(false).build())
+                .values(Arrays.stream(DamageType.values())
                         .map(v -> FilterValueMeta.builder()
                                 .id(v.name())
                                 .value(v.name())

--- a/src/main/java/club/ttg/dnd5/domain/item/service/ItemPredicateBuilder.java
+++ b/src/main/java/club/ttg/dnd5/domain/item/service/ItemPredicateBuilder.java
@@ -17,6 +17,8 @@ public class ItemPredicateBuilder
         builder.and(Q.isHiddenEntity.isFalse());
         builder.and(PredicateUtils.buildTextSearch(request.getSearch(), Q.name, Q.english, Q.alternative));
         PredicateUtils.applyJsonbEnumArrayFilter(builder, request.getItemType(), "item_types");
+        PredicateUtils.applyJsonbNestedEnumArrayFilter(builder, request.getWeaponProperty(), "weapon", "properties");
+        PredicateUtils.applyJsonbNestedObjectEnumFieldFilter(builder, request.getDamageType(), "weapon", "damage", "type");
         PredicateUtils.applySourcesFilter(builder, request.getSource(), "item", "source");
         PredicateUtils.applyStringFilter(builder, request.getSrdVersion(), Q.srdVersion);
         return builder;

--- a/src/main/java/club/ttg/dnd5/dto/base/filters/PredicateUtils.java
+++ b/src/main/java/club/ttg/dnd5/dto/base/filters/PredicateUtils.java
@@ -520,6 +520,58 @@ public class PredicateUtils
     }
 
     /**
+     * Фильтр по строковому полю внутри вложенного JSONB-объекта.
+     * Пример: {@code (weapon->'damage'->>'type') IN ('SLASHING','PIERCING')}.
+     * <p>
+     * Записи без такого объекта (у предмета нет оружейной части) не проходят
+     * ни включающий, ни исключающий фильтр: сравнение с NULL не истинно.
+     *
+     * @param columnName имя JSONB-колонки (например, "weapon")
+     * @param objectKey  ключ вложенного объекта (например, "damage")
+     * @param jsonKey    ключ поля внутри объекта (например, "type")
+     */
+    public <E extends Enum<E>> void applyJsonbNestedObjectEnumFieldFilter(final BooleanBuilder builder,
+                                                                           final QueryFilter<E> filter,
+                                                                           final String columnName,
+                                                                           final String objectKey,
+                                                                           final String jsonKey)
+    {
+        if (filter == null || !filter.isActive())
+        {
+            return;
+        }
+
+        String path = "(" + columnName + "->'" + objectKey + "'->>'" + jsonKey + "')";
+
+        if (filter.isExclude())
+        {
+            builder.and(Expressions.booleanTemplate(path + " NOT IN (" + toQuotedNames(filter) + ")"));
+        }
+        else if (filter.isUnion())
+        {
+            for (E val : filter.getValues())
+            {
+                builder.and(Expressions.booleanTemplate(path + " = '" + val.name() + "'"));
+            }
+        }
+        else
+        {
+            builder.and(Expressions.booleanTemplate(path + " IN (" + toQuotedNames(filter) + ")"));
+        }
+    }
+
+    /**
+     * Значения enum-фильтра в виде списка SQL-строк: {@code 'ACID','COLD'}.
+     */
+    private <E extends Enum<E>> String toQuotedNames(final QueryFilter<E> filter)
+    {
+        return filter.getValues().stream()
+                .map(Enum::name)
+                .map(name -> "'" + name + "'")
+                .collect(java.util.stream.Collectors.joining(","));
+    }
+
+    /**
      * Фильтр по строковому полю внутри JSONB-объекта (не массива).
      * Пример: {@code area_of_effect->>'type' IN ('CONE','SPHERE')}.
      */


### PR DESCRIPTION
Ответ поиска отдавал только стоимость, поэтому раздел снаряжения не мог группировать предметы по категории. Вместо поля `type`, которое маппер никогда не заполнял, `ItemShortResponse` получает `category` и `types` — их и раскладывает фронт в иерархию групп.