### PR TITLE
feat(magic-items): механика влияния предмета на лист персонажа

### DIFF
--- a/src/main/java/club/ttg/dnd5/domain/common/model/ActiveEffect.java
+++ b/src/main/java/club/ttg/dnd5/domain/common/model/ActiveEffect.java
@@ -1,4 +1,4 @@
-package club.ttg.dnd5.domain.spell.model;
+package club.ttg.dnd5.domain.common.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
@@ -8,11 +8,16 @@ import lombok.Setter;
 import java.util.List;
 
 /**
- * Активный эффект заклинания, совместимый с системой Active Effects VTTG.
+ * Активный эффект, совместимый с системой Active Effects VTTG. Одна и та же
+ * модель у всего, что меняет числа на листе персонажа: заклинаний и магических
+ * предметов.
  * <p>
  * Хранится как JSONB и передаётся в VTTG без преобразования словарей, поэтому
  * значения (характеристики, режимы, ключи состояний, флаги) держим строками в
- * вокабуляре VTTG, а не доменными enum'ами core-api.
+ * вокабуляре VTTG, а не доменными enum'ами core-api. Ключ изменения
+ * ({@link Change#key}) — это {@code EffectTargetKey} VTTG: {@code armorClass},
+ * {@code save.constitution}, {@code skill.stealth}, {@code movement.swim},
+ * {@code ability.strength}, {@code attack.melee} и прочие.
  *
  * @see club.ttg.dnd5.domain.vttg
  */
