### PR TITLE
feat(vttg): источники записей едут в компендиум, снятая пометка SRD снимается

### DIFF
--- a/src/main/java/club/ttg/dnd5/domain/common/model/NamedEntity.java
+++ b/src/main/java/club/ttg/dnd5/domain/common/model/NamedEntity.java
@@ -40,9 +40,23 @@ public abstract class NamedEntity extends Timestamped implements Persistable<Str
     @Column(name = "is_hidden_entity")
     private boolean isHiddenEntity = false;
 
-    /** Версия SRD, например "5.1" */
+    /** Версия SRD, например "5.1"; {@code null} — сущность не входит в SRD. */
     @Column(name = "srd_version")
     private String srdVersion;
+
+    /**
+     * Пустая строка означает «версии нет», а не «версия пустая». Формы админки при очистке
+     * поля присылают {@code ""}, а признак принадлежности к SRD везде читается как «поле не
+     * null» — и в выгрузке ({@code isSRD}), и в фильтрах «только SRD»
+     * ({@code where srdVersion is not null}). Без нормализации снятая в админке пометка не
+     * снималась бы ни на сайте, ни в компендиуме.
+     *
+     * @param srdVersion версия SRD; пустая строка и пробелы трактуются как её отсутствие
+     */
+    public void setSrdVersion(String srdVersion) {
+        String trimmed = srdVersion == null ? null : srdVersion.trim();
+        this.srdVersion = trimmed == null || trimmed.isEmpty() ? null : trimmed;
+    }
 
     @Override
     @Transient

