### PR TITLE
feat(vttg): записи компендиума несут адрес своей страницы на сайте

### DIFF
--- a/src/main/java/club/ttg/dnd5/domain/vttg/rest/dto/VttgBackground.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/rest/dto/VttgBackground.java
@@ -35,6 +35,14 @@ public class VttgBackground {
     private String description;
     /** Слаг листа дерева разделов, в котором показывается запись — всегда "backgrounds". */
     private String section;
+    /**
+     * Раздел сайта в адресе страницы-источника ({@code backgrounds} в {@code /backgrounds/sage-phb}).
+     * По паре {@code srcSection}/{@code srcUrl} VTTG находит запись в компендиуме, когда в
+     * описании кликают ссылку.
+     */
+    private String srcSection;
+    /** Слаг страницы-источника на сайте; с {@code srcSection} составляет адрес ссылки. */
+    private String srcUrl;
     /** Ключ источника: "phb"/"dmg"/... */
     private String sourceKey;
     private AbilityGrant abilityGrant;

--- a/src/main/java/club/ttg/dnd5/domain/vttg/rest/dto/VttgClass.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/rest/dto/VttgClass.java
@@ -37,6 +37,15 @@ public class VttgClass {
     private String id;
     /** Слаг листа дерева разделов, в котором показывается запись — всегда "classes". */
     private String section;
+    /**
+     * Раздел сайта в адресе страницы-источника ({@code classes} в {@code /classes/druid-phb}).
+     * По паре {@code srcSection}/{@code srcUrl} VTTG находит запись в компендиуме, когда в
+     * описании кликают ссылку. {@code srcUrl} не равен {@code id}: тот собирается из
+     * английского имени ({@code druid}), а слаг сайта несёт суффикс источника.
+     */
+    private String srcSection;
+    /** Слаг страницы-источника на сайте; с {@code srcSection} составляет адрес ссылки. */
+    private String srcUrl;
     /** Стабильный ключ класса (slug из английского имени, как в {@code spell.classKeys}). */
     private String key;
     private String name;

--- a/src/main/java/club/ttg/dnd5/domain/vttg/rest/dto/VttgCreature.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/rest/dto/VttgCreature.java
@@ -15,6 +15,15 @@ public class VttgCreature {
     private String type;
     /** Slug листа дерева разделов, в котором показывается запись (всегда "creatures"). */
     private String section;
+    /**
+     * Раздел сайта в адресе страницы-источника ({@code bestiary} в {@code /bestiary/goblin-mm}).
+     * По паре {@code srcSection}/{@code srcUrl} VTTG находит запись в компендиуме, когда в
+     * описании кликают ссылку. С {@code section} не совпадает: там лист дерева компендиума
+     * ({@code creatures}), здесь раздел сайта.
+     */
+    private String srcSection;
+    /** Слаг страницы-источника на сайте; с {@code srcSection} составляет адрес ссылки. */
+    private String srcUrl;
     private Boolean autoSaves;
     private String name;
     private String nameEn;

--- a/src/main/java/club/ttg/dnd5/domain/vttg/rest/dto/VttgFeat.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/rest/dto/VttgFeat.java
@@ -24,6 +24,15 @@ public class VttgFeat {
     private String type;
     /** Слаг листа дерева разделов, в котором показывается запись — всегда "feats". */
     private String section;
+    /**
+     * Раздел сайта в адресе страницы-источника ({@code feats} в {@code /feats/alert-phb}).
+     * По паре {@code srcSection}/{@code srcUrl} VTTG находит запись в компендиуме, когда в
+     * описании кликают ссылку. {@code srcUrl} не равен {@code id}: тот собирается по схеме
+     * эталона ({@code srd_feat_alert}).
+     */
+    private String srcSection;
+    /** Слаг страницы-источника на сайте; с {@code srcSection} составляет адрес ссылки. */
+    private String srcUrl;
     /** Ключ источника: "phb"/"dmg"/... */
     private String sourceKey;
     /** Подтип записи в VTTG — всегда "feat". */

--- a/src/main/java/club/ttg/dnd5/domain/vttg/rest/dto/VttgMagicItem.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/rest/dto/VttgMagicItem.java
@@ -31,6 +31,27 @@ public class VttgMagicItem {
     private String typeLabel;
     /** Slug листа дерева разделов, куда положить запись (weapons/armor/rings/wands/wondrous). */
     private String section;
+    /**
+     * Раздел сайта в адресе страницы-источника — всегда {@code magic-items}. По паре
+     * {@code srcSection}/{@code srcUrl} VTTG находит запись в компендиуме, когда в описании
+     * кликают ссылку. С {@code section} не совпадает: там лист дерева компендиума.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String srcSection;
+    /**
+     * Слаг страницы-источника на сайте. У всех записей, на которые раскрылся один предмет,
+     * он ОДИН И ТОТ ЖЕ — слаг родителя: страница на сайте у них общая.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String srcUrl;
+    /**
+     * Запись — производная от страницы-источника, а не сама она: раскрытие по базовому
+     * предмету («полулаты или латы») или по шаблону «+1/+2/+3». Нужен VTTG, чтобы из группы
+     * записей с общим {@code srcUrl} выбрать ту, которую открывать по ссылке. У якорной
+     * записи опускается.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean srcVariant;
     private int quantity;
     /** Вес в фунтах (в модели источника отсутствует — по умолчанию 0). */
     private double weight;

--- a/src/main/java/club/ttg/dnd5/domain/vttg/rest/dto/VttgSpecies.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/rest/dto/VttgSpecies.java
@@ -37,6 +37,14 @@ public class VttgSpecies {
     private String id;
     /** Слаг листа дерева разделов, в котором показывается запись — всегда "species". */
     private String section;
+    /**
+     * Раздел сайта в адресе страницы-источника ({@code species} в {@code /species/elf-phb}).
+     * По паре {@code srcSection}/{@code srcUrl} VTTG находит запись в компендиуме, когда в
+     * описании кликают ссылку.
+     */
+    private String srcSection;
+    /** Слаг страницы-источника на сайте; с {@code srcSection} составляет адрес ссылки. */
+    private String srcUrl;
     /** Стабильный ключ вида (slug из url). */
     private String key;
     /** Признак SRD (для раскладки по пакам); выводится всегда. */

--- a/src/main/java/club/ttg/dnd5/domain/vttg/rest/dto/VttgSpell.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/rest/dto/VttgSpell.java
@@ -54,6 +54,15 @@ public class VttgSpell {
     private String type;
     /** Slug листа дерева разделов, в котором показывается запись (всегда "spells"). */
     private String section;
+    /**
+     * Раздел сайта в адресе страницы-источника ({@code items} в {@code /items/dagger-phb}).
+     * По паре {@code srcSection}/{@code srcUrl} VTTG находит запись в компендиуме, когда в
+     * описании кликают ссылку. С {@code section} совпадает не всегда: там лист дерева
+     * компендиума, здесь раздел сайта.
+     */
+    private String srcSection;
+    /** Слаг страницы-источника на сайте; с {@code srcSection} составляет адрес ссылки. */
+    private String srcUrl;
 
     @JsonProperty("isSRD")
     public boolean isSRD() {

--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgBackgroundMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgBackgroundMapper.java
@@ -3,6 +3,7 @@ package club.ttg.dnd5.domain.vttg.service;
 import club.ttg.dnd5.domain.background.model.Background;
 import club.ttg.dnd5.domain.common.dictionary.Ability;
 import club.ttg.dnd5.domain.common.dictionary.Skill;
+import club.ttg.dnd5.domain.common.model.SectionType;
 import club.ttg.dnd5.domain.feat.model.Feat;
 import club.ttg.dnd5.domain.source.model.Source;
 import club.ttg.dnd5.domain.vttg.rest.dto.VttgBackground;
@@ -51,6 +52,8 @@ public class VttgBackgroundMapper {
                 .nameEn(optional(background.getEnglish()))
                 .description(markupConverter.toText(background.getDescription()))
                 .section(SECTION)
+                .srcSection(SectionType.BACKGROUND.getValue())
+                .srcUrl(background.getUrl())
                 .sourceKey(sourceKey(background.getSource()))
                 .isSRD(background.getSrdVersion() != null)
                 .abilityGrant(abilityGrant(background.getAbilities()))

--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgClassMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgClassMapper.java
@@ -4,6 +4,7 @@ import club.ttg.dnd5.domain.character_class.model.ArmorProficiency;
 import club.ttg.dnd5.domain.character_class.model.CasterType;
 import club.ttg.dnd5.domain.character_class.model.CharacterClass;
 import club.ttg.dnd5.domain.character_class.model.ClassFeature;
+import club.ttg.dnd5.domain.common.model.SectionType;
 import club.ttg.dnd5.domain.character_class.model.ClassFeatureOption;
 import club.ttg.dnd5.domain.character_class.model.ClassFeatureScaling;
 import club.ttg.dnd5.domain.character_class.model.ClassTableColumn;
@@ -104,6 +105,8 @@ public class VttgClassMapper {
                 .type(TYPE)
                 .id(key)
                 .section(SECTION)
+                .srcSection(SectionType.CLASS.getValue())
+                .srcUrl(characterClass.getUrl())
                 .key(key)
                 .name(characterClass.getName())
                 .nameEn(optional(characterClass.getEnglish()))

--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgCreatureMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgCreatureMapper.java
@@ -1,6 +1,7 @@
 package club.ttg.dnd5.domain.vttg.service;
 
 import club.ttg.dnd5.domain.beastiary.model.Creature;
+import club.ttg.dnd5.domain.common.model.SectionType;
 import club.ttg.dnd5.domain.beastiary.model.CreatureAbility;
 import club.ttg.dnd5.domain.beastiary.model.CreatureLair;
 import club.ttg.dnd5.domain.beastiary.model.CreatureSkill;
@@ -76,6 +77,9 @@ public class VttgCreatureMapper {
                 .entityType("creature")
                 .type("creature")
                 .section("creatures")
+                // Раздел сайта у существ — "bestiary", а лист компендиума — "creatures".
+                .srcSection(SectionType.BESTIARY.getValue())
+                .srcUrl(creature.getUrl())
                 .autoSaves(true)
                 .name(creature.getName())
                 .nameEn(creature.getEnglish())

--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgFeatMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgFeatMapper.java
@@ -1,5 +1,6 @@
 package club.ttg.dnd5.domain.vttg.service;
 
+import club.ttg.dnd5.domain.common.model.SectionType;
 import club.ttg.dnd5.domain.feat.model.Feat;
 import club.ttg.dnd5.domain.feat.model.FeatCategory;
 import club.ttg.dnd5.domain.source.model.Source;
@@ -47,6 +48,8 @@ public class VttgFeatMapper {
                 .nameEn(optional(feat.getEnglish()))
                 .type(TYPE)
                 .section(SECTION)
+                .srcSection(SectionType.FEAT.getValue())
+                .srcUrl(feat.getUrl())
                 .sourceKey(sourceKey(feat.getSource()))
                 .isSRD(feat.getSrdVersion() != null)
                 .featureType(TYPE)

--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgItemMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgItemMapper.java
@@ -4,6 +4,7 @@ import club.ttg.dnd5.domain.common.dictionary.ArmorCategory;
 import club.ttg.dnd5.domain.common.dictionary.DamageType;
 import club.ttg.dnd5.domain.common.dictionary.WeaponCategory;
 import club.ttg.dnd5.domain.common.model.Roll;
+import club.ttg.dnd5.domain.common.model.SectionType;
 import club.ttg.dnd5.domain.item.model.Armor;
 import club.ttg.dnd5.domain.item.model.Item;
 import club.ttg.dnd5.domain.item.model.ItemCategory;
@@ -56,6 +57,10 @@ public class VttgItemMapper {
         Map<String, Object> data = new LinkedHashMap<>();
 
         data.put("id", id(item, sourceKey));
+        // Страница-источник: id несёт суффикс источника, слаг сайта — не всегда, поэтому
+        // адрес ссылки из описаний выводится только из этой пары, а не из id.
+        data.put("srcSection", SectionType.ITEM.getValue());
+        data.put("srcUrl", item.getUrl());
         data.put("name", item.getName());
         String nameEn = cleanNameEn(item.getEnglish());
         if (nameEn != null) {

--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgMagicItemMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgMagicItemMapper.java
@@ -3,6 +3,7 @@ package club.ttg.dnd5.domain.vttg.service;
 import club.ttg.dnd5.domain.common.dictionary.ArmorCategory;
 import club.ttg.dnd5.domain.common.dictionary.Coin;
 import club.ttg.dnd5.domain.common.dictionary.Rarity;
+import club.ttg.dnd5.domain.common.model.SectionType;
 import club.ttg.dnd5.domain.item.model.Item;
 import club.ttg.dnd5.domain.item.repository.ItemRepository;
 import club.ttg.dnd5.domain.magic.model.Attunement;
@@ -23,6 +24,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -167,6 +169,11 @@ public class VttgMagicItemMapper {
                 .type(weapon ? "weapon" : "equipment")
                 .typeLabel(weapon ? "Оружие" : "Снаряжение")
                 .section(section(category))
+                // Страница-источник у всех записей раскрытия одна — родительская: варианты
+                // («полулаты или латы», «+1/+2/+3») своих страниц на сайте не имеют.
+                .srcSection(SectionType.MAGIC_ITEM.getValue())
+                .srcUrl(item.getUrl())
+                .srcVariant(Objects.equals(url, item.getUrl()) ? null : Boolean.TRUE)
                 .quantity(1)
                 // Вес берём у базового предмета (по clarification); иначе 0.
                 .weight(mechanics.weight())

--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgMarkupConverter.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgMarkupConverter.java
@@ -1,5 +1,6 @@
 package club.ttg.dnd5.domain.vttg.service;
 
+import club.ttg.dnd5.domain.common.model.SectionType;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -586,19 +587,24 @@ public class VttgMarkupConverter {
      * {@code MARKER_URL_MAP} (тот же список, что в форматтерах статей): в контенте
      * встречаются ссылки на любой раздел, а не только на глоссарий и заклинания —
      * например стартовое снаряжение предыстории состоит из {@code {@item ...}}.
+     *
+     * <p>Пути берутся из {@link SectionType}, а не пишутся строками: мапперы выгрузки кладут
+     * в записи компендиума ту же величину полем {@code srcSection}, и по паре
+     * {@code srcSection}/{@code srcUrl} VTTG находит цель ссылки у себя. Разъехаться эти два
+     * места не должны.</p>
      */
     private static Map<String, String> siteLinkSections() {
         Map<String, String> result = new LinkedHashMap<>();
-        result.put("class", "classes");
-        result.put("spell", "spells");
-        result.put("feat", "feats");
-        result.put("background", "backgrounds");
-        result.put("magicItem", "magic-items");
-        result.put("magic-item", "magic-items");
-        result.put("item", "items");
-        result.put("creature", "bestiary");
-        result.put("bestiary", "bestiary");
-        result.put("glossary", "glossary");
+        result.put("class", SectionType.CLASS.getValue());
+        result.put("spell", SectionType.SPELL.getValue());
+        result.put("feat", SectionType.FEAT.getValue());
+        result.put("background", SectionType.BACKGROUND.getValue());
+        result.put("magicItem", SectionType.MAGIC_ITEM.getValue());
+        result.put("magic-item", SectionType.MAGIC_ITEM.getValue());
+        result.put("item", SectionType.ITEM.getValue());
+        result.put("creature", SectionType.BESTIARY.getValue());
+        result.put("bestiary", SectionType.BESTIARY.getValue());
+        result.put("glossary", SectionType.GLOSSARY.getValue());
         return result;
     }
 }

--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgPayloadStore.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgPayloadStore.java
@@ -46,7 +46,7 @@ public class VttgPayloadStore {
     private static final Logger log = LoggerFactory.getLogger(VttgPayloadStore.class);
 
     /** Версия логики мапперов. Увеличьте при изменении формата payload — все строки пересчитаются. */
-    public static final int SCHEMA_VERSION = 9;
+    public static final int SCHEMA_VERSION = 10;
     /**
      * Размер пакета пересчёта/сохранения: ограничивает {@code IN}-список, объём транзакции и
      * зону поражения при сбое (на поштучную обработку переходит только сбойный пакет).

--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgSpeciesMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgSpeciesMapper.java
@@ -1,6 +1,7 @@
 package club.ttg.dnd5.domain.vttg.service;
 
 import club.ttg.dnd5.domain.common.dictionary.CreatureType;
+import club.ttg.dnd5.domain.common.model.SectionType;
 import club.ttg.dnd5.domain.common.dictionary.Size;
 import club.ttg.dnd5.domain.source.model.Source;
 import club.ttg.dnd5.domain.species.model.Species;
@@ -45,6 +46,8 @@ public class VttgSpeciesMapper {
                 // id обязателен для раскладки дельты (routeEntity: <id>.json), иначе вид отбрасывается.
                 .id(key)
                 .section(SECTION)
+                .srcSection(SectionType.SPECIES.getValue())
+                .srcUrl(species.getUrl())
                 .key(key)
                 .isSRD(species.getSrdVersion() != null)
                 .name(species.getName())

--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgSpellMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgSpellMapper.java
@@ -3,6 +3,7 @@ package club.ttg.dnd5.domain.vttg.service;
 import club.ttg.dnd5.domain.beastiary.model.action.AttackType;
 import club.ttg.dnd5.domain.character_class.model.CharacterClass;
 import club.ttg.dnd5.domain.common.dictionary.Ability;
+import club.ttg.dnd5.domain.common.model.SectionType;
 import club.ttg.dnd5.domain.source.model.Source;
 import club.ttg.dnd5.domain.spell.model.AreaOfEffect;
 import club.ttg.dnd5.domain.spell.model.MaterialComponent;
@@ -97,6 +98,8 @@ public class VttgSpellMapper {
                 .classKeys(classKeys(spell))
                 .type("spell")
                 .section("spells")
+                .srcSection(SectionType.SPELL.getValue())
+                .srcUrl(spell.getUrl())
                 .build();
     }
 

--- a/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgBackgroundMapperTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgBackgroundMapperTest.java
@@ -164,6 +164,15 @@ class VttgBackgroundMapperTest {
         );
     }
 
+    /** Идентичность страницы-источника предыстории. */
+    @Test
+    void exportsSourcePageIdentity() {
+        JsonNode json = json(baseBackground("sage-phb", "Мудрец", "Sage"));
+
+        assertEquals("backgrounds", json.get("srcSection").asText());
+        assertEquals("sage-phb", json.get("srcUrl").asText());
+    }
+
     private JsonNode json(Background bg) {
         return objectMapper.valueToTree(mapper.toVttg(bg));
     }

--- a/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgClassMapperTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgClassMapperTest.java
@@ -154,6 +154,20 @@ class VttgClassMapperTest {
         return columns.get(0).get("key").asText();
     }
 
+    /**
+     * Идентичность страницы-источника: {@code id}/{@code key} собираются из английского имени,
+     * поэтому адрес страницы из них не выводится — его отдаём отдельно.
+     */
+    @Test
+    void exportsSourcePageIdentity() {
+        JsonNode json = json(baseClass("druid-phb", "Друид", "Druid"));
+
+        assertEquals("classes", json.get("srcSection").asText());
+        assertEquals("druid-phb", json.get("srcUrl").asText());
+        assertEquals("druid", json.get("id").asText());
+        assertEquals("druid", json.get("key").asText());
+    }
+
     private JsonNode json(CharacterClass characterClass) {
         return objectMapper.valueToTree(mapper.toVttg(characterClass));
     }

--- a/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgCreatureMapperTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgCreatureMapperTest.java
@@ -1,6 +1,7 @@
 package club.ttg.dnd5.domain.vttg.service;
 
 import club.ttg.dnd5.domain.beastiary.model.Creature;
+import club.ttg.dnd5.domain.vttg.rest.dto.VttgCreature;
 import club.ttg.dnd5.domain.beastiary.model.CreatureAbilities;
 import club.ttg.dnd5.domain.beastiary.model.CreatureAbility;
 import club.ttg.dnd5.domain.beastiary.model.CreatureArmor;
@@ -262,6 +263,24 @@ class VttgCreatureMapperTest {
         Map<?, ?> action = firstAction(mapper.toVttg(creature).getSystem());
 
         assertActiveEffect(action, "prone");
+    }
+
+    /**
+     * Идентичность страницы-источника существа: раздел сайта — {@code bestiary}, тогда как лист
+     * компендиума — {@code creatures}. Разрешать ссылку по {@code section} нельзя.
+     */
+    @Test
+    void exportsSourcePageIdentity() {
+        Creature creature = new Creature();
+        creature.setUrl("goblin-mm");
+        creature.setName("Гоблин");
+        creature.setDescription("");
+
+        VttgCreature result = mapper.toVttg(creature);
+
+        assertEquals("bestiary", result.getSrcSection());
+        assertEquals("goblin-mm", result.getSrcUrl());
+        assertEquals("creatures", result.getSection());
     }
 
     @Test

--- a/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgFeatMapperTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgFeatMapperTest.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -87,6 +89,28 @@ class VttgFeatMapperTest {
         assertEquals("origin_feat", mapper.separator(FeatCategory.ORIGIN).get("id"));
         assertEquals("Черта происхождения", mapper.separator(FeatCategory.ORIGIN).get("name"));
         assertEquals("epic_feat", mapper.separator(FeatCategory.EPIC_BOON).get("id"));
+    }
+
+    /**
+     * Идентичность страницы-источника: по ней VTTG находит черту в компендиуме по ссылке из
+     * описания. Именно поэтому её нельзя выводить из {@code id} — тот собран по схеме эталона.
+     */
+    @Test
+    void exportsSourcePageIdentity() {
+        JsonNode json = json(baseFeat("two-weapon-fighting-phb", "Сражение двумя оружиями", "Two-Weapon Fighting"));
+
+        assertEquals("feats", json.get("srcSection").asText());
+        assertEquals("two-weapon-fighting-phb", json.get("srcUrl").asText());
+        assertEquals("srd_feat_two_weapon_fighting", json.get("id").asText());
+    }
+
+    /** У разделителя страницы на сайте нет — идентичности источника он не несёт. */
+    @Test
+    void separatorHasNoSourcePageIdentity() {
+        Map<String, Object> separator = mapper.separator(FeatCategory.FIGHTING_STYLE);
+
+        assertFalse(separator.containsKey("srcSection"));
+        assertFalse(separator.containsKey("srcUrl"));
     }
 
     /** Все категории enum покрыты порядком разделителей — ни одна черта не «потеряется». */

--- a/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgItemMapperTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgItemMapperTest.java
@@ -208,6 +208,20 @@ class VttgItemMapperTest {
         assertFalse(json.has("mastery"));
     }
 
+    /**
+     * Идентичность страницы-источника: раздел сайта — {@code items}, тогда как лист компендиума
+     * зависит от вида предмета, а {@code id} несёт суффикс источника. Ссылку из описания можно
+     * разрешить только по этой паре.
+     */
+    @Test
+    void exportsSourcePageIdentity() {
+        JsonNode json = json(baseItem("longsword", "Длинный меч", "Longsword"));
+
+        assertEquals("items", json.get("srcSection").asText());
+        assertEquals("longsword", json.get("srcUrl").asText());
+        assertEquals("longsword-phb", json.get("id").asText());
+    }
+
     private JsonNode json(Item item) {
         return objectMapper.valueToTree(mapper.toVttg(item));
     }

--- a/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgMagicItemMapperTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgMagicItemMapperTest.java
@@ -239,6 +239,50 @@ class VttgMagicItemMapperTest {
         assertEquals(1, mapper.toVttgVariants(item, new HashMap<>()).size());
     }
 
+    /**
+     * У всех записей раскрытия страница-источник одна — родительская: только по ней VTTG найдёт
+     * цель ссылки. Отличить якорь от производных даёт {@code srcVariant}.
+     */
+    @Test
+    void variantsShareParentSourcePageIdentity() {
+        when(itemRepository.findBaseByNameForVttgExport("латы")).thenReturn(List.of(plate()));
+        when(itemRepository.findBaseByNameForVttgExport("полулаты")).thenReturn(List.of(halfPlate()));
+
+        MagicItem item = new MagicItem();
+        item.setUrl("dwarven-plate");
+        item.setName("Латы дварфов");
+        item.setCategory(MagicItemCategory.ARMOR);
+        item.setClarification("полулаты или латы");
+        item.setRarity(Rarity.VERY_RARE);
+        Source source = new Source();
+        source.setAcronym("DMG");
+        item.setSource(source);
+
+        List<VttgMagicItem> variants = mapper.toVttgVariants(item, new HashMap<>());
+
+        VttgMagicItem anchor = byName(variants, "Латы дварфов");
+        assertEquals("magic-items", anchor.getSrcSection());
+        assertEquals("dwarven-plate", anchor.getSrcUrl());
+        assertNull(anchor.getSrcVariant());
+
+        VttgMagicItem derived = byName(variants, "Полулаты дварфов");
+        assertEquals("dwarven-plate", derived.getSrcUrl());
+        assertEquals(Boolean.TRUE, derived.getSrcVariant());
+        // id разошёлся с адресом страницы — по нему ссылку не разрешить.
+        assertEquals("dwarven-plate-half-plate-dmg", derived.getId());
+    }
+
+    /** Нерасщеплённый предмет — сам себе страница-источник, флага варианта нет. */
+    @Test
+    void plainItemIsItsOwnSourcePage() {
+        VttgMagicItem wand = mapper.toVttgVariants(wandOfFear(), new HashMap<>()).getFirst();
+
+        assertEquals("magic-items", wand.getSrcSection());
+        assertEquals("wand-of-fear", wand.getSrcUrl());
+        assertNull(wand.getSrcVariant());
+        assertEquals("wand-of-fear-dmg", wand.getId());
+    }
+
     private VttgMagicItem byName(List<VttgMagicItem> variants, String name) {
         return variants.stream()
                 .filter(v -> name.equals(v.getName()))

--- a/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgSpeciesMapperTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgSpeciesMapperTest.java
@@ -104,6 +104,15 @@ class VttgSpeciesMapperTest {
         assertEquals("drow", choices.get(1).get("key").asText());
     }
 
+    /** Идентичность страницы-источника вида. */
+    @Test
+    void exportsSourcePageIdentity() {
+        JsonNode json = json(baseSpecies("elf-phb", "Эльф", "Elf"));
+
+        assertEquals("species", json.get("srcSection").asText());
+        assertEquals("elf-phb", json.get("srcUrl").asText());
+    }
+
     private JsonNode json(Species species) {
         return objectMapper.valueToTree(mapper.toVttg(species));
     }

--- a/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgSpellMapperTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgSpellMapperTest.java
@@ -7,6 +7,7 @@ import club.ttg.dnd5.domain.source.model.Source;
 import club.ttg.dnd5.domain.spell.model.AreaOfEffect;
 import club.ttg.dnd5.domain.spell.model.MaterialComponent;
 import club.ttg.dnd5.domain.spell.model.Spell;
+import club.ttg.dnd5.domain.vttg.rest.dto.VttgSpell;
 import club.ttg.dnd5.domain.spell.model.SpellCastingTime;
 import club.ttg.dnd5.domain.spell.model.SpellComponents;
 import club.ttg.dnd5.domain.spell.model.SpellDistance;
@@ -233,6 +234,23 @@ class VttgSpellMapperTest {
         assertEquals(List.of("wizard"), classKeys);
         assertEquals("wizard", classKey);
         assertTrue(classKeys.contains(classKey));
+    }
+
+    /** Идентичность страницы-источника заклинания: раздел сайта и слаг рядом с {@code id}. */
+    @Test
+    void exportsSourcePageIdentity() {
+        Spell spell = new Spell();
+        spell.setUrl("magic-missile-phb");
+        spell.setName("Волшебная стрела");
+        spell.setEnglish("Magic Missile");
+        spell.setLevel(1L);
+        spell.setSchool(SpellSchool.builder().school(MagicSchool.EVOCATION).build());
+
+        VttgSpell result = mapper.toVttg(spell);
+
+        assertEquals("spells", result.getSrcSection());
+        assertEquals("magic-missile-phb", result.getSrcUrl());
+        assertEquals("magic-missile-phb", result.getId());
     }
 
     /** Несколько принадлежностей: канонические ключи, отсортированы и без дублей; неканонические отброшены. */


### PR DESCRIPTION
Перекрёстные ссылки в описаниях — обычные markdown-адреса вида [кинжал](https://ttg.club/items/dagger-phb). VTTG не мог сопоставить такую ссылку с записью у себя и открывал её в системном браузере, даже когда сама запись лежала в компендиуме.

Разрешить ссылку по слагу из адреса нельзя: id записи чеканится по правилам выгрузки и часто с ним расходится.

- черты: /feats/ability-score-improvement-phb против srd_feat_ability_score_improvement;
- классы: /classes/druid-phb против druid (slug английского имени);
- предметы: id получает суффикс источника, а слаг сайта — не всегда;
- разделы тоже не совпадают: /bestiary/ ложится в лист creatures, а /items/ и /magic-items/ разъезжаются по weapons/armor/tools/trinkets/ rings/wands/wondrous.

Поэтому адрес отдаётся явно, а не выводится:

- каждая запись выгрузки несёт srcSection (раздел сайта) и srcUrl (слаг);
- значения берутся из SectionType, и на него же переведена карта siteLinkSections в конвертере разметки — генератор ссылки и идентичность записи теперь читают одни и те же константы и разъехаться не могут;
- существующее поле section не трогается: это по-прежнему лист дерева компендиума, а не раздел сайта, и у существ с предметами они разные.

Магические предметы раскрываются в несколько записей (несколько базовых предметов в уточнении, шаблон «+1/+2/+3»), а страница на сайте у них одна:

- все записи раскрытия несут srcUrl родителя;
- производные помечаются srcVariant, чтобы по ссылке открывалась якорная запись, а не первая попавшаяся. Без флага группы «+1/+2/+3» якоря не имеют вовсе, и потребителю пришлось бы повторять у себя правило чеканки id.

Разделители черт полей не получают — страницы на сайте у них нет.

Версия схемы payload (SCHEMA_VERSION 9 → 10): формат изменился, иначе закешированные строки vttg_export так и отдавались бы без новых полей для сущностей, которые больше не менялись. Бамп пересчитывает payload, но не доставляет их: окно /changes определяется по updatedAt сущности, поэтому клиент с живым курсором получит новые поля только после полной пересинхронизации.

Текст описаний не изменился — ни нового синтаксиса разметки, ни правок вывода.

Тесты мапперов: 149 (9 новых) — пара полей на каждый тип, отдельно расхождение id и srcUrl у черт, классов и предметов, якорь и производные у магических предметов, отсутствие полей у разделителя.