@@ -20,7 +25,7 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class SpellActiveEffect {
+public class ActiveEffect {
     private String id;
     private String name;
     private String description;

--- a/src/main/java/club/ttg/dnd5/domain/magic/model/MagicItem.java
+++ b/src/main/java/club/ttg/dnd5/domain/magic/model/MagicItem.java
@@ -4,6 +4,7 @@ import club.ttg.dnd5.domain.source.model.Source;
 import club.ttg.dnd5.domain.common.dictionary.Rarity;
 import club.ttg.dnd5.domain.common.model.NamedEntity;
 import club.ttg.dnd5.domain.item.model.Item;
+import club.ttg.dnd5.domain.magic.model.mechanics.MagicItemMechanics;
 import io.hypersistence.utils.hibernate.type.json.JsonType;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -59,6 +60,15 @@ public class MagicItem extends NamedEntity {
     @Type(JsonType.class)
     @Column(columnDefinition = "jsonb")
     private MagicItemBonuses bonuses;
+
+    /**
+     * Механика влияния предмета на лист персонажа: условие применения, эффекты и заряды.
+     * {@code null} — у записей, сохранённых до появления поля, и у предметов, чьё действие
+     * пока описано только текстом.
+     */
+    @Type(JsonType.class)
+    @Column(columnDefinition = "jsonb")
+    private MagicItemMechanics mechanics;
 
     /**
      * Количество зарядов магического предмета.

--- a/src/main/java/club/ttg/dnd5/domain/magic/model/mechanics/MagicItemActivation.java
+++ b/src/main/java/club/ttg/dnd5/domain/magic/model/mechanics/MagicItemActivation.java
@@ -1,0 +1,29 @@
+package club.ttg.dnd5.domain.magic.model.mechanics;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Условие, при котором механика предмета работает.
+ *
+ * <p>Лист персонажа применяет эффекты, только когда состояние предмета в инвентаре
+ * совпадает с условием: {@link #WORN} и {@link #HELD} требуют отметки «надет»,
+ * {@link #EQUIPPED} — «экипирован» (оружие в руках, доспех на теле),
+ * {@link #CARRIED} достаточно наличия в инвентаре. Требование настройки берётся
+ * отдельно из {@code attunement} и проверяется дополнительно.</p>
+ *
+ * <p>Своего аналога в VTTG у этого различения нет — там эффекты предмета
+ * включает один признак «экипирован», поэтому в экспорт условие не идёт.</p>
+ */
+@Getter
+@AllArgsConstructor
+public enum MagicItemActivation {
+    CARRIED("при себе"),
+    WORN("надет"),
+    HELD("в руке"),
+    EQUIPPED("экипирован"),
+    CONSUMED("при использовании"),
+    MANUAL("вручную");
+
+    private final String name;
+}

--- a/src/main/java/club/ttg/dnd5/domain/magic/model/mechanics/MagicItemMechanics.java
+++ b/src/main/java/club/ttg/dnd5/domain/magic/model/mechanics/MagicItemMechanics.java
@@ -1,0 +1,48 @@
+package club.ttg.dnd5.domain.magic.model.mechanics;
+
+import club.ttg.dnd5.domain.common.model.ActiveEffect;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * Механика влияния магического предмета на лист персонажа.
+ *
+ * <p>Сами изменения описывает {@link ActiveEffect} — та же модель, что у эффектов
+ * заклинания, в вокабуляре VTTG. Плащ защиты — это два изменения
+ * ({@code armorClass} и {@code save.*} режимом {@code add}), амулет здоровья —
+ * одно ({@code ability.constitution} режимом {@code upgrade} до 19), плащ ската
+ * — {@code movement.swim} тем же {@code upgrade}. Ситуационность («+2 КД против
+ * дальнобойных атак») живёт в {@code Change.condition}.</p>
+ *
+ * <p>Остальные поля своих аналогов в VTTG не имеют и в экспорт не идут: там
+ * эффекты предмета включаются одним признаком «экипирован», а зарядов предмета
+ * система не знает.</p>
+ *
+ * <p>{@code null} — у записей, сохранённых до появления поля, и у предметов, чьё
+ * действие пока описано только текстом.</p>
+ */
+@Getter
+@Setter
+public class MagicItemMechanics {
+    @Schema(description = "Когда механика работает", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private MagicItemActivation activation;
+
+    @Schema(description = "Изменения, которые предмет вносит в лист персонажа (модель Active Effects VTTG)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private List<ActiveEffect> activeEffects;
+
+    @Schema(description = "Заряды предмета", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private MagicItemResource resource;
+
+    /**
+     * Свойства, которые лист показывает справкой, но не считает: дыхание под водой,
+     * иммунитет к чтению мыслей и прочее, чему пока нет места в формулах.
+     */
+    @Schema(description = "Пассивные свойства для листа, не участвующие в расчётах",
+            examples = {"Вы можете дышать под водой"},
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String passive;
+}

--- a/src/main/java/club/ttg/dnd5/domain/magic/model/mechanics/MagicItemRechargeEvent.java
+++ b/src/main/java/club/ttg/dnd5/domain/magic/model/mechanics/MagicItemRechargeEvent.java
@@ -1,0 +1,17 @@
+package club.ttg.dnd5.domain.magic.model.mechanics;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Событие, по которому магический предмет восстанавливает заряды.
+ */
+@Getter
+@AllArgsConstructor
+public enum MagicItemRechargeEvent {
+    DAWN("на рассвете"),
+    SHORT_REST("после короткого отдыха"),
+    LONG_REST("после продолжительного отдыха");
+
+    private final String name;
+}

--- a/src/main/java/club/ttg/dnd5/domain/magic/model/mechanics/MagicItemResource.java
+++ b/src/main/java/club/ttg/dnd5/domain/magic/model/mechanics/MagicItemResource.java
@@ -1,0 +1,29 @@
+package club.ttg.dnd5.domain.magic.model.mechanics;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Заряды магического предмета: сколько их всего и как они возвращаются.
+ *
+ * <p>Здесь только описание предмета из каталога. Текущий остаток зарядов — состояние
+ * конкретного экземпляра и живёт на листе персонажа, а не в справочнике.</p>
+ */
+@Getter
+@Setter
+public class MagicItemResource {
+    @Schema(description = "Максимум зарядов", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private Integer maxCharges;
+
+    @Schema(description = "Формула восстановления, например «1к6+4»",
+            examples = {"1к6+4", "все"},
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String recharge;
+
+    @Schema(description = "Когда заряды восстанавливаются", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private MagicItemRechargeEvent rechargeEvent;
+
+    @Schema(description = "Сколько зарядов тратит одно применение", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private Integer cost;
+}

--- a/src/main/java/club/ttg/dnd5/domain/magic/rest/dto/MagicItemDetailResponse.java
+++ b/src/main/java/club/ttg/dnd5/domain/magic/rest/dto/MagicItemDetailResponse.java
@@ -1,6 +1,7 @@
 package club.ttg.dnd5.domain.magic.rest.dto;
 
 import club.ttg.dnd5.domain.common.rest.dto.BaseResponse;
+import club.ttg.dnd5.domain.magic.model.mechanics.MagicItemMechanics;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
@@ -10,4 +11,7 @@ import lombok.Setter;
 public class MagicItemDetailResponse extends BaseResponse {
     @Schema(description = "Подзаголовок")
     private String subtitle;
+
+    @Schema(description = "Механика влияния на лист персонажа; null — предмет её не описывает")
+    private MagicItemMechanics mechanics;
 }

--- a/src/main/java/club/ttg/dnd5/domain/magic/rest/dto/MagicItemRequest.java
+++ b/src/main/java/club/ttg/dnd5/domain/magic/rest/dto/MagicItemRequest.java
@@ -3,6 +3,7 @@ package club.ttg.dnd5.domain.magic.rest.dto;
 import club.ttg.dnd5.domain.common.rest.dto.BaseRequest;
 import club.ttg.dnd5.domain.magic.model.Attunement;
 import club.ttg.dnd5.domain.magic.model.MagicItemBonuses;
+import club.ttg.dnd5.domain.magic.model.mechanics.MagicItemMechanics;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
@@ -25,6 +26,10 @@ public class MagicItemRequest extends BaseRequest {
     @Schema(description = "Бонусы поверх немагического предмета: к атаке, к урону и к КД",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private MagicItemBonuses bonuses;
+
+    @Schema(description = "Механика влияния на лист персонажа: условие применения, эффекты и заряды",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private MagicItemMechanics mechanics;
 
     @Schema(description = "Количество зарядов, если есть", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private Byte charges;

--- a/src/main/java/club/ttg/dnd5/domain/spell/model/Spell.java
+++ b/src/main/java/club/ttg/dnd5/domain/spell/model/Spell.java
@@ -3,6 +3,7 @@ package club.ttg.dnd5.domain.spell.model;
 import club.ttg.dnd5.domain.feat.model.Feat;
 import club.ttg.dnd5.domain.source.model.Source;
 import club.ttg.dnd5.domain.character_class.model.CharacterClass;
+import club.ttg.dnd5.domain.common.model.ActiveEffect;
 import club.ttg.dnd5.domain.common.model.NamedEntity;
 import club.ttg.dnd5.domain.species.model.Species;
 import io.hypersistence.utils.hibernate.type.json.JsonType;
@@ -84,5 +85,5 @@ public class Spell extends NamedEntity {
 
     @Type(JsonType.class)
     @Column(name = "active_effects", columnDefinition = "jsonb")
-    private List<SpellActiveEffect> activeEffects;
+    private List<ActiveEffect> activeEffects;
 }

--- a/src/main/java/club/ttg/dnd5/domain/spell/rest/dto/create/SpellRequest.java
+++ b/src/main/java/club/ttg/dnd5/domain/spell/rest/dto/create/SpellRequest.java
@@ -4,7 +4,7 @@ import club.ttg.dnd5.domain.common.rest.dto.BaseRequest;
 import club.ttg.dnd5.domain.spell.model.SpellCastingTime;
 import club.ttg.dnd5.domain.spell.model.SpellComponents;
 import club.ttg.dnd5.domain.spell.model.SpellDistance;
-import club.ttg.dnd5.domain.spell.model.SpellActiveEffect;
+import club.ttg.dnd5.domain.common.model.ActiveEffect;
 import club.ttg.dnd5.domain.spell.model.SpellDuration;
 import club.ttg.dnd5.domain.spell.model.SpellEffect;
 import club.ttg.dnd5.domain.spell.model.SpellSchool;
@@ -67,5 +67,5 @@ public class SpellRequest extends BaseRequest {
     @Schema(description = "Активные эффекты заклинания для экспорта в VTTG")
     @Nullable
     @Valid
-    private List<SpellActiveEffect> activeEffects;
+    private List<ActiveEffect> activeEffects;
 }

--- a/src/main/java/club/ttg/dnd5/domain/vttg/rest/dto/VttgSpell.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/rest/dto/VttgSpell.java
@@ -1,6 +1,6 @@
 package club.ttg.dnd5.domain.vttg.rest.dto;
 
-import club.ttg.dnd5.domain.spell.model.SpellActiveEffect;
+import club.ttg.dnd5.domain.common.model.ActiveEffect;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
@@ -41,7 +41,7 @@ public class VttgSpell {
      * Активные эффекты заклинания (система Active Effects VTTG) — например помеха на атаку у
      * «Злой насмешки». Передаются без преобразования (модель уже в вокабуляре VTTG).
      */
-    private List<SpellActiveEffect> activeEffects;
+    private List<ActiveEffect> activeEffects;
     private String cantripScaling;
     private List<VttgCantripScalingTier> cantripScalingTiers;
     private VttgSpellScaling scaling;

--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgSpellMapper.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgSpellMapper.java
@@ -11,7 +11,7 @@ import club.ttg.dnd5.domain.spell.model.SpellCastingTime;
 import club.ttg.dnd5.domain.spell.model.SpellComponents;
 import club.ttg.dnd5.domain.spell.model.SpellDistance;
 import club.ttg.dnd5.domain.spell.model.SpellDuration;
-import club.ttg.dnd5.domain.spell.model.SpellActiveEffect;
+import club.ttg.dnd5.domain.common.model.ActiveEffect;
 import club.ttg.dnd5.domain.spell.model.SpellEffect;
 import club.ttg.dnd5.domain.spell.model.enums.AreaOfEffectType;
 import club.ttg.dnd5.domain.spell.model.enums.CastingUnit;
@@ -340,12 +340,12 @@ public class VttgSpellMapper {
     }
 
     /**
-     * Активные эффекты заклинания «как есть»: модель {@link SpellActiveEffect} уже в вокабуляре VTTG
+     * Активные эффекты заклинания «как есть»: модель {@link ActiveEffect} уже в вокабуляре VTTG
      * (Active Effects), поэтому передаётся без преобразования. Пустой/отсутствующий список → {@code null}
      * (поле опускается в выгрузке).
      */
-    private List<SpellActiveEffect> activeEffects(Spell spell) {
-        List<SpellActiveEffect> effects = spell.getActiveEffects();
+    private List<ActiveEffect> activeEffects(Spell spell) {
+        List<ActiveEffect> effects = spell.getActiveEffects();
         return effects == null || effects.isEmpty() ? null : effects;
     }
 

--- a/src/main/resources/db/changelog/2026/08/04-01-add-magic-item-mechanics.yaml
+++ b/src/main/resources/db/changelog/2026/08/04-01-add-magic-item-mechanics.yaml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-08-04-01-add-magic-item-mechanics
+      author: Magistrus
+      changes:
+        - addColumn:
+            tableName: magic_item
+            columns:
+              - column:
+                  name: mechanics
+                  type: jsonb
+                  constraints:
+                    nullable: true

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -277,3 +277,5 @@ databaseChangeLog:
       file: db/changelog/2026/07/30-02-fix-weapon-ammunition-types.yaml
   - include:
       file: db/changelog/2026/08/02-01-add-magic-item-bonuses.yaml
+  - include:
+      file: db/changelog/2026/08/04-01-add-magic-item-mechanics.yaml

--- a/src/test/java/club/ttg/dnd5/domain/magic/rest/mapper/MagicItemMechanicsMappingTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/magic/rest/mapper/MagicItemMechanicsMappingTest.java
@@ -1,0 +1,125 @@
+package club.ttg.dnd5.domain.magic.rest.mapper;
+
+import club.ttg.dnd5.domain.common.model.ActiveEffect;
+import club.ttg.dnd5.domain.magic.model.MagicItem;
+import club.ttg.dnd5.domain.magic.model.mechanics.MagicItemActivation;
+import club.ttg.dnd5.domain.magic.model.mechanics.MagicItemMechanics;
+import club.ttg.dnd5.domain.magic.model.mechanics.MagicItemRechargeEvent;
+import club.ttg.dnd5.domain.magic.model.mechanics.MagicItemResource;
+import club.ttg.dnd5.domain.magic.rest.dto.MagicItemRequest;
+import club.ttg.dnd5.dto.base.mapping.BaseMapping;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@ExtendWith(MockitoExtension.class)
+class MagicItemMechanicsMappingTest {
+
+    @Mock
+    private BaseMapping baseMapping;
+
+    @InjectMocks
+    private MagicItemMapperImpl mapper;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void rawFormReturnsMechanicsOfEntity() {
+        MagicItem entity = new MagicItem();
+        entity.setMechanics(cloakOfProtection());
+
+        MagicItemRequest request = mapper.toRequest(entity);
+        List<ActiveEffect.Change> changes = request.getMechanics()
+                .getActiveEffects()
+                .getFirst()
+                .getChanges();
+
+        assertEquals(MagicItemActivation.WORN, request.getMechanics().getActivation());
+        assertEquals(2, changes.size());
+        assertEquals("armorClass", changes.get(0).getKey());
+        assertEquals("save.constitution", changes.get(1).getKey());
+    }
+
+    @Test
+    void updateWithoutMechanicsClearsThem() {
+        MagicItem entity = new MagicItem();
+        entity.setMechanics(cloakOfProtection());
+
+        mapper.updateEntity(new MagicItemRequest(), null, Set.of(), entity);
+
+        assertNull(entity.getMechanics());
+    }
+
+    /**
+     * Снимок ревизии — это сериализованный {@link MagicItemRequest}, а откат читает его
+     * обратно. Значит механика обязана переживать оба конца JSON без потерь.
+     */
+    @Test
+    void revisionSnapshotSurvivesJsonRoundTrip() throws Exception {
+        MagicItemRequest request = new MagicItemRequest();
+        request.setMechanics(situationalWithCharges());
+
+        String snapshot = objectMapper.writeValueAsString(request);
+        MagicItemMechanics restored = objectMapper.readValue(snapshot, MagicItemRequest.class).getMechanics();
+        ActiveEffect.Change change = restored.getActiveEffects().getFirst().getChanges().getFirst();
+
+        assertEquals(MagicItemActivation.HELD, restored.getActivation());
+        assertEquals("add", change.getMode());
+        assertEquals("attacker.isRanged === true", change.getCondition());
+        assertEquals(Integer.valueOf(7), restored.getResource().getMaxCharges());
+        assertEquals(MagicItemRechargeEvent.DAWN, restored.getResource().getRechargeEvent());
+        assertEquals("1к6+1", restored.getResource().getRecharge());
+        assertEquals("Вы можете дышать под водой", restored.getPassive());
+    }
+
+    /** Плащ защиты: надет, +1 к КД и +1 ко всем спасброскам. */
+    private MagicItemMechanics cloakOfProtection() {
+        ActiveEffect effect = new ActiveEffect();
+        effect.setName("Плащ защиты");
+        effect.setChanges(List.of(
+                change("armorClass", "1", null),
+                change("save.constitution", "1", null)));
+
+        MagicItemMechanics mechanics = new MagicItemMechanics();
+        mechanics.setActivation(MagicItemActivation.WORN);
+        mechanics.setActiveEffects(List.of(effect));
+        return mechanics;
+    }
+
+    /** Предмет с зарядами и ситуационным «+2 КД против дальнобойных атак». */
+    private MagicItemMechanics situationalWithCharges() {
+        ActiveEffect effect = new ActiveEffect();
+        effect.setChanges(List.of(change("armorClass", "2", "attacker.isRanged === true")));
+
+        MagicItemResource resource = new MagicItemResource();
+        resource.setMaxCharges(7);
+        resource.setRecharge("1к6+1");
+        resource.setRechargeEvent(MagicItemRechargeEvent.DAWN);
+        resource.setCost(1);
+
+        MagicItemMechanics mechanics = new MagicItemMechanics();
+        mechanics.setActivation(MagicItemActivation.HELD);
+        mechanics.setActiveEffects(List.of(effect));
+        mechanics.setResource(resource);
+        mechanics.setPassive("Вы можете дышать под водой");
+        return mechanics;
+    }
+
+    private ActiveEffect.Change change(String key, String value, String condition) {
+        ActiveEffect.Change change = new ActiveEffect.Change();
+        change.setKey(key);
+        change.setMode("add");
+        change.setValue(value);
+        change.setCondition(condition);
+        return change;
+    }
+}

--- a/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgSpellMapperTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgSpellMapperTest.java
@@ -12,7 +12,7 @@ import club.ttg.dnd5.domain.spell.model.SpellCastingTime;
 import club.ttg.dnd5.domain.spell.model.SpellComponents;
 import club.ttg.dnd5.domain.spell.model.SpellDistance;
 import club.ttg.dnd5.domain.spell.model.SpellDuration;
-import club.ttg.dnd5.domain.spell.model.SpellActiveEffect;
+import club.ttg.dnd5.domain.common.model.ActiveEffect;
 import club.ttg.dnd5.domain.spell.model.SpellEffect;
 import club.ttg.dnd5.domain.spell.model.SpellSchool;
 import club.ttg.dnd5.domain.spell.model.enums.AreaOfEffectType;
@@ -338,7 +338,7 @@ class VttgSpellMapperTest {
         spell.setLevel(0L);
         spell.setSchool(SpellSchool.builder().school(MagicSchool.ENCHANTMENT).build());
 
-        SpellActiveEffect effect = new SpellActiveEffect();
+        ActiveEffect effect = new ActiveEffect();
         effect.setId("vicious-mockery-attack-disadvantage");
         effect.setName("Помеха на следующую атаку");
         effect.setEffectTarget("target");


### PR DESCRIPTION
Магический предмет получил jsonb-поле mechanics: условие применения, активные эффекты, заряды и пассивные свойства. Колонка magic_item.mechanics, поле в форме предмета (round-trip через MagicItemRequest и /raw) и в детальном ответе; в историю изменений и откат оно попадает само — снимок ревизии это и есть сериализованный запрос формы.

Сами эффекты описывает модель Active Effects VTTG — та же, что у заклинаний, поэтому SpellActiveEffect переехал в domain/common/model под именем ActiveEffect и делится между доменами. Плащ защиты — это два изменения (armorClass и save.* режимом add), амулет здоровья — одно (ability.constitution режимом upgrade до 19). JSON при переезде не изменился, заклинаниям миграция не нужна.

Условие применения и заряды остались своими: в VTTG эффекты предмета включает один признак «экипирован», а зарядов система не знает.