--- a/src/main/java/club/ttg/dnd5/domain/vttg/rest/dto/VttgChangesResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/rest/dto/VttgChangesResponse.java
@@ -14,8 +14,13 @@ import java.util.Map;
  * @param until    верхняя граница окна (включительно); именно это значение клиент сохраняет как новый курсор
  * @param upserts  добавленные/изменённые сущности с полезной нагрузкой
  * @param sections дерево разделов («манифест» отображения), см. {@code VttgCompendiumSections#changesTree()}
+ * @param sources  словарь источников, встречающихся у {@code upserts} этого окна: записи везут
+ *                 только {@code sourceKey}, а название и аббревиатуру берут отсюда. Клиент
+ *                 накапливает словарь по ключу, а не заменяет — в инкрементальном окне приезжают
+ *                 только источники изменившихся записей
  */
 public record VttgChangesResponse(Instant until,
                                   List<VttgChange> upserts,
-                                  List<Map<String, Object>> sections) {
+                                  List<Map<String, Object>> sections,
+                                  List<VttgSource> sources) {
 }

--- a/src/main/java/club/ttg/dnd5/domain/vttg/rest/dto/VttgSource.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/rest/dto/VttgSource.java
@@ -1,0 +1,17 @@
+package club.ttg.dnd5.domain.vttg.rest.dto;
+
+/**
+ * Источник в вокабуляре VTTG ({@code SourceDefinition}).
+ *
+ * <p>Записи компендиума везут только ключ источника ({@code sourceKey}); по нему из этого
+ * словаря берётся подпись в карточке и вариант в выпадающем списке при создании своего
+ * контента. Без словаря приложение знает лишь встроенные PHB/DMG/MM/HB, и всё остальное
+ * ({@code lfl}, {@code efa}, …) остаётся безымянным.</p>
+ *
+ * @param key          ключ, совпадающий с {@code sourceKey} записей (см. {@code VttgSourceKeys})
+ * @param name         русское название
+ * @param nameEn       английское название
+ * @param abbreviation аббревиатура для компактной подписи
+ */
+public record VttgSource(String key, String name, String nameEn, String abbreviation) {
+}

--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgBackgroundMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgBackgroundMapper.java
@@ -5,7 +5,6 @@ import club.ttg.dnd5.domain.common.dictionary.Ability;
 import club.ttg.dnd5.domain.common.dictionary.Skill;
 import club.ttg.dnd5.domain.common.model.SectionType;
 import club.ttg.dnd5.domain.feat.model.Feat;
-import club.ttg.dnd5.domain.source.model.Source;
 import club.ttg.dnd5.domain.vttg.rest.dto.VttgBackground;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -36,7 +35,6 @@ import java.util.Set;
 @Component
 @RequiredArgsConstructor
 public class VttgBackgroundMapper {
-    private static final String SOURCE = "srd";
     /** Слаг листа дерева разделов для предысторий (см. {@link VttgCompendiumSections}). */
     private static final String SECTION = "backgrounds";
 
@@ -54,7 +52,7 @@ public class VttgBackgroundMapper {
                 .section(SECTION)
                 .srcSection(SectionType.BACKGROUND.getValue())
                 .srcUrl(background.getUrl())
-                .sourceKey(sourceKey(background.getSource()))
+                .sourceKey(VttgSourceKeys.of(background.getSource()))
                 .isSRD(background.getSrdVersion() != null)
                 .abilityGrant(abilityGrant(background.getAbilities()))
                 .skillGrant(skillGrant(background.getSkillProficiencies()))
@@ -162,15 +160,4 @@ public class VttgBackgroundMapper {
         return StringUtils.hasText(value) ? value : null;
     }
 
-    private String sourceKey(Source source) {
-        if (source == null) {
-            return SOURCE;
-        }
-        if ("PHB24".equalsIgnoreCase(source.getAcronym())) {
-            return "phb";
-        }
-        return StringUtils.hasText(source.getAcronym())
-                ? source.getAcronym().toLowerCase(Locale.ROOT)
-                : SOURCE;
-    }
 }

--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgChangesService.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgChangesService.java
@@ -18,9 +18,13 @@ import club.ttg.dnd5.domain.species.model.Species;
 import club.ttg.dnd5.domain.species.repository.SpeciesRepository;
 import club.ttg.dnd5.domain.spell.model.Spell;
 import club.ttg.dnd5.domain.spell.repository.SpellRepository;
+import club.ttg.dnd5.domain.source.model.Source;
+import club.ttg.dnd5.domain.source.repository.SourceRepository;
 import club.ttg.dnd5.domain.vttg.rest.dto.VttgChange;
 import club.ttg.dnd5.domain.vttg.rest.dto.VttgChangesResponse;
 import club.ttg.dnd5.domain.vttg.rest.dto.VttgChangesStatus;
+import club.ttg.dnd5.domain.vttg.rest.dto.VttgSource;
+import com.fasterxml.jackson.databind.JsonNode;
 import club.ttg.dnd5.domain.vttg.repository.VttgEntityRef;
 import club.ttg.dnd5.config.CacheConfig;
 import lombok.RequiredArgsConstructor;
@@ -40,6 +44,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Collection;
 import java.util.Map;
@@ -81,6 +86,7 @@ public class VttgChangesService {
     private static final Set<String> SUPPORTED_TYPES =
             Set.of(SPELLS, BESTIARY, MAGIC_ITEMS, ITEMS, BACKGROUNDS, FEATS, SPECIES, CLASSES);
 
+    private final SourceRepository sourceRepository;
     private final SpellRepository spellRepository;
     private final CreatureRepository creatureRepository;
     private final MagicItemRepository magicItemRepository;
@@ -257,9 +263,59 @@ public class VttgChangesService {
         upserts.replaceAll(change -> change.updatedAt() != null ? change
                 : new VttgChange(change.type(), change.url(), fallbackStamp, change.data()));
 
-        VttgChangesResponse response = new VttgChangesResponse(window.until(), upserts, compendiumSections.changesTree());
+        VttgChangesResponse response = new VttgChangesResponse(
+                window.until(), upserts, compendiumSections.changesTree(), sources(upserts));
         logTimings(timings, upserts.size(), millisSince(startedAt, System.nanoTime()));
         return response;
+    }
+
+    /**
+     * Словарь источников, встречающихся у отданных записей.
+     *
+     * <p>Отдаём только задействованные: у записи в компендиуме есть лишь {@code sourceKey}, и
+     * потребителю нужны названия ровно для тех ключей, что к нему приехали. Ключ считается тем
+     * же {@link VttgSourceKeys}, что и у самих записей, иначе подпись не нашлась бы.</p>
+     *
+     * <p>Справочник источников маленький и читается целиком: обратного отображения
+     * «ключ → строка таблицы» нет ({@code PHB24} сводится к {@code phb}), а сводить несколько
+     * акронимов к одному ключу приходится здесь же — побеждает первый по алфавиту.</p>
+     */
+    private List<VttgSource> sources(List<VttgChange> upserts) {
+        Set<String> keys = new HashSet<>();
+        for (VttgChange change : upserts) {
+            String key = sourceKeyOf(change.data());
+            if (key != null) {
+                keys.add(key);
+            }
+        }
+        if (keys.isEmpty()) {
+            return List.of();
+        }
+
+        Map<String, VttgSource> byKey = new LinkedHashMap<>();
+        sourceRepository.findAll().stream()
+                .sorted(Comparator.comparing(Source::getAcronym,
+                        Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)))
+                .forEach(source -> {
+                    String key = VttgSourceKeys.of(source);
+                    if (keys.contains(key)) {
+                        byKey.putIfAbsent(key, new VttgSource(key, source.getName(), source.getEnglish(),
+                                key.toUpperCase(Locale.ROOT)));
+                    }
+                });
+        return List.copyOf(byKey.values());
+    }
+
+    /** Ключ источника записи: payload — либо дерево Jackson, либо карта (разделители черт). */
+    private String sourceKeyOf(Object data) {
+        if (data instanceof JsonNode node) {
+            JsonNode key = node.get("sourceKey");
+            return key != null && key.isTextual() ? key.asText() : null;
+        }
+        if (data instanceof Map<?, ?> map) {
+            return map.get("sourceKey") instanceof String key ? key : null;
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgClassMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgClassMapper.java
@@ -18,7 +18,6 @@ import club.ttg.dnd5.domain.common.dictionary.Dice;
 import club.ttg.dnd5.domain.common.dictionary.Skill;
 import club.ttg.dnd5.domain.common.dictionary.WeaponCategory;
 import club.ttg.dnd5.domain.common.rest.dto.Name;
-import club.ttg.dnd5.domain.source.model.Source;
 import club.ttg.dnd5.domain.vttg.rest.dto.VttgClass;
 import club.ttg.dnd5.util.SlugifyUtil;
 import lombok.RequiredArgsConstructor;
@@ -56,8 +55,6 @@ public class VttgClassMapper {
     private static final String TYPE = "class";
     /** Слаг листа дерева разделов (совпадает с {@code SectionType.CLASS} = "classes"). */
     private static final String SECTION = "classes";
-    /** Запасной ключ источника, если у класса его нет. */
-    private static final String SOURCE = "srd";
     /** Максимальный уровень персонажа D&D 5e — глубина таблицы прогрессии. */
     private static final int MAX_LEVEL = 20;
     /** Уровень выбора подкласса по умолчанию (PHB 2024). */
@@ -111,7 +108,7 @@ public class VttgClassMapper {
                 .name(characterClass.getName())
                 .nameEn(optional(characterClass.getEnglish()))
                 .description(description(characterClass.getDescription()))
-                .sourceKey(sourceKey(characterClass.getSource()))
+                .sourceKey(VttgSourceKeys.of(characterClass.getSource()))
                 .isSRD(characterClass.getSrdVersion() != null)
                 .hitDie(hitDie(characterClass.getHitDice()))
                 .armorProficiencies(armor(characterClass.getArmorProficiency()))
@@ -156,7 +153,7 @@ public class VttgClassMapper {
                 .nameEn(optional(subclass.getEnglish()))
                 .description(description(subclass.getDescription()))
                 .unlockLevel(unlockLevel(features))
-                .sourceKey(sourceKey(subclass.getSource()))
+                .sourceKey(VttgSourceKeys.of(subclass.getSource()))
                 .spellcasting(spellcasting(null, subclass.getCasterType()))
                 .features(features)
                 .levelTable(hasTable(subclass.getTable()) ? levelTable(subclass.getTable(), features) : null)
@@ -468,17 +465,6 @@ public class VttgClassMapper {
         return StringUtils.hasText(text) ? text : null;
     }
 
-    private String sourceKey(Source source) {
-        if (source == null) {
-            return SOURCE;
-        }
-        if ("PHB24".equalsIgnoreCase(source.getAcronym())) {
-            return "phb";
-        }
-        return StringUtils.hasText(source.getAcronym())
-                ? source.getAcronym().toLowerCase(Locale.ROOT)
-                : SOURCE;
-    }
 
     /** Ключ класса: как в {@code spell.classKeys} — транслит/slug английского имени, иначе из url. */
     private String classKey(CharacterClass characterClass) {

--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgCreatureMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgCreatureMapper.java
@@ -21,7 +21,6 @@ import club.ttg.dnd5.domain.common.dictionary.CreatureType;
 import club.ttg.dnd5.domain.common.dictionary.DamageType;
 import club.ttg.dnd5.domain.common.dictionary.Habitat;
 import club.ttg.dnd5.domain.common.dictionary.Size;
-import club.ttg.dnd5.domain.source.model.Source;
 import club.ttg.dnd5.domain.vttg.rest.dto.VttgCreature;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -87,7 +86,7 @@ public class VttgCreatureMapper {
                 .header(header(creature))
                 .token(token(creature))
                 .system(system(creature))
-                .sourceKey(sourceKey(creature.getSource()))
+                .sourceKey(VttgSourceKeys.of(creature.getSource()))
                 .isSRD(creature.getSrdVersion() != null)
                 .isReadOnly(true)
                 .build();
@@ -638,17 +637,6 @@ public class VttgCreatureMapper {
         return alignment.name().toLowerCase(Locale.ROOT).replace("_", "-");
     }
 
-    private String sourceKey(Source source) {
-        if (source == null) {
-            return "srd";
-        }
-        if ("PHB24".equalsIgnoreCase(source.getAcronym())) {
-            return "phb";
-        }
-        return StringUtils.hasText(source.getAcronym())
-                ? source.getAcronym().toLowerCase(Locale.ROOT)
-                : "srd";
-    }
 
     private List<String> enumNames(Collection<DamageType> values) {
         return values == null ? List.of() : values.stream().filter(Objects::nonNull)

--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgFeatMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgFeatMapper.java
@@ -3,7 +3,6 @@ package club.ttg.dnd5.domain.vttg.service;
 import club.ttg.dnd5.domain.common.model.SectionType;
 import club.ttg.dnd5.domain.feat.model.Feat;
 import club.ttg.dnd5.domain.feat.model.FeatCategory;
-import club.ttg.dnd5.domain.source.model.Source;
 import club.ttg.dnd5.domain.vttg.rest.dto.VttgFeat;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -26,7 +25,6 @@ import java.util.Map;
 @Component
 @RequiredArgsConstructor
 public class VttgFeatMapper {
-    private static final String SOURCE = "srd";
     private static final String TYPE = "feat";
     private static final String TYPE_LABEL = "Черты";
     /** Слаг листа дерева разделов для черт и их разделителей (см. {@link VttgCompendiumSections}). */
@@ -50,7 +48,7 @@ public class VttgFeatMapper {
                 .section(SECTION)
                 .srcSection(SectionType.FEAT.getValue())
                 .srcUrl(feat.getUrl())
-                .sourceKey(sourceKey(feat.getSource()))
+                .sourceKey(VttgSourceKeys.of(feat.getSource()))
                 .isSRD(feat.getSrdVersion() != null)
                 .featureType(TYPE)
                 .category(categoryName(feat.getCategory()))
@@ -115,17 +113,6 @@ public class VttgFeatMapper {
                 .replaceAll("^_+|_+$", ""));
     }
 
-    private String sourceKey(Source source) {
-        if (source == null) {
-            return SOURCE;
-        }
-        if ("PHB24".equalsIgnoreCase(source.getAcronym())) {
-            return "phb";
-        }
-        return StringUtils.hasText(source.getAcronym())
-                ? source.getAcronym().toLowerCase(Locale.ROOT)
-                : SOURCE;
-    }
 
     private String optional(String value) {
         return StringUtils.hasText(value) ? value : null;

--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgItemMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgItemMapper.java
@@ -14,7 +14,6 @@ import club.ttg.dnd5.domain.item.model.weapon.Damage;
 import club.ttg.dnd5.domain.item.model.weapon.Property;
 import club.ttg.dnd5.domain.item.model.weapon.Weapon;
 import club.ttg.dnd5.domain.item.rest.dto.Range;
-import club.ttg.dnd5.domain.source.model.Source;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -46,14 +45,12 @@ import java.util.regex.Pattern;
 @Component
 @RequiredArgsConstructor
 public class VttgItemMapper {
-    /** Запасной ключ источника, если у предмета его нет. */
-    private static final String SOURCE = "srd";
     private static final Pattern LEADING_NUMBER = Pattern.compile("(\\d+(?:[.,]\\d+)?)");
 
     private final VttgMarkupConverter markupConverter;
 
     public Map<String, Object> toVttg(Item item) {
-        String sourceKey = sourceKey(item.getSource());
+        String sourceKey = VttgSourceKeys.of(item.getSource());
         Map<String, Object> data = new LinkedHashMap<>();
 
         data.put("id", id(item, sourceKey));
@@ -397,15 +394,4 @@ public class VttgItemMapper {
         return item.getCost() + " " + item.getCoin().getShortName();
     }
 
-    private String sourceKey(Source source) {
-        if (source == null) {
-            return SOURCE;
-        }
-        if ("PHB24".equalsIgnoreCase(source.getAcronym())) {
-            return "phb";
-        }
-        return StringUtils.hasText(source.getAcronym())
-                ? source.getAcronym().toLowerCase(Locale.ROOT)
-                : SOURCE;
-    }
 }

--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgMagicItemMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgMagicItemMapper.java
@@ -9,7 +9,6 @@ import club.ttg.dnd5.domain.item.repository.ItemRepository;
 import club.ttg.dnd5.domain.magic.model.Attunement;
 import club.ttg.dnd5.domain.magic.model.MagicItem;
 import club.ttg.dnd5.domain.magic.model.MagicItemCategory;
-import club.ttg.dnd5.domain.source.model.Source;
 import club.ttg.dnd5.domain.vttg.rest.dto.VttgMagicItem;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -46,8 +45,6 @@ import java.util.regex.Pattern;
 @Component
 @RequiredArgsConstructor
 public class VttgMagicItemMapper {
-    /** Запасной ключ источника, если у предмета его нет. */
-    private static final String SOURCE = "srd";
     /** Дефолтная редкость магического предмета, когда реальную не удалось определить (none недопустим). */
     private static final Rarity DEFAULT_MAGIC_RARITY = Rarity.UNCOMMON;
     /** Бонус «+1/+2/+3» из названия/уточнения предмета. */
@@ -154,7 +151,7 @@ public class VttgMagicItemMapper {
                                      String english, Rarity rarity, Integer bonus) {
         Attunement attunement = item.getAttunement();
         boolean requiresAttunement = attunement != null && attunement.isRequires();
-        String sourceKey = sourceKey(item.getSource());
+        String sourceKey = VttgSourceKeys.of(item.getSource());
         MagicItemCategory category = item.getCategory();
         boolean weapon = category == MagicItemCategory.WEAPON;
         BaseMechanics mechanics = mechanics(base, category);
@@ -574,17 +571,6 @@ public class VttgMagicItemMapper {
         return null;
     }
 
-    private String sourceKey(Source source) {
-        if (source == null) {
-            return SOURCE;
-        }
-        if ("PHB24".equalsIgnoreCase(source.getAcronym())) {
-            return "phb";
-        }
-        return StringUtils.hasText(source.getAcronym())
-                ? source.getAcronym().toLowerCase(Locale.ROOT)
-                : SOURCE;
-    }
 
     /** Выведенные из базового предмета поля: вес, стоимость в золоте и боевые/доспешные поля ({@code null} — нет). */
     private record BaseMechanics(double weight, Double costGold, Map<String, Object> fields) {

--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgSourceKeys.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgSourceKeys.java
@@ -1,0 +1,40 @@
+package club.ttg.dnd5.domain.vttg.service;
+
+import club.ttg.dnd5.domain.source.model.Source;
+import org.springframework.util.StringUtils;
+
+import java.util.Locale;
+
+/**
+ * Ключ источника в вокабуляре VTTG ({@code sourceKey} записи компендиума).
+ *
+ * <p>Правило одно на всю выгрузку намеренно: по этому же ключу к записи подбирается
+ * подпись из словаря источников, который выгрузка отдаёт отдельно
+ * ({@code VttgChangesResponse#sources}). Разойдись эти два места — записи остались бы
+ * без названия источника, поэтому и ключ записи, и ключ словаря считаются здесь.</p>
+ */
+final class VttgSourceKeys {
+    /** Ключ, когда источник не указан. */
+    static final String FALLBACK = "srd";
+
+    private VttgSourceKeys() {
+    }
+
+    /**
+     * Ключ источника: аббревиатура в нижнем регистре.
+     *
+     * <p>{@code PHB24} сводится к {@code phb}: в TTG Club это отдельный источник, а в
+     * вокабуляре VTTG «Книга игрока» одна.</p>
+     *
+     * @param source источник сущности; {@code null} — источник не задан
+     */
+    static String of(Source source) {
+        if (source == null || !StringUtils.hasText(source.getAcronym())) {
+            return FALLBACK;
+        }
+        if ("PHB24".equalsIgnoreCase(source.getAcronym())) {
+            return "phb";
+        }
+        return source.getAcronym().toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgSpeciesMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgSpeciesMapper.java
@@ -3,7 +3,6 @@ package club.ttg.dnd5.domain.vttg.service;
 import club.ttg.dnd5.domain.common.dictionary.CreatureType;
 import club.ttg.dnd5.domain.common.model.SectionType;
 import club.ttg.dnd5.domain.common.dictionary.Size;
-import club.ttg.dnd5.domain.source.model.Source;
 import club.ttg.dnd5.domain.species.model.Species;
 import club.ttg.dnd5.domain.species.model.SpeciesFeature;
 import club.ttg.dnd5.domain.species.rest.dto.SpeciesSizeDto;
@@ -34,8 +33,6 @@ public class VttgSpeciesMapper {
     private static final String TYPE = "species";
     private static final String SECTION = "species";
     private static final String DARKVISION = "darkvision";
-    /** Запасной ключ источника, если у вида его нет. */
-    private static final String SOURCE = "srd";
 
     private final VttgMarkupConverter markupConverter;
 
@@ -53,7 +50,7 @@ public class VttgSpeciesMapper {
                 .name(species.getName())
                 .nameEn(optional(species.getEnglish()))
                 .description(markupConverter.toText(species.getDescription()))
-                .sourceKey(sourceKey(species.getSource()))
+                .sourceKey(VttgSourceKeys.of(species.getSource()))
                 .creatureType(creatureType(species.getType()))
                 .size(sizes(species.getSizes()))
                 .speed(speed(species))
@@ -185,17 +182,6 @@ public class VttgSpeciesMapper {
         return builder.toString();
     }
 
-    private String sourceKey(Source source) {
-        if (source == null) {
-            return SOURCE;
-        }
-        if ("PHB24".equalsIgnoreCase(source.getAcronym())) {
-            return "phb";
-        }
-        return StringUtils.hasText(source.getAcronym())
-                ? source.getAcronym().toLowerCase(Locale.ROOT)
-                : SOURCE;
-    }
 
     /** kebab-case slug из url: {@code "draconic-flight" → "draconic-flight"}. */
     private String slug(String value) {

--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgSpellMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgSpellMapper.java
@@ -4,7 +4,6 @@ import club.ttg.dnd5.domain.beastiary.model.action.AttackType;
 import club.ttg.dnd5.domain.character_class.model.CharacterClass;
 import club.ttg.dnd5.domain.common.dictionary.Ability;
 import club.ttg.dnd5.domain.common.model.SectionType;
-import club.ttg.dnd5.domain.source.model.Source;
 import club.ttg.dnd5.domain.spell.model.AreaOfEffect;
 import club.ttg.dnd5.domain.spell.model.MaterialComponent;
 import club.ttg.dnd5.domain.spell.model.Spell;
@@ -93,7 +92,7 @@ public class VttgSpellMapper {
                 .description(description)
                 .higherLevelDescription(higherLevelDescription)
                 .activeEffects(activeEffects(spell))
-                .sourceKey(sourceKey(spell.getSource()))
+                .sourceKey(VttgSourceKeys.of(spell.getSource()))
                 .isSRD(spell.getSrdVersion() != null)
                 .classKeys(classKeys(spell))
                 .type("spell")
@@ -316,15 +315,6 @@ public class VttgSpellMapper {
         return higherLevelDescription.matches("(?s).*\\b5\\b.*\\b11\\b.*\\b17\\b.*");
     }
 
-    private String sourceKey(Source source) {
-        if (source == null) {
-            return "srd";
-        }
-        if ("PHB24".equalsIgnoreCase(source.getAcronym())) {
-            return "phb";
-        }
-        return source.getAcronym().toLowerCase(Locale.ROOT);
-    }
 
     /**
      * Ключи классов заклинания — источник «списка заклинаний класса» в VTTG (фильтр компендиума

--- a/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgSpeciesMapperTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgSpeciesMapperTest.java
@@ -113,6 +113,22 @@ class VttgSpeciesMapperTest {
         assertEquals("elf-phb", json.get("srcUrl").asText());
     }
 
+    /**
+     * Снятая в админке пометка SRD приезжает пустой строкой, а не null. Признак читается как
+     * «поле не null», поэтому пустая версия нормализуется в null — иначе запись оставалась бы
+     * SRD и уезжала не в тот пак.
+     */
+    @Test
+    void treatsBlankSrdVersionAsNotSrd() {
+        Species species = baseSpecies("elf-lfl", "Эльф", "Elf");
+        species.setSrdVersion("");
+
+        assertFalse(json(species).get("isSRD").asBoolean());
+
+        species.setSrdVersion("5.2");
+        assertTrue(json(species).get("isSRD").asBoolean());
+    }
+
     private JsonNode json(Species species) {
         return objectMapper.valueToTree(mapper.toVttg(species));
     }


### PR DESCRIPTION
Две проблемы одного места — принадлежности записи к источнику и к SRD.

Пустая версия SRD больше не считается пометкой:

- формы админки при очистке поля присылают "", а не null, тогда как признак «запись из SRD» везде читается как «поле не null» — и в выгрузке (isSRD), и в фильтрах «только SRD» (where srdVersion is not null);
- поэтому снятая в админке пометка не снималась нигде: запись оставалась SRD и уезжала не в тот пак компендиума;
- срез по видам: все 33 записи числились SRD, включая источники Лорвина, Эберрона и прочие, которые SRD быть не могут;
- нормализация сделана в сеттере NamedEntity — там же, где поле объявлено, поэтому правило одно на все типы контента и на все пути записи, включая MapStruct. Править восемь мапперов и два десятка запросов не понадобилось.

Уже сохранённые пустые строки нормализация не чинит — их нужно вычистить в базе отдельно.

Словарь источников в ответе /changes:

- запись компендиума везёт только sourceKey, а названия у потребителя нет: ему известны лишь базовые книги, и всё остальное (lfl, efa, feq, rhw, abh) оставалось без подписи в карточке и без варианта при выборе источника;
- в ответ добавлено поле sources — словарь ровно тех ключей, что встретились у upserts этого окна: отдавать справочник целиком незачем, названия нужны только для приехавших записей;
- потребитель накапливает словарь по ключу, а не заменяет: в инкрементальном окне приезжают источники лишь изменившихся записей.

Ключ источника вынесен в VttgSourceKeys:

- метод sourceKey был скопирован в восемь мапперов слово в слово (-95 строк);
- важнее дедупликации то, что ключ записи и ключ словаря теперь считаются одним кодом: разойдись они, подпись источника не нашлась бы. Тот же приём, что и с разделами сайта в конвертере разметки.

Версия схемы payload не поднята намеренно: payload записей не изменился, словарь живёт на уровне ответа, а вынос ключа вывод не меняет.

Тесты: 153 (1 новый) — пустая версия SRD не делает запись SRD, непустая делает.