### PR TITLE
feat(spell): цель части урона отдельным полем damageFormulaTargets

### DIFF
--- a/src/main/java/club/ttg/dnd5/domain/spell/model/SpellEffect.java
+++ b/src/main/java/club/ttg/dnd5/domain/spell/model/SpellEffect.java
@@ -27,6 +27,13 @@ public class SpellEffect {
     private Boolean autoHit;
     private Projectiles projectiles;
     private List<String> damageFormulas;
+    /**
+     * Цели частей урона по индексам {@link #damageFormulas}: {@code selected}
+     * (дефолт), {@code self}, {@code choose} — словарь VTTG {@code DamagePartTarget}.
+     * В формулу цель не пишется: VTTG знает в ней только теги
+     * {@code @target.full}/{@code @target.notFull}.
+     */
+    private List<String> damageFormulaTargets;
     private List<HealingType> healingTypes;
     private List<Ability> savingThrows;
     private SpellSaveEffect saveEffect;

--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgSpellMechanicsExtractor.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgSpellMechanicsExtractor.java
@@ -6,10 +6,12 @@ import club.ttg.dnd5.domain.vttg.rest.dto.VttgDamagePart;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -41,6 +43,8 @@ public class VttgSpellMechanicsExtractor {
             "(?iu)(?:не\\s+получ\\p{L}*|не\\s+нанос\\p{L}*).{0,60}?урон\\p{L}*"
     );
     private static final Map<String, Pattern> TEXT_DAMAGE_TYPES = textDamageTypes();
+    private static final Set<String> DAMAGE_PART_TARGETS = Set.of("selected", "self", "choose");
+    private static final String DEFAULT_DAMAGE_PART_TARGET = "selected";
 
     public VttgSpellMechanics extract(Spell spell, String description) {
         String text = description == null ? "" : description;
@@ -70,7 +74,10 @@ public class VttgSpellMechanicsExtractor {
         return new VttgSpellMechanics(
                 primaryFormula,
                 primaryDamageType,
-                damageParts(formulas, !formulaHealing && (structuredHealing || (!structuredFormulas && healing))),
+                damageParts(
+                        formulas,
+                        !formulaHealing && (structuredHealing || (!structuredFormulas && healing)),
+                        structuredFormulas ? effect.getDamageFormulaTargets() : null),
                 healing ? true : null,
                 extractSaveEffect(effect, text)
         );
@@ -210,18 +217,36 @@ public class VttgSpellMechanicsExtractor {
                 || TEMPORARY_HEALING_MARKER.matcher(formula).find());
     }
 
-    private List<VttgDamagePart> damageParts(List<String> formulas, boolean legacyHealing) {
+    /**
+     * Части урона для компендиума. Цель части берётся из {@code damageFormulaTargets}
+     * по индексу формулы, поэтому список обходится по индексам, а пустые формулы
+     * пропускаются без сдвига выравнивания.
+     */
+    private List<VttgDamagePart> damageParts(List<String> formulas, boolean legacyHealing, List<String> targets) {
         if (!hasValues(formulas)) {
             return null;
         }
-        return formulas.stream()
-                .filter(StringUtils::hasText)
-                .map(formula -> VttgDamagePart.builder()
-                        .formula(applyHealMarker(normalizeDamagePartFormula(formula),
-                                isHealingFormula(formula), legacyHealing))
-                        .target("selected")
-                        .build())
-                .toList();
+        List<VttgDamagePart> parts = new ArrayList<>();
+        for (int index = 0; index < formulas.size(); index++) {
+            String formula = formulas.get(index);
+            if (!StringUtils.hasText(formula)) {
+                continue;
+            }
+            parts.add(VttgDamagePart.builder()
+                    .formula(applyHealMarker(normalizeDamagePartFormula(formula),
+                            isHealingFormula(formula), legacyHealing))
+                    .target(damagePartTarget(targets, index))
+                    .build());
+        }
+        return parts;
+    }
+
+    private String damagePartTarget(List<String> targets, int index) {
+        if (targets == null || index >= targets.size()) {
+            return DEFAULT_DAMAGE_PART_TARGET;
+        }
+        String target = targets.get(index);
+        return DAMAGE_PART_TARGETS.contains(target) ? target : DEFAULT_DAMAGE_PART_TARGET;
     }
 
     /**

--- a/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgSpellMechanicsExtractor.java
+++ b/src/main/java/club/ttg/dnd5/domain/vttg/service/VttgSpellMechanicsExtractor.java
@@ -45,11 +45,22 @@ public class VttgSpellMechanicsExtractor {
     private static final Map<String, Pattern> TEXT_DAMAGE_TYPES = textDamageTypes();
     private static final Set<String> DAMAGE_PART_TARGETS = Set.of("selected", "self", "choose");
     private static final String DEFAULT_DAMAGE_PART_TARGET = "selected";
+    /**
+     * Legacy-теги цели, которые редактор писал прямо в формулу до появления
+     * {@code effect.damageFormulaTargets}. В компендиум они попасть не должны:
+     * VTTG понимает в формуле только {@code @target.full}/{@code @target.notFull},
+     * которые под этот шаблон не подпадают.
+     */
+    private static final Pattern LEGACY_TARGET_MARKER = Pattern.compile("(?i)@target\\.(self|separate)\\b");
 
     public VttgSpellMechanics extract(Spell spell, String description) {
         String text = description == null ? "" : description;
         SpellEffect effect = spell.getEffect();
-        List<String> formulas = structuredDamageFormulas(effect);
+        List<String> rawFormulas = structuredDamageFormulas(effect);
+        // Цели резолвятся по «сырым» формулам (в них может остаться legacy-тег),
+        // а наружу уходят формулы уже без него.
+        List<String> damagePartTargets = damagePartTargets(rawFormulas, effect);
+        List<String> formulas = stripLegacyTargets(rawFormulas);
         boolean structuredFormulas = formulas != null;
         boolean formulaHealing = hasHealingMarker(formulas);
         boolean structuredHealing = effect != null && hasValues(effect.getHealingTypes());
@@ -77,7 +88,7 @@ public class VttgSpellMechanicsExtractor {
                 damageParts(
                         formulas,
                         !formulaHealing && (structuredHealing || (!structuredFormulas && healing)),
-                        structuredFormulas ? effect.getDamageFormulaTargets() : null),
+                        damagePartTargets),
                 healing ? true : null,
                 extractSaveEffect(effect, text)
         );
@@ -242,11 +253,59 @@ public class VttgSpellMechanicsExtractor {
     }
 
     private String damagePartTarget(List<String> targets, int index) {
-        if (targets == null || index >= targets.size()) {
-            return DEFAULT_DAMAGE_PART_TARGET;
+        return targets == null || index >= targets.size()
+                ? DEFAULT_DAMAGE_PART_TARGET
+                : targets.get(index);
+    }
+
+    /**
+     * Цели частей урона по индексам формул: структурное поле
+     * {@code effect.damageFormulaTargets} важнее, при пустом или неизвестном
+     * значении подхватывается legacy-тег из самой формулы, иначе — {@code selected}.
+     */
+    private List<String> damagePartTargets(List<String> rawFormulas, SpellEffect effect) {
+        if (rawFormulas == null) {
+            return null;
         }
-        String target = targets.get(index);
-        return DAMAGE_PART_TARGETS.contains(target) ? target : DEFAULT_DAMAGE_PART_TARGET;
+        List<String> structuredTargets = effect == null ? null : effect.getDamageFormulaTargets();
+        List<String> targets = new ArrayList<>();
+        for (int index = 0; index < rawFormulas.size(); index++) {
+            targets.add(resolveDamagePartTarget(structuredTargets, index, rawFormulas.get(index)));
+        }
+        return targets;
+    }
+
+    private String resolveDamagePartTarget(List<String> structuredTargets, int index, String rawFormula) {
+        String structuredTarget = structuredTargets == null || index >= structuredTargets.size()
+                ? null
+                : structuredTargets.get(index);
+        if (structuredTarget != null && DAMAGE_PART_TARGETS.contains(structuredTarget)) {
+            return structuredTarget;
+        }
+        String legacyTarget = legacyTarget(rawFormula);
+        return legacyTarget == null ? DEFAULT_DAMAGE_PART_TARGET : legacyTarget;
+    }
+
+    private String legacyTarget(String formula) {
+        if (!StringUtils.hasText(formula)) {
+            return null;
+        }
+        Matcher marker = LEGACY_TARGET_MARKER.matcher(formula);
+        if (!marker.find()) {
+            return null;
+        }
+        return "self".equalsIgnoreCase(marker.group(1)) ? "self" : "choose";
+    }
+
+    private List<String> stripLegacyTargets(List<String> formulas) {
+        return formulas == null ? null : formulas.stream().map(this::stripLegacyTarget).toList();
+    }
+
+    private String stripLegacyTarget(String formula) {
+        if (!StringUtils.hasText(formula)) {
+            return formula;
+        }
+        return LEGACY_TARGET_MARKER.matcher(formula).replaceAll("").trim();
     }
 
     /**

--- a/src/main/resources/db/changelog/2026/08/05-01-spell-damage-formula-targets.yaml
+++ b/src/main/resources/db/changelog/2026/08/05-01-spell-damage-formula-targets.yaml
@@ -1,0 +1,40 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-08-05-01-spell-damage-formula-targets
+      author: codex
+      comment: >-
+        Переносит цель части урона из тегов @target.self/@target.separate внутри
+        формулы в отдельный массив effect.damageFormulaTargets (словарь VTTG:
+        selected/self/choose). Внутри формулы такие теги не понимает никто:
+        VTTG знает только @target.full/@target.notFull.
+      changes:
+        - sql:
+            sql: |
+              UPDATE spell
+              SET effect = jsonb_set(
+                  jsonb_set(spell.effect, '{damageFormulas}', damage_part.formulas),
+                  '{damageFormulaTargets}',
+                  damage_part.targets
+              )
+              FROM (
+                  SELECT source.url AS url,
+                         jsonb_agg(
+                             to_jsonb(btrim(regexp_replace(formula, '@target\.(self|separate)', '', 'gi')))
+                             ORDER BY formula_index
+                         ) AS formulas,
+                         jsonb_agg(
+                             CASE
+                                 WHEN formula ~* '@target\.self' THEN '"self"'::jsonb
+                                 WHEN formula ~* '@target\.separate' THEN '"choose"'::jsonb
+                                 ELSE '"selected"'::jsonb
+                             END
+                             ORDER BY formula_index
+                         ) AS targets
+                  FROM spell AS source,
+                       LATERAL jsonb_array_elements_text(source.effect->'damageFormulas')
+                           WITH ORDINALITY AS damage_formula(formula, formula_index)
+                  WHERE jsonb_typeof(source.effect->'damageFormulas') = 'array'
+                    AND source.effect->>'damageFormulas' ~* '@target\.(self|separate)'
+                  GROUP BY source.url
+              ) AS damage_part
+              WHERE spell.url = damage_part.url;

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -279,3 +279,5 @@ databaseChangeLog:
       file: db/changelog/2026/08/02-01-add-magic-item-bonuses.yaml
   - include:
       file: db/changelog/2026/08/04-01-add-magic-item-mechanics.yaml
+  - include:
+      file: db/changelog/2026/08/05-01-spell-damage-formula-targets.yaml

--- a/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgSpellMechanicsExtractorTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgSpellMechanicsExtractorTest.java
@@ -138,6 +138,49 @@ class VttgSpellMechanicsExtractorTest {
     }
 
     @Test
+    void movesLegacyTargetTagFromFormulaToDamagePartTarget() {
+        Spell spell = new Spell();
+        SpellEffect effect = new SpellEffect();
+        effect.setDamageFormulas(List.of("2к6@dmg.fire@target.separate", "1к8@heal@target.self"));
+        spell.setEffect(effect);
+
+        var result = extractor.extract(spell, "");
+
+        assertEquals("2к6@dmg.fire", result.damageParts().get(0).getFormula());
+        assertEquals("choose", result.damageParts().get(0).getTarget());
+        assertEquals("1к8@heal", result.damageParts().get(1).getFormula());
+        assertEquals("self", result.damageParts().get(1).getTarget());
+        assertEquals("2к6", result.damageFormula());
+    }
+
+    @Test
+    void prefersStructuredTargetOverLegacyTargetTag() {
+        Spell spell = new Spell();
+        SpellEffect effect = new SpellEffect();
+        effect.setDamageFormulas(List.of("2к6@dmg.fire@target.self"));
+        effect.setDamageFormulaTargets(List.of("choose"));
+        spell.setEffect(effect);
+
+        var result = extractor.extract(spell, "");
+
+        assertEquals("2к6@dmg.fire", result.damageParts().getFirst().getFormula());
+        assertEquals("choose", result.damageParts().getFirst().getTarget());
+    }
+
+    @Test
+    void keepsTargetStateTokensInsideFormula() {
+        Spell spell = new Spell();
+        SpellEffect effect = new SpellEffect();
+        effect.setDamageFormulas(List.of("2к6@dmg.fire@target.notFull"));
+        spell.setEffect(effect);
+
+        var result = extractor.extract(spell, "");
+
+        assertEquals("2к6@dmg.fire@target.notFull", result.damageParts().getFirst().getFormula());
+        assertEquals("selected", result.damageParts().getFirst().getTarget());
+    }
+
+    @Test
     void fallsBackToSelectedTargetWhenTargetIsMissingOrUnknown() {
         Spell spell = new Spell();
         SpellEffect effect = new SpellEffect();

--- a/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgSpellMechanicsExtractorTest.java
+++ b/src/test/java/club/ttg/dnd5/domain/vttg/service/VttgSpellMechanicsExtractorTest.java
@@ -124,6 +124,34 @@ class VttgSpellMechanicsExtractorTest {
     }
 
     @Test
+    void mapsDamageFormulaTargetsByFormulaIndex() {
+        Spell spell = new Spell();
+        SpellEffect effect = new SpellEffect();
+        effect.setDamageFormulas(List.of("2к6@dmg.fire", "1к8@heal"));
+        effect.setDamageFormulaTargets(List.of("selected", "self"));
+        spell.setEffect(effect);
+
+        var result = extractor.extract(spell, "");
+
+        assertEquals("selected", result.damageParts().get(0).getTarget());
+        assertEquals("self", result.damageParts().get(1).getTarget());
+    }
+
+    @Test
+    void fallsBackToSelectedTargetWhenTargetIsMissingOrUnknown() {
+        Spell spell = new Spell();
+        SpellEffect effect = new SpellEffect();
+        effect.setDamageFormulas(List.of("2к6@dmg.fire", "1к6@dmg.cold"));
+        effect.setDamageFormulaTargets(List.of("target.separate"));
+        spell.setEffect(effect);
+
+        var result = extractor.extract(spell, "");
+
+        assertEquals("selected", result.damageParts().get(0).getTarget());
+        assertEquals("selected", result.damageParts().get(1).getTarget());
+    }
+
+    @Test
     void ignoresRollThatIsNotDamageOrHealing() {
         Spell spell = new Spell();
 


### PR DESCRIPTION
SpellEffect получил damageFormulaTargets — цели частей урона по индексам damageFormulas (словарь VTTG: selected/self/choose). Раньше цель писалась тегом @target.self/@target.separate прямо в формулу, где её не понимает ни VttgSpellMechanicsExtractor, ни клиент.

Экспорт в VTTG берёт target части из нового поля вместо жёстко зашитого selected; неизвестное значение и отсутствие цели дают selected. Миграция переносит legacy-теги из формул уже сохранённых заклинаний.