### PR TITLE
fix(vttg): ссылки в ячейках таблиц доезжают ссылками, а не текстом

### DIFF
--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgMarkupConverter.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgMarkupConverter.java
@@ -264,7 +264,7 @@ public class VttgMarkupConverter {
         JsonNode colLabels = node.get("colLabels");
         if (colLabels != null && colLabels.isArray()) {
             List<String> header = new ArrayList<>();
-            colLabels.forEach(label -> header.add(formatTableCell(extractInlineCell(label, target))));
+            colLabels.forEach(label -> header.add(formatTableCell(extractInlineCell(label, target), target)));
             if (!header.isEmpty()) {
                 table.add(header);
             }
@@ -277,7 +277,7 @@ public class VttgMarkupConverter {
                     continue;
                 }
                 List<String> cells = new ArrayList<>();
-                row.forEach(cell -> cells.add(formatTableCell(extractInlineCell(cell, target))));
+                row.forEach(cell -> cells.add(formatTableCell(extractInlineCell(cell, target), target)));
                 if (!cells.isEmpty()) {
                     table.add(cells);
                 }
@@ -380,12 +380,27 @@ public class VttgMarkupConverter {
         }
 
         List<String> result = new ArrayList<>();
-        cells.forEach(cell -> result.add(formatTableCell(extract(cell, target))));
+        cells.forEach(cell -> result.add(formatTableCell(extract(cell, target), target)));
         return result;
     }
 
-    private String formatTableCell(String cell) {
-        return cell.trim()
+    /**
+     * Ячейка markdown-таблицы: разметка раскрывается, служебные символы экранируются.
+     *
+     * <p>Порядок здесь принципиален. Разметку ячейки раскрываем ДО экранирования
+     * разделителей: у маркеров-ссылок «|» — разделитель атрибутов
+     * ({@code {@spell Терновый кнут [Thorn Whip]|url:thorn-whip-phb}}), и если
+     * экранировать раньше, обратный слэш уезжает в конец метки — ссылка выходит
+     * оборванной ({@code [Терновый кнут [Thorn Whip]\](...)}) и markdown её уже не
+     * разбирает. По той же причине здесь раскрывается {@code {@br}}: в общем проходе
+     * он развернулся бы в настоящий перевод строки и разорвал строку таблицы.</p>
+     *
+     * <p>Броски оставляем целыми ({@code keepRolls = true}) — их раскроет общий проход
+     * в нужном режиме; знать про него ячейке не нужно. Всё остальное после раскрытия
+     * уже не содержит маркеров, поэтому повторный проход для ячейки холостой.</p>
+     */
+    private String formatTableCell(String cell, Target target) {
+        return replaceMarkup(cell.trim(), true, target)
                 .replace("|", "\\|")
                 .replace("\r\n", "\n")
                 .replace('\r', '\n')

--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgPayloadStore.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgPayloadStore.java
@@ -46,7 +46,7 @@ public class VttgPayloadStore {
     private static final Logger log = LoggerFactory.getLogger(VttgPayloadStore.class);
 
     /** Версия логики мапперов. Увеличьте при изменении формата payload — все строки пересчитаются. */
-    public static final int SCHEMA_VERSION = 10;
+    public static final int SCHEMA_VERSION = 11;
     /**
      * Размер пакета пересчёта/сохранения: ограничивает {@code IN}-список, объём транзакции и
      * зону поражения при сбое (на поштучную обработку переходит только сбойный пакет).

--- a/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgMarkupConverterTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgMarkupConverterTest.java
@@ -415,6 +415,68 @@ class VttgMarkupConverterTest {
         );
     }
 
+    /**
+     * Маркер-ссылка внутри ячейки: «|» в нём — разделитель атрибутов, а не колонок.
+     * Экранирование до раскрытия загоняло обратный слэш в конец метки, и markdown
+     * переставал видеть ссылку («Эльфийское происхождение» у видов).
+     */
+    @Test
+    void expandsLinkMarkupInsideTableCell() {
+        String markup = """
+                {
+                  "type": "table",
+                  "colLabels": ["Происхождение", "1-й уровень"],
+                  "rows": [
+                    [
+                      "Лорвин",
+                      "Вы знаете заговор {@spell Терновый кнут [Thorn Whip]|url:thorn-whip-phb}."
+                    ]
+                  ]
+                }
+                """;
+
+        assertEquals(
+                "| Происхождение | 1-й уровень |\n| --- | --- |\n"
+                        + "| Лорвин | Вы знаете заговор "
+                        + "[Терновый кнут [Thorn Whip]](https://ttg.club/spells/thorn-whip-phb). |",
+                converter.toText(markup)
+        );
+    }
+
+    /** Настоящий «|» в прозе ячейки по-прежнему экранируется — иначе он разорвал бы строку. */
+    @Test
+    void escapesLiteralPipeInsideTableCell() {
+        String markup = """
+                {
+                  "type": "table",
+                  "colLabels": ["Запись"],
+                  "rows": [["{@b Сила|Ловкость}"]]
+                }
+                """;
+
+        assertEquals(
+                "| Запись |\n| --- |\n| **Сила\\|Ловкость** |",
+                converter.toText(markup)
+        );
+    }
+
+    /** {@code {@br}} в ячейке — перенос внутри неё (<br>), а не разрыв строки таблицы. */
+    @Test
+    void keepsLineBreakMarkupInsideTableCell() {
+        String markup = """
+                {
+                  "type": "table",
+                  "colLabels": ["Запись"],
+                  "rows": [["Первая{@br}Вторая"]]
+                }
+                """;
+
+        assertEquals(
+                "| Запись |\n| --- |\n| Первая<br>Вторая |",
+                converter.toText(markup)
+        );
+    }
+
     @Test
     void convertsFrontendTableWithNodeArrayHeaders() {
         // Реальный формат редактора (toStoredMarkup): colLabels[i] — МАССИВ инлайн-


### PR DESCRIPTION
В таблицах компендиума маркеры-ссылки показывались сырыми: markdown видел оборванную конструкцию и разбирал автолинком только голый адрес, поэтому в карточке оставались «[метка](» и URL текстом. Заметнее всего на таблице «Эльфийское происхождение» у видов, где ссылка на заклинание есть в каждой ячейке.

Причина — порядок операций. Ячейка собиралась ДО раскрытия разметки, и экранирование разделителей колонок било по «|» внутри маркера, где это разделитель атрибутов:

    {@spell Терновый кнут [Thorn Whip]|url:thorn-whip-phb}
  → {@spell Терновый кнут [Thorn Whip]\|url:thorn-whip-phb}
  → [Терновый кнут [Thorn Whip]\](https://.../thorn-whip-phb)

Обратный слэш уезжал в конец метки, и ссылки больше не было.

Теперь разметка ячейки раскрывается до экранирования: к моменту замены «|» на «\|» все маркеры уже развёрнуты, и каждый оставшийся разделитель — действительно текстовый. Настоящий «|» в прозе по-прежнему экранируется.

Попутно чинится второй разрыв на том же месте: {@br} внутри ячейки разворачивался общим проходом в настоящий перевод строки уже после сборки строки таблицы и рвал её пополам. Раскрытый в ячейке, он становится <br> — переносом внутри ячейки, как и задумано.

Броски в ячейке остаются целыми: их раскрывает общий проход в нужном режиме, и ячейке не нужно знать, сохраняются ли интерактивные броски у потребителя. Повторный проход по уже раскрытой ячейке холостой — маркеров в ней не осталось.

Версия схемы payload (SCHEMA_VERSION 10 → 11): вывод таблиц изменился, иначе закешированные строки vttg_export так и отдавали бы сломанные ссылки.

Тесты конвертера: 30 (3 новых) — ссылка в ячейке, экранирование настоящего «|» в прозе, {@br} как перенос внутри ячейки.