### PR TITLE
feat(vttg): маркеры разметки доезжают до компендиума оформлением, а не текстом

### DIFF
--- a/src/main/java/club/ttg/dnd5/domain/article/service/DiscordMarkdownFormatter.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/service/DiscordMarkdownFormatter.java
@@ -19,7 +19,7 @@ import java.util.regex.Pattern;
  * Приводит разметку статьи/новости к тексту для Discord (обычное сообщение, не embed).
  * <p>
  * Контент хранится массивом блоков: строки-абзацы и узлы-объекты (цитата/список/таблица/заголовок).
- * {@link VttgMarkupConverter#toText} разворачивает блок в промежуточный markdown-подобный текст
+ * {@link VttgMarkupConverter#toTextKeepingMarkers} разворачивает блок в промежуточный markdown-подобный текст
  * ({@code **жирный**}, {@code *курсив*}, {@code [метка](url)}). Discord-разметка почти совпадает с ним,
  * поэтому {@code **}/{@code *} оставляем как есть; переводим лишь литеральные маркеры {@code {@u}}/
  * {@code {@s}}/{@code {@spoiler}}/{@code {@code}} в Discord-markdown и цитату — в префикс {@code > }.
@@ -135,7 +135,7 @@ public class DiscordMarkdownFormatter {
                 out.add(new Rendered(DIVIDER, DIVIDER));
                 continue;
             }
-            String text = clean(markupConverter.toText(preprocessLinks(block.markup())));
+            String text = clean(markupConverter.toTextKeepingMarkers(preprocessLinks(block.markup())));
             if (text.isEmpty()) {
                 continue;
             }
@@ -189,7 +189,7 @@ public class DiscordMarkdownFormatter {
     }
 
     /**
-     * Пред-обработка ДО {@link VttgMarkupConverter#toText}: маркеры-ссылки {@code {@type label | url:...}}
+     * Пред-обработка ДО {@link VttgMarkupConverter#toTextKeepingMarkers}: маркеры-ссылки {@code {@type label | url:...}}
      * → markdown {@code [label](абсолютный url)}. Нужна потому, что toText теряет ссылки: у обычного
      * {@code {@link}} выкидывает url, а секции со спейсовым {@code | url:} не распознаёт. Остальные маркеры
      * ({@code {@b}}/{@code {@u}}/…) не трогаем — их разберут toText и {@link #applyTags}.

--- a/src/main/java/club/ttg/dnd5/domain/article/service/TelegramHtmlFormatter.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/service/TelegramHtmlFormatter.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
  * Приводит разметку статьи/новости к тексту для Telegram.
  * <p>
  * Контент хранится массивом блоков: строки-абзацы и узлы-объекты (цитата/список/таблица/заголовок).
- * {@link VttgMarkupConverter#toText} разворачивает блок в промежуточный markdown-подобный текст
+ * {@link VttgMarkupConverter#toTextKeepingMarkers} разворачивает блок в промежуточный markdown-подобный текст
  * ({@code **жирный**}, {@code *курсив*}, {@code [метка](url)}) и при этом теряет обёртку цитаты —
  * поэтому цитату ({@code type: quote}) мы выделяем на уровне блоков и оборачиваем в Telegram
  * {@code <blockquote>}. Остальное переводим в Telegram-HTML: {@code <b>/<i>/<u>/<s>/<a>}. Всё, что
@@ -131,7 +131,7 @@ public class TelegramHtmlFormatter {
                 out.add(new Rendered(DIVIDER, DIVIDER, DIVIDER.length()));
                 continue;
             }
-            String text = clean(markupConverter.toText(preprocessLinks(block.markup())));
+            String text = clean(markupConverter.toTextKeepingMarkers(preprocessLinks(block.markup())));
             if (text.isEmpty()) {
                 continue;
             }
@@ -172,7 +172,7 @@ public class TelegramHtmlFormatter {
     }
 
     /**
-     * Пред-обработка ДО {@link VttgMarkupConverter#toText}: маркеры-ссылки {@code {@type label | url:...}}
+     * Пред-обработка ДО {@link VttgMarkupConverter#toTextKeepingMarkers}: маркеры-ссылки {@code {@type label | url:...}}
      * → markdown {@code [label](абсолютный url)}. Нужна потому, что toText теряет ссылки: у обычного
      * {@code {@link}} выкидывает url, а секции со спейсовым {@code | url:} не распознаёт. Остальные маркеры
      * ({@code {@b}}/{@code {@u}}/…) не трогаем — их разберут toText и {@link #applyTags}.

--- a/src/main/java/club/ttg/dnd5/domain/article/service/VkTextFormatter.java
+++ b/src/main/java/club/ttg/dnd5/domain/article/service/VkTextFormatter.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
  * Пост на стене VK — это обычный текст без форматирования: жирный/курсив/подчёркивание VK в постах не
  * рендерит, поэтому все markdown-маркеры и теги {@code {@..}} снимаются, оставляя только содержимое.
  * Контент хранится массивом блоков (строки-абзацы и узлы-объекты: цитата/заголовок/разделитель);
- * {@link VttgMarkupConverter#toText} разворачивает блок в промежуточный markdown-подобный текст, из которого
+ * {@link VttgMarkupConverter#toTextKeepingMarkers} разворачивает блок в промежуточный markdown-подобный текст, из которого
  * мы убираем {@code **}/{@code *} и раскрываем ссылки.
  * <p>
  * Ссылки: внешние URL VK не умеет «маскировать» (подмена текста ссылкой работает только для внутренних
@@ -90,7 +90,7 @@ public class VkTextFormatter {
                 out.add(DIVIDER);
                 continue;
             }
-            String text = clean(markupConverter.toText(preprocessLinks(block.markup())));
+            String text = clean(markupConverter.toTextKeepingMarkers(preprocessLinks(block.markup())));
             if (text.isEmpty()) {
                 continue;
             }
@@ -169,7 +169,7 @@ public class VkTextFormatter {
     }
 
     /**
-     * Пред-обработка ДО {@link VttgMarkupConverter#toText}: маркеры-ссылки {@code {@type label | url:...}}
+     * Пред-обработка ДО {@link VttgMarkupConverter#toTextKeepingMarkers}: маркеры-ссылки {@code {@type label | url:...}}
      * → markdown {@code [label](абсолютный url)}. Нужна потому, что toText теряет ссылки: у обычного
      * {@code {@link}} выкидывает url, а секции со спейсовым {@code | url:} не распознаёт. Остальные маркеры
      * ({@code {@b}}/{@code {@u}}/…) не трогаем — их снимет {@link #stripTags}.

--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgMarkupConverter.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgMarkupConverter.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -22,24 +23,57 @@ public class VttgMarkupConverter {
     private static final Set<String> BLOCK_CONTENT_TYPES = Set.of(
             "doc", "blockquote", "bulletList", "orderedList", "listItem", "table", "tableRow"
     );
-    private static final Pattern SITE_LINK = Pattern.compile(
-            "\\{@(glossary|spell)\\s+([^|}]+)\\|url:([^}]+)}"
-    );
     private static final Map<String, String> SITE_LINK_SECTIONS = siteLinkSections();
-    private static final Pattern ITALIC = Pattern.compile("\\{@i\\s+([^}]+)}");
-    private static final Pattern BOLD = Pattern.compile("\\{@b\\s+([^}]+)}");
-    private static final Pattern ROLL = Pattern.compile("\\{@roll\\s+([^|}]+)(?:\\|[^}]*)?}");
-    /** Generic <code>{&#64;link term|url:...}</code> link; VTTG receives only the visible term text. */
-    private static final Pattern LINK = Pattern.compile("\\{@link\\s+([^|}]+)(?:\\|[^}]*)?}");
+    /**
+     * Ссылка на раздел сайта: {@code {@item кинжал|url:dagger-phb}}. Типы — ключи
+     * {@link #SITE_LINK_SECTIONS}: шаблон не должен хватать маркер другого рода с
+     * похожим телом. Метка — без фигурных скобок, чтобы вложенный маркер достался
+     * общему разбору, а не уехал внутрь текста ссылки. Пробелы вокруг {@code |} и
+     * после {@code url:} допускаются — в контенте встречается и такое написание.
+     */
+    private static final Pattern SITE_LINK = Pattern.compile(
+            "\\{@(" + String.join("|", SITE_LINK_SECTIONS.keySet()) + ")"
+                    + "\\s+([^|{}]+)\\|\\s*url:\\s*([^}|]+)}"
+    );
     /** Перенос строки {@code {@br}} — в VTTG раскрывается в обычный перевод строки. */
     private static final Pattern BR = Pattern.compile("\\{@br}");
+    /**
+     * Маркер {@code {@тип тело}}; тело — без вложенных скобок, поэтому совпадает самый
+     * внутренний. Разбор идёт повторными проходами изнутри наружу, так что вложенное
+     * оформление ({@code {@b важно: {@u прочти}}}) раскрывается целиком — регэксп с
+     * {@code [^}]} на такой вложенности рвал текст по первой закрывающей скобке.
+     */
+    private static final Pattern MARKER = Pattern.compile("\\{@([\\w-]+)(?:\\s+([^{}]*))?}");
+    /** Предел проходов раскрытия вложенных маркеров (как в форматтерах статей). */
+    private static final int MAX_MARKER_NESTING = 8;
+    /**
+     * Маркеры, у которых нет своего вида ни в одной целевой разметке — остаётся только
+     * метка. Броски: интерактивными их оставляет лишь {@link #toTextKeepingRolls}.
+     * {@code {@link}}: ведёт на произвольный роут сайта, а не на карточку сущности.
+     */
+    private static final Set<String> LABEL_ONLY_MARKERS = Set.of("roll", "link");
 
     private final ObjectMapper objectMapper;
     @Value("${app.url:https://ttg.club}")
     private String appUrl;
 
+    /**
+     * Куда поедет результат — от этого зависит, насколько разворачивать оформление.
+     *
+     * <p>{@code VTTG} — прямо в компендиум. Оформление раскрывается в разметку, которую
+     * понимает рендерер VTTG (markdown с GFM плюс инлайновый HTML для того, чего в
+     * markdown нет), а маркер, которому вида не нашлось, сворачивается в свою метку:
+     * служебные фигурные скобки в тексте карточки не нужны.</p>
+     *
+     * <p>{@code INTERMEDIATE} — вызывающему, который разбирает оформление сам под свою
+     * целевую разметку (форматтеры статей для Discord/Telegram/VK). Раскрываются только
+     * жирный и курсив — на них эти форматтеры и рассчитывают; остальные маркеры доезжают
+     * целыми, иначе {@code {@u ...}} или {@code {@spoiler ...}} потеряли бы вид.</p>
+     */
+    private enum Target { VTTG, INTERMEDIATE }
+
     public String toText(String markup) {
-        return convert(markup, false);
+        return convert(markup, false, Target.VTTG);
     }
 
     /**
@@ -48,23 +82,34 @@ public class VttgMarkupConverter {
      * (например магические предметы — см. wands.json).
      */
     public String toTextKeepingRolls(String markup) {
-        return convert(markup, true);
+        return convert(markup, true, Target.VTTG);
     }
 
-    private String convert(String markup, boolean keepRolls) {
+    /**
+     * Как {@link #toText(String)}, но отдаёт ПРОМЕЖУТОЧНЫЙ текст: маркеры оформления,
+     * кроме жирного и курсива, остаются нетронутыми — вызывающий разворачивает их сам
+     * под свою целевую разметку (форматтеры статей для Discord/Telegram/VK). Для VTTG
+     * такой режим не подходит: там нераскрытый маркер уедет в компендиум как есть.
+     */
+    public String toTextKeepingMarkers(String markup) {
+        return convert(markup, false, Target.INTERMEDIATE);
+    }
+
+    private String convert(String markup, boolean keepRolls, Target target) {
         if (!StringUtils.hasText(markup)) {
             return "";
         }
 
         try {
-            String extracted = extract(objectMapper.readTree(markup)).trim();
-            return replaceMarkup(StringUtils.hasText(extracted) ? extracted : markup, keepRolls);
+            String extracted = extract(objectMapper.readTree(markup), target).trim();
+            String source = StringUtils.hasText(extracted) ? extracted : markup;
+            return replaceMarkup(source, keepRolls, target);
         } catch (Exception ignored) {
-            return replaceMarkup(markup, keepRolls);
+            return replaceMarkup(markup, keepRolls, target);
         }
     }
 
-    private String extract(JsonNode node) {
+    private String extract(JsonNode node, Target target) {
         if (node == null || node.isNull()) {
             return "";
         }
@@ -72,7 +117,7 @@ public class VttgMarkupConverter {
             String value = node.textValue();
             if (looksLikeJson(value)) {
                 try {
-                    return extract(objectMapper.readTree(value));
+                    return extract(objectMapper.readTree(value), target);
                 } catch (Exception ignored) {
                     return value;
                 }
@@ -80,7 +125,7 @@ public class VttgMarkupConverter {
             return value;
         }
         if (node.isArray()) {
-            return extractChildren(node, true);
+            return extractChildren(node, true, target);
         }
         if (node.isObject()) {
             String type = node.path("type").asText();
@@ -91,38 +136,38 @@ public class VttgMarkupConverter {
             }
             // Списки: ProseMirror (bulletList/orderedList) и фронтовый {type:list}.
             if ("bulletList".equals(type)) {
-                return extractList(node, false);
+                return extractList(node, false, target);
             }
             if ("orderedList".equals(type)) {
-                return extractList(node, true);
+                return extractList(node, true, target);
             }
             if ("list".equals(type)) {
-                return extractFrontendList(node);
+                return extractFrontendList(node, target);
             }
             // Таблица: фронтовая форма (colLabels/rows) либо ProseMirror (content).
             if ("table".equals(type)) {
                 return node.has("colLabels") || node.has("rows")
-                        ? extractFrontendTable(node)
-                        : extractTable(node);
+                        ? extractFrontendTable(node, target)
+                        : extractTable(node, target);
             }
             // Инлайн-узлы фронтового диалекта (формат/ссылки) — узловая форма тех
             // же тегов, что в строках-абзацах идут литералами и разворачиваются в
             // replaceMarkup. null — не инлайн-узел, идёт обобщённо (текст+контент).
-            String inline = extractInlineNode(node, type);
+            String inline = extractInlineNode(node, type, target);
             if (inline != null) {
                 return inline;
             }
 
             String text = node.hasNonNull("text") ? node.get("text").asText() : "";
             String content = node.has("content")
-                    ? extractChildren(node.get("content"), hasBlockContent(type))
+                    ? extractChildren(node.get("content"), hasBlockContent(type), target)
                     : "";
             return text + content;
         }
         return "";
     }
 
-    private String extractList(JsonNode node, boolean ordered) {
+    private String extractList(JsonNode node, boolean ordered, Target target) {
         JsonNode items = node.get("content");
         if (items == null || !items.isArray()) {
             return "";
@@ -131,7 +176,7 @@ public class VttgMarkupConverter {
         int start = node.path("attrs").path("start").asInt(1);
         List<String> lines = new ArrayList<>();
         for (int index = 0; index < items.size(); index++) {
-            String content = extractListItem(items.get(index));
+            String content = extractListItem(items.get(index), target);
             if (StringUtils.hasText(content)) {
                 String marker = ordered ? (start + index) + ". " : "- ";
                 lines.add(marker + indentContinuation(content));
@@ -140,16 +185,16 @@ public class VttgMarkupConverter {
         return String.join("\n", lines);
     }
 
-    private String extractListItem(JsonNode item) {
+    private String extractListItem(JsonNode item, Target target) {
         if (item == null || !item.isObject()) {
-            return extract(item).trim();
+            return extract(item, target).trim();
         }
 
         JsonNode content = item.get("content");
         if (content == null) {
             return "";
         }
-        return extractChildren(content, true).trim();
+        return extractChildren(content, true, target).trim();
     }
 
     private String indentContinuation(String content) {
@@ -161,7 +206,7 @@ public class VttgMarkupConverter {
      * пункт — это МАССИВ-батч инлайна либо узел {@code {type:li}}. В markdown —
      * маркеры {@code - } / {@code N. } (как {@link #extractList}).
      */
-    private String extractFrontendList(JsonNode node) {
+    private String extractFrontendList(JsonNode node, Target target) {
         JsonNode items = node.get("content");
         if (items == null || !items.isArray()) {
             return "";
@@ -171,7 +216,7 @@ public class VttgMarkupConverter {
         List<String> lines = new ArrayList<>();
         int number = 1;
         for (JsonNode item : items) {
-            String content = extractFrontendListItem(item).trim();
+            String content = extractFrontendListItem(item, target).trim();
             if (StringUtils.hasText(content)) {
                 String marker = ordered ? (number++) + ". " : "- ";
                 lines.add(marker + indentContinuation(content));
@@ -181,14 +226,14 @@ public class VttgMarkupConverter {
     }
 
     /** Содержимое пункта фронтового списка: батч-массив, узел {@code {type:li}} или иной узел. */
-    private String extractFrontendListItem(JsonNode item) {
+    private String extractFrontendListItem(JsonNode item, Target target) {
         if (item.isArray()) {
-            return extractChildren(item, false);
+            return extractChildren(item, false, target);
         }
         if ("li".equals(item.path("type").asText())) {
-            return extractContent(item);
+            return extractContent(item, target);
         }
-        return extract(item);
+        return extract(item, target);
     }
 
     /**
@@ -196,13 +241,13 @@ public class VttgMarkupConverter {
      * rows[][]}} → markdown-таблица. Ячейка — строка либо {@code {content, align}}.
      * Стили колонок и подпись в VTTG опускаются (как и в {@link #extractTable}).
      */
-    private String extractFrontendTable(JsonNode node) {
+    private String extractFrontendTable(JsonNode node, Target target) {
         List<List<String>> table = new ArrayList<>();
 
         JsonNode colLabels = node.get("colLabels");
         if (colLabels != null && colLabels.isArray()) {
             List<String> header = new ArrayList<>();
-            colLabels.forEach(label -> header.add(formatTableCell(extractInlineCell(label))));
+            colLabels.forEach(label -> header.add(formatTableCell(extractInlineCell(label, target))));
             if (!header.isEmpty()) {
                 table.add(header);
             }
@@ -215,7 +260,7 @@ public class VttgMarkupConverter {
                     continue;
                 }
                 List<String> cells = new ArrayList<>();
-                row.forEach(cell -> cells.add(formatTableCell(extractInlineCell(cell))));
+                row.forEach(cell -> cells.add(formatTableCell(extractInlineCell(cell, target))));
                 if (!cells.isEmpty()) {
                     table.add(cells);
                 }
@@ -242,52 +287,49 @@ public class VttgMarkupConverter {
      * Всегда инлайн-склейка (без блочного {@code \n\n}), иначе в ячейке из нескольких
      * фрагментов (например {@code {@th Урон ({@dice к6})}}) появился бы ложный перенос.
      */
-    private String extractInlineCell(JsonNode cell) {
+    private String extractInlineCell(JsonNode cell, Target target) {
         if (cell.isArray()) {
-            return extractChildren(cell, false);
+            return extractChildren(cell, false, target);
         }
         if (cell.isObject() && cell.has("content") && !cell.has("type")) {
-            return extractChildren(cell.get("content"), false);
+            return extractChildren(cell.get("content"), false, target);
         }
-        return extract(cell);
+        return extract(cell, target);
     }
 
     /**
      * Разворачивает ИНЛАЙН-узел фронтового диалекта в текст/markdown. Возвращает
-     * null, если это не инлайн-узел (обрабатывается обобщённо). Форматирование
-     * повторяет {@link #replaceMarkup} (там — литеральные {@code {@...}} из строк),
-     * но здесь рекурсирует по вложенным узлам без риска регэкспа на «}».
+     * null, если это не инлайн-узел (обрабатывается обобщённо). Ссылки и оформление
+     * берутся из тех же таблиц, что и литеральные {@code {@...}} в строках
+     * ({@link #SITE_LINK_SECTIONS}, {@link #formatting}): один и тот же текст обязан
+     * выглядеть одинаково, в каком бы из двух диалектов его ни сохранили. Здесь разбор
+     * идёт рекурсией по вложенным узлам — без риска регэкспа на «}».
      */
-    private String extractInlineNode(JsonNode node, String type) {
-        if ("bold".equals(type)) {
-            return "**" + extractContent(node) + "**";
-        }
-        if ("italic".equals(type)) {
-            return "*" + extractContent(node) + "*";
-        }
-        // Ссылки на разделы сайта ({type:glossary|spell}, attrs.url) — как в
-        // replaceSiteLinks; прочие типы разделов/форматов идут обобщённо (текст).
+    private String extractInlineNode(JsonNode node, String type, Target target) {
+        // Ссылки на разделы сайта ({type:item|spell|glossary|…}, attrs.url) — как в
+        // replaceSiteLinks; прочие типы разделов идут обобщённо (текст).
         String section = SITE_LINK_SECTIONS.get(type);
         if (section != null) {
-            String label = extractContent(node).trim();
+            String label = extractContent(node, target).trim();
             String url = node.path("attrs").path("url").asText("");
             return url.isEmpty()
                     ? label
                     : "[" + label + "](" + siteUrl() + "/" + section + "/" + url + ")";
         }
         if ("link".equals(type)) {
-            return extractContent(node);
+            return extractContent(node, target);
         }
-        return null;
+        Wrap wrap = formatting(type, target);
+        return wrap == null ? null : wrap.around(extractContent(node, target));
     }
 
     /** Инлайн-содержимое узла (content) без блочных переносов; "" если пусто. */
-    private String extractContent(JsonNode node) {
+    private String extractContent(JsonNode node, Target target) {
         JsonNode content = node.get("content");
-        return content == null ? "" : extractChildren(content, false);
+        return content == null ? "" : extractChildren(content, false, target);
     }
 
-    private String extractTable(JsonNode node) {
+    private String extractTable(JsonNode node, Target target) {
         JsonNode rows = node.get("content");
         if (rows == null || !rows.isArray()) {
             return "";
@@ -295,7 +337,7 @@ public class VttgMarkupConverter {
 
         List<List<String>> table = new ArrayList<>();
         for (JsonNode row : rows) {
-            List<String> cells = extractTableRow(row);
+            List<String> cells = extractTableRow(row, target);
             if (!cells.isEmpty()) {
                 table.add(cells);
             }
@@ -314,14 +356,14 @@ public class VttgMarkupConverter {
         return String.join("\n", markdown);
     }
 
-    private List<String> extractTableRow(JsonNode row) {
+    private List<String> extractTableRow(JsonNode row, Target target) {
         JsonNode cells = row.get("content");
         if (cells == null || !cells.isArray()) {
             return List.of();
         }
 
         List<String> result = new ArrayList<>();
-        cells.forEach(cell -> result.add(formatTableCell(extract(cell))));
+        cells.forEach(cell -> result.add(formatTableCell(extract(cell, target))));
         return result;
     }
 
@@ -346,14 +388,14 @@ public class VttgMarkupConverter {
         return "| " + String.join(" | ", Collections.nCopies(width, "---")) + " |";
     }
 
-    private String extractChildren(JsonNode children, boolean blockContent) {
+    private String extractChildren(JsonNode children, boolean blockContent, Target target) {
         if (!children.isArray()) {
-            return extract(children);
+            return extract(children, target);
         }
 
         List<String> parts = new ArrayList<>();
         children.forEach(child -> {
-            String value = extract(child);
+            String value = extract(child, target);
             if (!value.isEmpty()) {
                 parts.add(blockContent ? value.trim() : value);
             }
@@ -374,27 +416,125 @@ public class VttgMarkupConverter {
                 || (trimmed.startsWith("{") && trimmed.endsWith("}"));
     }
 
-    private String replaceMarkup(String text, boolean keepRolls) {
+    private String replaceMarkup(String text, boolean keepRolls, Target target) {
         String formatted = replaceInline(text, BR, "\n");
-        formatted = replaceInline(formatted, ITALIC, "*$1*");
-        formatted = replaceInline(formatted, BOLD, "**$1**");
-        if (!keepRolls) {
-            formatted = unwrapLabel(formatted, ROLL);
-        }
-        formatted = unwrapLabel(formatted, LINK);
+        // Ссылки — до общего разбора: иначе от {@item ...|url:...} осталась бы метка.
+        formatted = replaceSiteLinks(formatted);
 
-        return replaceSiteLinks(formatted);
+        return expandMarkers(formatted, keepRolls, target);
     }
 
-    /** Заменяет каждое совпадение на его первую группу (метку), без обрамляющих тегов. */
-    private String unwrapLabel(String text, Pattern pattern) {
-        Matcher matcher = pattern.matcher(text);
-        StringBuilder result = new StringBuilder();
-        while (matcher.find()) {
-            matcher.appendReplacement(result, Matcher.quoteReplacement(matcher.group(1).trim()));
+    /**
+     * Разворачивает маркеры {@code {@тип тело}} повторными проходами изнутри наружу —
+     * так вложенное оформление раскрывается целиком, а не рвётся по первой закрывающей
+     * скобке. Проходы прекращаются, как только очередной ничего не заменил.
+     *
+     * @param text      текст с уже разобранными ссылками на разделы сайта
+     * @param keepRolls сохранять ли inline-теги {@code {@roll ...}}
+     * @param target    куда поедет результат (см. {@link Target})
+     */
+    private String expandMarkers(String text, boolean keepRolls, Target target) {
+        String current = text;
+        for (int pass = 0; pass < MAX_MARKER_NESTING && current.contains("{@"); pass++) {
+            Matcher matcher = MARKER.matcher(current);
+            StringBuilder result = new StringBuilder();
+            boolean replaced = false;
+            while (matcher.find()) {
+                String tag = matcher.group(1).toLowerCase(Locale.ROOT);
+                String expanded = expandMarker(tag, matcher.group(2), keepRolls, target);
+                if (expanded == null) {
+                    continue;
+                }
+                matcher.appendReplacement(result, Matcher.quoteReplacement(expanded));
+                replaced = true;
+            }
+            if (!replaced) {
+                return current;
+            }
+            matcher.appendTail(result);
+            current = result.toString();
         }
-        matcher.appendTail(result);
-        return result.toString();
+        return current;
+    }
+
+    /**
+     * Раскрытие одного маркера; {@code null} — оставить маркер как есть.
+     *
+     * <p>У тега оформления тело берётся целиком: это проза, в которой {@code |} — обычный
+     * символ. У остальных тело устроено как {@code метка|атрибут:значение}, поэтому
+     * остаётся только метка.</p>
+     *
+     * @param tag       тип маркера в нижнем регистре
+     * @param body      тело маркера ({@code null}, если его нет)
+     * @param keepRolls сохранять ли inline-теги {@code {@roll ...}}
+     * @param target    куда поедет результат (см. {@link Target})
+     */
+    private static String expandMarker(String tag, String body, boolean keepRolls, Target target) {
+        if (keepRolls && "roll".equals(tag)) {
+            return null;
+        }
+        Wrap wrap = formatting(tag, target);
+        if (wrap != null) {
+            return wrap.around(body == null ? "" : body.trim());
+        }
+        // Незнакомый маркер сворачивается в метку только для VTTG: промежуточному
+        // потребителю он нужен целым, чтобы развернуть под свою разметку самому.
+        String label = markerLabel(body);
+        return target == Target.VTTG || LABEL_ONLY_MARKERS.contains(tag) ? label : null;
+    }
+
+    /** Обёртка оформления в целевой разметке. */
+    private record Wrap(String open, String close) {
+        /** Оборачивает содержимое; пустое оставляет пустым, чтобы не родить голые «****». */
+        private String around(String content) {
+            return content.isEmpty() ? content : open + content + close;
+        }
+    }
+
+    /**
+     * Обёртка для тега оформления либо {@code null}, если тег не про оформление.
+     *
+     * <p>Жирный и курсив раскрываются всегда: на них рассчитывают форматтеры статей,
+     * которые читают из промежуточного текста только {@code **}, {@code *} и
+     * {@code [](…)}. Остальное — только для VTTG: там рендерер разбирает markdown с
+     * GFM и вставляет результат как HTML, поэтому зачёркнутый и код выражаются
+     * markdown'ом, а подчёркнутый, индексы и выделение — инлайновым HTML, которого в
+     * markdown нет. Промежуточному потребителю они уходят маркерами: {@code ~~} и
+     * {@code <u>} он не понимает и показал бы их сырыми.</p>
+     *
+     * @param tag    тип маркера в нижнем регистре либо тип инлайн-узла
+     * @param target куда поедет результат (см. {@link Target})
+     */
+    private static Wrap formatting(String tag, Target target) {
+        Wrap core = switch (tag) {
+            case "b", "bold" -> new Wrap("**", "**");
+            case "i", "italic" -> new Wrap("*", "*");
+            default -> null;
+        };
+        if (core != null || target != Target.VTTG) {
+            return core;
+        }
+        return switch (tag) {
+            case "em" -> new Wrap("*", "*");
+            // Заголовок внутри абзаца отдельным уровнем не выразить — остаётся жирным.
+            case "h", "heading" -> new Wrap("**", "**");
+            case "s", "strike", "strikethrough" -> new Wrap("~~", "~~");
+            case "code", "kbd" -> new Wrap("`", "`");
+            case "u", "underline" -> new Wrap("<u>", "</u>");
+            case "sup" -> new Wrap("<sup>", "</sup>");
+            case "sub" -> new Wrap("<sub>", "</sub>");
+            case "mark", "highlight" -> new Wrap("<mark>", "</mark>");
+            default -> null;
+        };
+    }
+
+    /** Видимая метка маркера: тело до первого {@code |}; пустая, если тела нет. */
+    private static String markerLabel(String body) {
+        if (body == null) {
+            return "";
+        }
+        int pipe = body.indexOf('|');
+        return (pipe < 0 ? body : body.substring(0, pipe)).trim();
     }
 
     private String replaceSiteLinks(String text) {
@@ -405,8 +545,10 @@ public class VttgMarkupConverter {
             String label = matcher.group(2).trim();
             String url = matcher.group(3).trim();
             String section = SITE_LINK_SECTIONS.get(type);
+            // Шаблон построен по ключам карты, поэтому раздел здесь всегда известен;
+            // ветка с меткой — страховка на случай расхождения.
             String replacement = section == null
-                    ? matcher.group()
+                    ? label
                     : "[" + label + "](" + siteUrl() + "/" + section + "/" + url + ")";
             matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
         }
@@ -423,10 +565,24 @@ public class VttgMarkupConverter {
         return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
     }
 
+    /**
+     * Тип маркера-ссылки → путь раздела на сайте. Повторяет фронтовую
+     * {@code MARKER_URL_MAP} (тот же список, что в форматтерах статей): в контенте
+     * встречаются ссылки на любой раздел, а не только на глоссарий и заклинания —
+     * например стартовое снаряжение предыстории состоит из {@code {@item ...}}.
+     */
     private static Map<String, String> siteLinkSections() {
         Map<String, String> result = new LinkedHashMap<>();
-        result.put("glossary", "glossary");
+        result.put("class", "classes");
         result.put("spell", "spells");
+        result.put("feat", "feats");
+        result.put("background", "backgrounds");
+        result.put("magicItem", "magic-items");
+        result.put("magic-item", "magic-items");
+        result.put("item", "items");
+        result.put("creature", "bestiary");
+        result.put("bestiary", "bestiary");
+        result.put("glossary", "glossary");
         return result;
     }
 }

--- a/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgMarkupConverterTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgMarkupConverterTest.java
@@ -177,6 +177,162 @@ class VttgMarkupConverterTest {
         );
     }
 
+    /** Ссылки на прочие разделы сайта — не только глоссарий и заклинания. */
+    @Test
+    void replacesOtherSectionMarkupWithSiteLink() {
+        assertEquals(
+                "[кинжал](https://ttg.club/items/dagger-phb)",
+                converter.toText("{@item кинжал|url:dagger-phb}")
+        );
+        assertEquals(
+                "[Бдительный](https://ttg.club/feats/alert-phb)",
+                converter.toText("{@feat Бдительный|url:alert-phb}")
+        );
+        assertEquals(
+                "[Гоблин](https://ttg.club/bestiary/goblin-mm)",
+                converter.toText("{@creature Гоблин|url:goblin-mm}")
+        );
+        assertEquals(
+                "[Сумка хранения](https://ttg.club/magic-items/bag-of-holding-dmg)",
+                converter.toText("{@magicItem Сумка хранения|url:bag-of-holding-dmg}")
+        );
+    }
+
+    /** Стартовое снаряжение предыстории целиком состоит из ссылок на предметы. */
+    @Test
+    void replacesEveryItemMarkupInEquipmentLine() {
+        assertEquals(
+                "2 [кинжала](https://ttg.club/items/dagger-phb), "
+                        + "[воровские инструменты](https://ttg.club/items/thieves-tools-phb), "
+                        + "[лом](https://ttg.club/items/crowbar-phb), "
+                        + "2 [сумки](https://ttg.club/items/pouch-phb), "
+                        + "[одежда путешественника](https://ttg.club/items/clothes-traveler-s-phb) и 16 зм",
+                converter.toText("2 {@item кинжала|url:dagger-phb}, "
+                        + "{@item воровские инструменты|url:thieves-tools-phb}, "
+                        + "{@item лом|url:crowbar-phb}, "
+                        + "2 {@item сумки|url:pouch-phb}, "
+                        + "{@item одежда путешественника|url:clothes-traveler-s-phb} и 16 зм")
+        );
+    }
+
+    /** Пробелы вокруг «|» и после «url:» встречаются в контенте и не должны ломать разбор. */
+    @Test
+    void toleratesSpacesAroundLinkAttribute() {
+        assertEquals(
+                "[лом](https://ttg.club/items/crowbar-phb)",
+                converter.toText("{@item лом | url: crowbar-phb}")
+        );
+    }
+
+    /** Незнакомый маркер разворачивается в метку — фигурные скобки в текст не уезжают. */
+    @Test
+    void unwrapsUnknownMarkerToItsLabel() {
+        assertEquals("Урон", converter.toText("{@th Урон}"));
+        assertEquals("Некий вид", converter.toText("{@species Некий вид|url:some-species}"));
+    }
+
+    /**
+     * Оформление доезжает до VTTG в разметке его рендерера: markdown с GFM для
+     * зачёркнутого и кода, инлайновый HTML для того, чего в markdown нет.
+     */
+    @Test
+    void expandsFormattingMarkupForVttg() {
+        assertEquals("**жирный**", converter.toText("{@b жирный}"));
+        assertEquals("*курсив*", converter.toText("{@i курсив}"));
+        assertEquals("*курсив*", converter.toText("{@em курсив}"));
+        assertEquals("~~зачёркнутый~~", converter.toText("{@s зачёркнутый}"));
+        assertEquals("~~зачёркнутый~~", converter.toText("{@strikethrough зачёркнутый}"));
+        assertEquals("`код`", converter.toText("{@code код}"));
+        assertEquals("<u>подчёркнутый</u>", converter.toText("{@u подчёркнутый}"));
+        assertEquals("<sup>2</sup>", converter.toText("{@sup 2}"));
+        assertEquals("<sub>n</sub>", converter.toText("{@sub n}"));
+        assertEquals("<mark>важное</mark>", converter.toText("{@highlight важное}"));
+        // Заголовок внутри абзаца отдельным уровнем не выразить — остаётся жирным.
+        assertEquals("**Заголовок**", converter.toText("{@h Заголовок}"));
+    }
+
+    /** Вложенное оформление раскрывается целиком, а не рвётся по первой закрывающей скобке. */
+    @Test
+    void expandsNestedFormattingMarkup() {
+        assertEquals(
+                "**важно: <u>прочти</u>**",
+                converter.toText("{@b важно: {@u прочти}}")
+        );
+        assertEquals(
+                "*см. [кинжал](https://ttg.club/items/dagger-phb)*",
+                converter.toText("{@i см. {@item кинжал|url:dagger-phb}}")
+        );
+    }
+
+    /** У тега оформления тело — проза: вертикальная черта в ней не отрезает остаток. */
+    @Test
+    void keepsPipeInsideFormattingBody() {
+        assertEquals("**2|3**", converter.toText("{@b 2|3}"));
+    }
+
+    /** Узловой диалект оформляется той же таблицей, что и литеральные маркеры. */
+    @Test
+    void expandsFormattingNodesForVttg() {
+        String markup = """
+                {
+                  "type": "doc",
+                  "content": [
+                    {
+                      "type": "paragraph",
+                      "content": [
+                        {"type": "underline", "content": [{"type": "text", "text": "важно"}]},
+                        {"type": "text", "text": " и "},
+                        {"type": "strike", "content": [{"type": "text", "text": "отменено"}]}
+                      ]
+                    }
+                  ]
+                }
+                """;
+
+        assertEquals("<u>важно</u> и ~~отменено~~", converter.toText(markup));
+    }
+
+    /** Тот же узловой диалект в промежуточном режиме — маркеры разметки не подставляются. */
+    @Test
+    void keepsFormattingNodesPlainForIntermediateTarget() {
+        String markup = """
+                {
+                  "type": "doc",
+                  "content": [
+                    {
+                      "type": "paragraph",
+                      "content": [
+                        {"type": "underline", "content": [{"type": "text", "text": "важно"}]}
+                      ]
+                    }
+                  ]
+                }
+                """;
+
+        assertEquals("важно", converter.toTextKeepingMarkers(markup));
+    }
+
+    /** Режим с сохранением бросков не должен быть съеден страховкой от утечки маркеров. */
+    @Test
+    void keepsRollMarkupInRollPreservingMode() {
+        assertEquals(
+                "Наносит {@roll 2к6} урона [кислотой](https://ttg.club/glossary/acid-phb)",
+                converter.toTextKeepingRolls("Наносит {@roll 2к6} урона {@glossary кислотой|url:acid-phb}")
+        );
+    }
+
+    /**
+     * Промежуточный режим отдаёт теги оформления нетронутыми — их разбирают
+     * форматтеры статей под свою целевую разметку.
+     */
+    @Test
+    void keepsUnknownMarkersInMarkerPreservingMode() {
+        assertEquals(
+                "**Важно**: {@u подчёркнутый} и {@spoiler скрытый}",
+                converter.toTextKeepingMarkers("{@b Важно}: {@u подчёркнутый} и {@spoiler скрытый}")
+        );
+    }
+
     @Test
     void replacesInlineRollMarkupWithDisplayedFormula() {
         assertEquals("+1", converter.toText("{@roll +1|notation:1d20+1}"));


### PR DESCRIPTION
Конвертер знал только два типа маркеров-ссылок — glossary и spell. Всё остальное проваливалось насквозь и уезжало в компендиум сырым: стартовое снаряжение предыстории состоит из {@item ...} целиком, поэтому в карточке показывались фигурные скобки вместо названий предметов. Теги оформления ({@u}, {@s}, {@code} и прочие) терялись там же.

Ссылки на разделы сайта:

- карта типов перенесена один в один из SECTION_PATHS форматтеров статей (она снята с фронтовой MARKER_URL_MAP): class, spell, feat, background, magicItem, magic-item, item, creature, bestiary, glossary;
- шаблон SITE_LINK строится из ключей карты — разъехаться они больше не могут — и не пускает фигурные скобки в метку, иначе вложенная ссылка внутри оформления съедалась бы целиком;
- допускаются пробелы вокруг «|» и после «url:» — в контенте встречается и такое написание.

Оформление:

- четыре отдельных регэкспа (ITALIC, BOLD, ROLL, LINK) заменены единым проходом по маркерам изнутри наружу с общей таблицей обёрток;
- попутно чинится разрыв текста на вложенности: шаблоны с [^}] резали тело по первой закрывающей скобке, и {@b важно: {@u прочти}} давало «**важно: {@u прочти**}»;
- таблица сверена с рендерером VTTG (marked с gfm, результат вставляется как HTML): зачёркнутый и код выражаются markdown'ом, подчёркнутый, индексы и выделение — инлайновым HTML, которого в markdown нет;
- у тега оформления тело берётся целиком: там проза, в которой «|» — обычный символ, а не разделитель атрибутов;
- маркер, которому вида не нашлось, сворачивается в свою метку — служебные скобки в тексте карточки не нужны.

Узловой диалект (форма из редактора) раньше знал только bold и italic — подчёркивание и зачёркивание молча терялись. Теперь extractInlineNode берёт ту же таблицу ссылок и оформления, что и литеральные маркеры: один и тот же текст выглядит одинаково, в каком бы диалекте его ни сохранили.

Режимы вывода разведены enum'ом Target вместо флага:

- VTTG (toText, toTextKeepingRolls) — раскрывать всё, незнакомое сворачивать в метку;
- INTERMEDIATE (новый toTextKeepingMarkers) — раскрывать только жирный и курсив, остальные маркеры отдавать целыми.

Второй режим нужен форматтерам статей: они читают из промежуточного текста только «**», «*» и «[](...)», а {@u}/{@spoiler} разворачивают сами под свою целевую разметку — получив «~~» или «<u>», они показали бы их сырыми. Все три форматтера переведены на него, их поведение не изменилось. Ради этого Target протянут через рекурсию extract* — иначе узловой диалект не мог бы вести себя по-разному для разных потребителей.

Тесты конвертера: 27 (12 новых) — ссылки на все разделы, точная строка снаряжения предыстории, вложенное оформление, оба диалекта и оба режима.